### PR TITLE
[eclipse/hono#1728] Update Prometheus to version 2.15.2

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.1.0
+version: 1.1.1
 # Version of Hono being deployed by the chart
 appVersion: 1.1.0
 keywords:

--- a/charts/hono/requirements.yaml
+++ b/charts/hono/requirements.yaml
@@ -12,7 +12,7 @@
 #
 dependencies:
   - name: prometheus
-    version: ~9.3.0
+    version: ~10.4.0
     repository: "https://kubernetes-charts.storage.googleapis.com/"
     condition: prometheus.createInstance
   - name: grafana


### PR DESCRIPTION
This PR is intended for the issue eclipse/hono#1728 to upgrade the Prometheus version to 2.15.2.