### PR TITLE
Add requirements for charts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ Please make sure any file you newly create contains a proper license header like
 
 ````
 /**
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -62,7 +62,7 @@ You should, of course, adapt this header to use the specific mechanism for comme
 
 ````
 <!--
- Copyright (c) 2019 Contributors to the Eclipse Foundation
+ Copyright (c) 2020 Contributors to the Eclipse Foundation
 
  See the NOTICE file(s) distributed with this work for additional
  information regarding copyright ownership.

--- a/homepage/about.html
+++ b/homepage/about.html
@@ -25,7 +25,7 @@ is possible with Eclipse IoT, and enables you to try it out first hand.
 
 <p>
 IoT Packages are a combination of two or more Eclipse IoT projects, combined in an integrated way,
-leveraging the benefits of each project, to showcasing the benefit of their integration.
+leveraging the benefits of each project, to showcase the benefits of their integration.
 </p>
 
 <p>
@@ -34,7 +34,7 @@ And also enable them to try it out themselves, within minutes and on their own i
 </p>
 
 <p>
-Packages not only to provide deployments scripts, but also some description what the benefit of the
+Packages not only provide deployment scripts, but also some description what the benefit of the
 integrated package is, and some initial, tutorial like steps, to play with the setup, once it is deployed.
 </p>
 
@@ -60,8 +60,9 @@ base for all IoT packages.
 </p>
 
 <p>
-Helm is an tool which integrates nicely with Kubernetes. It is easy to use, and has the ability to create
-a set of YAML files, which are easy to deploy.
+Helm is a command line tool for managing Kubernetes applications. Helm Charts help define, install
+and upgrade even the most complex Kubernetes application.
+Packages consist of one or more Helm Charts which can be used to install the package to a Kubernetes cluster.
 </p>
 
 </div>

--- a/homepage/contribute.md
+++ b/homepage/contribute.md
@@ -31,26 +31,96 @@ We also do have a channel on Gitter: [https://gitter.im/eclipse/packages](https:
 There is always room for improvement. Found a bug, have an idea how to make things better.
 Make a change and create a pull request.
 
-## Enhancing an existing package
+## Extending an existing package
 
-Got a cool idea on adding something new to an existing package. It makes sense to create an issue on GitHub,
+Got a cool idea on adding something new to an existing package? It makes sense to create an issue on GitHub,
 and discuss your proposal. The existing maintainers of a package might want to understand how this fits
-into their package, what the benefit is, and what is required. Get in contact, get on the same page, and start coding.
+into their package, what the benefit is, and what is required. Get in touch, get on the same page, and start coding.
 
 ## Creating a new package
 
-Next, open a new PR against this repository, adding your package. Please ensure that:
+Found some Eclipse IoT projects that would make a great package? Then don't hesitate to create a
+PR against this repository which contains your new package. Please make sure that your PR's description
+explains why you think this new package should be created. Note that by adding a new package you
+are expected to take ownership of the package as well.
 
-* The new package brings together at least two Eclipse IoT projects
-  * There is a real benefit in the combination of the projects
-  * You only use stable, released versions of the projects (no milestones or snapshots)
-* The package contains only open source components, license compatible with the EPLv2
-* You describe your motivation in the PR
-* The package contains at least:
-  * A basic introduction and idea behind this package
-  * The Helm charts to deploy
-  * A tutorial what do to once the deployment is done
-* You take ownership of the package
+## Requirements for packages
+
+Regardless of whether you want to contribute a small change only or a completely new package, there
+are some qualitative requirements that all packages and the charts they contain must meet.
+
+All IoT Packages must
+
+* comprise of at least two Eclipse IoT projects that provide a real benefit when being
+  integrated with each other in this way.
+* only contain artifacts that are distributed under a license that is compatible with the EPLv2.
+* only contain stable, released versions of project artifacts (no milestones or snapshots).
+* must contain
+  * a README covering a basic introduction and the idea behind the package,
+  * the Helm charts constituting the components of the package,
+  * some guidance regarding what users might want to do with the package after installation.
+
+IoT Packages are implemented by means of Helm charts that are combined together and configured in
+a particular way. An IoT Package must not *contain* the Helm charts of the projects it comprises of
+but instead must only *refer* to the projects' Helm charts which are maintained and distributed separately.
+This allows for a modular approach where projects can easily be (re)used in multiple IoT Packages.
+
+The IoT Packages GitHub repository can be used to maintain both individual charts for Eclipse IoT Projects
+as well as packages that are comprised of multiple projects:
+
+* The `charts` folder contains Helm charts for Eclipse IoT projects. Each sub-folder contains a chart for
+  one project.
+* The `packages` folder contains the IoT packages. Each sub-folder represents one package.
+
+## Requirements for charts
+
+All Helm charts in the repository must meet the following technical and documentation requirements.
+
+### Technical requirements
+
+Helm charts
+
+* must not contain other charts that they depend on
+* must pass the Helm linter (`helm lint`)
+* must successfully launch with default values (`helm install .`)
+    * all pods go to the running state (or NOTES.txt provides further instructions if a required value is missing e.g. [minecraft](https://github.com/helm/charts/blob/master/stable/minecraft/templates/NOTES.txt#L3))
+    * all services have at least one endpoint
+* must contain pointers to source GitHub repositories for images used in the chart
+* must not use container images that have any major security vulnerabilities
+* must be up-to-date with the latest stable Helm/Kubernetes features
+    * use Deployments in favor of ReplicationControllers
+* should follow Kubernetes best practices
+    * include Health Checks wherever practical
+    * allow configurable [resource requests and limits](http://kubernetes.io/docs/user-guide/compute-resources/#resource-requests-and-limits-of-pod-and-container)
+* must provide a method for data persistence (if applicable)
+* must support application upgrades
+* must allow customization of the application configuration by means of Helm properties
+* must provide a secure default configuration
+* must not leverage alpha features of Kubernetes
+* must include a [NOTES.txt](https://github.com/helm/helm/blob/master/docs/charts.md#chart-license-readme-and-notes) explaining how to use the application after install
+* must follow [best practices](https://github.com/helm/helm/tree/master/docs/chart_best_practices)
+  (especially for [labels](https://github.com/helm/helm/blob/master/docs/chart_best_practices/labels.md)
+  and [values](https://github.com/helm/helm/blob/master/docs/chart_best_practices/values.md))
+
+### Documentation Requirements
+
+Helm charts
+
+* must include a `README.md`, containing:
+    * a short description of the chart
+    * any prerequisites or requirements
+* must include a short `NOTES.txt`, containing:
+    * any relevant post-installation information for the chart
+    * instructions on how to access the application or service provided by the chart
+* must contain a `values.yaml` file which contains a reasonable default configuration and explains
+  how the properties can be used to customize the chart
+
+## Merge approval and release process
+
+All pull requests will be verified by a CI job which runs the linter and tries to install the chart to at least the three most recent minor releases of kubernetes.
+At least one maintainer needs to explicitly approve the PR before it can be merged.
+
+Once the Chart has been merged, a CI job will automatically package and release the Chart in the [Eclipse IoT Packages repository](https://eclipse.org/packages/repository/).
 
 ## The legal side of things
 
@@ -60,3 +130,4 @@ and [sign the Eclipse Contributor Agreement](https://accounts.eclipse.org/user/e
 
 Is this required? Yes! Is there a way around it? No! Why is this necessary? Because legal
 issues are as though as software engineering issues, and this is the way to solve them.
+


### PR DESCRIPTION
It seems feasible to define some constraints and requirements regarding
the quality of the charts being hosted in the IoT Packages project.
This includes documentation, functionality, compliance etc.

The requirements have been copied (and slightly adapted) from the
central Helm Chart repo's CONTRIBUTING guide on GitHub.
