### PR TITLE
improve helm ci pipline

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,9 +13,11 @@ name: ci
 
 on:
   pull_request:
+    paths:
+      - 'charts/**'
 
 jobs:
-  check-for-chart-changes:
+  lint-bash-scripts:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -24,6 +26,12 @@ jobs:
         uses: docker://koalaman/shellcheck-alpine:v0.7.0
         with:
           args: /github/workspace/.github/lint-scripts.sh
+
+  check-for-chart-changes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
       - name: Check for chart changes
         run: /home/runner/work/packages/packages/.github/check-for-chart-changes.sh
 
@@ -37,7 +45,7 @@ jobs:
         uses: helm/chart-testing-action@master
         with:
           command: lint
-          config: /home/runner/work/packages/packages/.github/ct.yaml
+          config: .github/ct.yaml
 
   install-chart:
     name: install-chart
@@ -48,10 +56,10 @@ jobs:
         k8s:
           - v1.11.10
           - v1.12.10
-          - v1.13.10
-          - v1.14.6
-          - v1.15.3
-          - v1.16.2
+          - v1.13.12
+          - v1.14.9
+          - v1.15.6
+          - v1.16.3
           - v1.17.0
     steps:
       - name: Checkout
@@ -66,3 +74,4 @@ jobs:
         uses: helm/chart-testing-action@master
         with:
           command: install
+          config: .github/ct.yaml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Lint Bash scripts
         uses: docker://koalaman/shellcheck-alpine:v0.7.0
         with:
-          args: /github/workspace/.github/lint-scripts.sh
+          args: .github/lint-scripts.sh
 
   check-for-chart-changes:
     runs-on: ubuntu-latest
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Check for chart changes
-        run: /home/runner/work/packages/packages/.github/check-for-chart-changes.sh
+        run: .github/check-for-chart-changes.sh
 
   lint-chart:
     runs-on: ubuntu-latest
@@ -67,7 +67,7 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@master
         with:
-          config: /home/runner/work/packages/packages/.github/kind-config.yaml
+          config: .github/kind-config.yaml
           installLocalPathProvisioner: true
           node-image: ${{ matrix.k8s }}
       - name: Run chart-testing (install)


### PR DESCRIPTION
Signed-off-by: André Bauer <andre.bauer@kiwigrid.com>

* only run when changes in charts dir
* fix timeout issue (configured timeout was not used as relative path for ct config file is needed)
* put lint bash scripts in own job
* updated kubernetes node versions to latest kind images


This will fix https://github.com/eclipse/packages/issues/16
