### PR TITLE
Allow creating an OpenShift route

### DIFF
--- a/charts/ditto/Chart.yaml
+++ b/charts/ditto/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v1
 appVersion: "1.0.0"
 description: A Helm chart for Eclipse Ditto
 name: ditto
-version: 1.0.0-snapshot.1
+version: 1.0.0-snapshot.2
 home: https://www.eclipse.org/ditto
 sources:
 - https://github.com/eclipse/ditto

--- a/charts/ditto/templates/NOTES.txt
+++ b/charts/ditto/templates/NOTES.txt
@@ -1,6 +1,7 @@
 Eclipse Ditto installed!
 
-Access ditto in your browser (http://localhost:8080) by running:
+{{- if ( not .Values.routes.enabled ) }}
+Access Ditto in your browser (http://localhost:8080) by running:
 
     kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "ditto.fullname" . }}-nginx 8080:8080
 
@@ -13,3 +14,20 @@ The /devops resource can be accessed by:
 
     export DEVOPS_PWD=$(kubectl --namespace {{ .Release.Namespace }} get secret {{ include "ditto.fullname" . }}-gateway-secret -o jsonpath="{.data.devops-password}" | base64 --decode)
     curl -i -X GET "http://devops:${DEVOPS_PWD}@localhost:8080/devops"
+{{- else -}}
+Access Ditto in your browser, get the URL with:
+
+    echo https://$(kubectl --namespace {{ .Release.Namespace }} get route {{ include "ditto.fullname" . }} -o jsonpath="{.status.ingress[0].host}")
+
+The /status resource can be accessed by:
+
+    export STATUS_PWD=$(kubectl --namespace {{ .Release.Namespace }} get secret {{ include "ditto.fullname" . }}-gateway-secret -o jsonpath="{.data.status-password}" | base64 --decode)
+    export URL=https://devops:${STATUS_PWD}@$(kubectl --namespace {{ .Release.Namespace }} get route {{ include "ditto.fullname" . }} -o jsonpath="{.status.ingress[0].host}")
+    curl -i -X GET "$URL/status"
+
+The /devops resource can be accessed by:
+
+    export DEVOPS_PWD=$(kubectl --namespace {{ .Release.Namespace }} get secret {{ include "ditto.fullname" . }}-gateway-secret -o jsonpath="{.data.devops-password}" | base64 --decode)
+    export URL=https://devops:${DEVOPS_PWD}@$(kubectl --namespace {{ .Release.Namespace }} get route {{ include "ditto.fullname" . }} -o jsonpath="{.status.ingress[0].host}")
+    curl -i -X GET "$URL/devops"
+{{- end }}

--- a/charts/ditto/templates/nginx-route.yaml
+++ b/charts/ditto/templates/nginx-route.yaml
@@ -1,0 +1,69 @@
+# Copyright (c) 2019 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+{{- if .Values.routes.enabled }}
+
+{{- if .Values.nginx.networkPolicy.enabled }}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ include "ditto.fullname" . }}-nginx
+  labels:
+    app.kubernetes.io/name: {{ include "ditto.name" . }}-nginx
+{{ include "ditto.labels" . | indent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "ditto.name" . }}-nginx
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+  - Ingress
+  ingress:
+  # Allow access from OpenShift Router
+  - ports:
+    - protocol: TCP
+      port: 8080
+{{- end }}
+
+---
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: {{ include "ditto.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "ditto.name" . }}-nginx
+{{ include "ditto.labels" . | indent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  host: ""
+  to:
+    kind: Service
+    name: {{ include "ditto.fullname" . }}-nginx
+    weight: 100
+  port:
+    targetPort: http
+  tls:
+    termination: {{ .Values.routes.tlsTermination | default "edge" }}
+    insecureEdgeTerminationPolicy: {{ .Values.routes.tlsInsecurePolicy | default "Redirect" }}
+status:
+  ingress:
+    - conditions:
+      - lastTransitionTime: "2019-12-06T03:24:58Z"
+        status: "True"
+        type: Admitted
+      host: 
+      routerCanonicalHostname: 
+      routerName: default
+      wildcardPolicy: None
+{{- end }}

--- a/charts/ditto/values.yaml
+++ b/charts/ditto/values.yaml
@@ -67,6 +67,11 @@ ingress:
   #    hosts:
   #      - ditto.example.com
 
+## OpenShift Routes
+routes:
+  enabled: false
+  annotations: {}
+
 ## ----------------------------------------------------------------------------
 ## global configuration shared by all components
 global:
@@ -377,6 +382,9 @@ nginx:
     port: 8080
     ## annotations to add arbritrary annotations to nginx service
     annotations: {}
+  networkPolicy:
+    ## enabled controls whether policies related NetworkPolicy should be created
+    enabled: true
   ## nodeSelector
   ## https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
   nodeSelector: {}


### PR DESCRIPTION
This change adds support for deploying an OpenShift route, when setting `routes.enabled= true` (which is false by default) .