### PR TITLE
Always include example key material in conf secret

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.1.1
+version: 1.1.2
 # Version of Hono being deployed by the chart
 appVersion: 1.1.0
 keywords:

--- a/charts/hono/templates/NOTES.txt
+++ b/charts/hono/templates/NOTES.txt
@@ -1,8 +1,30 @@
-Thank you for installing {{ .Chart.Name }}.
+Thank you for installing Eclipse Hono.
 
 Your release is named {{ .Release.Name }}.
 
-To learn more about the release, try:
+It might take some time for all of Hono's services to start up.
+You can check the current status by issuing the following command:
+{{ if ( eq .Release.Namespace "default" ) }}
+  $ kubectl get pods
+{{- else }}
+  $ kubectl get -n {{ .Release.Namespace }} pods
+{{- end }}
 
-  $ helm status {{ .Release.Name }}
-  $ helm get {{ .Release.Name }}
+Once all services are up and running, the output should look similar to this:
+
+NAME                                          READY   STATUS    RESTARTS   AGE
+my-hono-adapter-amqp-vertx-65cfb4d675-g5wn4   1/1     Running   0          5m50s
+my-hono-adapter-http-vertx-66bd6bb89c-mng5t   1/1     Running   0          5m51s
+my-hono-adapter-mqtt-vertx-765fcd578b-5rl7n   1/1     Running   0          5m51s
+my-hono-artemis-f8f7dc7f4-864cj               1/1     Running   0          5m51s
+my-hono-dispatch-router-6c77dc78bd-hjn4l      1/1     Running   0          5m51s
+my-hono-service-auth-84d9695cfc-5wlfh         1/1     Running   0          5m51s
+my-hono-service-device-registry-0             1/1     Running   0          5m51s
+
+Once all pods have status 'RUNNING', Hono is ready to be used.
+
+To learn more about Hono's functionality, you should follow the Getting started guide at
+https://eclipse.org/hono/getting-started/
+
+Enjoy :-)
+

--- a/charts/hono/templates/hono-adapter-amqp/hono-adapter-amqp-vertx-secret.yaml
+++ b/charts/hono/templates/hono-adapter-amqp/hono-adapter-amqp-vertx-secret.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -34,10 +34,8 @@ stringData:
         {{- end }}
       {{- include "hono.healthServerConfig" .Values.adapters.amqp.hono.healthCheck | nindent 6 }}
       {{- include "hono.serviceClientConfig" $args | nindent 6 }}
-{{- if not .Values.adapters.amqp.extraSecretMounts }}
 data:
   key.pem: {{ .Files.Get "hono-demo-certs-jar/amqp-adapter-key.pem" | b64enc }}
   cert.pem: {{ .Files.Get "hono-demo-certs-jar/amqp-adapter-cert.pem" | b64enc }}
   trusted-certs.pem: {{ .Files.Get "hono-demo-certs-jar/trusted-certs.pem" | b64enc }}
   adapter.credentials: {{ .Files.Get "example/amqp-adapter.credentials" | b64enc }}
-{{- end }}

--- a/charts/hono/templates/hono-adapter-coap/hono-adapter-coap-vertx-secret.yaml
+++ b/charts/hono/templates/hono-adapter-coap/hono-adapter-coap-vertx-secret.yaml
@@ -32,11 +32,9 @@ stringData:
         {{- end }}
       {{- include "hono.healthServerConfig" .Values.adapters.coap.hono.healthCheck | nindent 6 }}
       {{- include "hono.serviceClientConfig" $args | nindent 6 }}
-{{- if not .Values.adapters.coap.extraSecretMounts }}
 data:
   key.pem: {{ .Files.Get "hono-demo-certs-jar/coap-adapter-key.pem" | b64enc }}
   cert.pem: {{ .Files.Get "hono-demo-certs-jar/coap-adapter-cert.pem" | b64enc }}
   trusted-certs.pem: {{ .Files.Get "hono-demo-certs-jar/trusted-certs.pem" | b64enc }}
   adapter.credentials: {{ .Files.Get "example/coap-adapter.credentials" | b64enc }}
 {{- end }}
-{{ end }}

--- a/charts/hono/templates/hono-adapter-http/hono-adapter-http-vertx-secret.yaml
+++ b/charts/hono/templates/hono-adapter-http/hono-adapter-http-vertx-secret.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -34,10 +34,8 @@ stringData:
         {{- end }}
       {{- include "hono.healthServerConfig" .Values.adapters.http.hono.healthCheck | nindent 6 }}
       {{- include "hono.serviceClientConfig" $args | nindent 6 }}
-{{- if not .Values.adapters.http.extraSecretMounts }}
 data:
   key.pem: {{ .Files.Get "hono-demo-certs-jar/http-adapter-key.pem" | b64enc }}
   cert.pem: {{ .Files.Get "hono-demo-certs-jar/http-adapter-cert.pem" | b64enc }}
   trusted-certs.pem: {{ .Files.Get "hono-demo-certs-jar/trusted-certs.pem" | b64enc }}
   adapter.credentials: {{ .Files.Get "example/http-adapter.credentials" | b64enc }}
-{{- end }}

--- a/charts/hono/templates/hono-adapter-kura/hono-adapter-kura-secret.yaml
+++ b/charts/hono/templates/hono-adapter-kura/hono-adapter-kura-secret.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.adapters.kura.enabled }}
 #
-# Copyright (c) 2019 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -35,11 +35,9 @@ stringData:
         {{- end }}
       {{- include "hono.healthServerConfig" .Values.adapters.kura.hono.healthCheck | nindent 6 }}
       {{- include "hono.serviceClientConfig" $args | nindent 6 }}
-{{- if not .Values.adapters.kura.extraSecretMounts }}
 data:
   key.pem: {{ .Files.Get "hono-demo-certs-jar/kura-adapter-key.pem" | b64enc }}
   cert.pem: {{ .Files.Get "hono-demo-certs-jar/kura-adapter-cert.pem" | b64enc }}
   trusted-certs.pem: {{ .Files.Get "hono-demo-certs-jar/trusted-certs.pem" | b64enc }}
   adapter.credentials: {{ .Files.Get "example/kura-adapter.credentials" | b64enc }}
 {{- end }}
-{{ end }}

--- a/charts/hono/templates/hono-adapter-lora/hono-adapter-lora-vertx-secret.yaml
+++ b/charts/hono/templates/hono-adapter-lora/hono-adapter-lora-vertx-secret.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.adapters.lora.enabled }}
 #
-# Copyright (c) 2019 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -34,11 +34,9 @@ stringData:
         {{- end }}
       {{- include "hono.healthServerConfig" .Values.adapters.lora.hono.healthCheck | nindent 6 }}
       {{- include "hono.serviceClientConfig" $args | nindent 6 }}
-{{- if not .Values.adapters.lora.extraSecretMounts }}
 data:
   key.pem: {{ .Files.Get "hono-demo-certs-jar/lora-adapter-key.pem" | b64enc }}
   cert.pem: {{ .Files.Get "hono-demo-certs-jar/lora-adapter-cert.pem" | b64enc }}
   trusted-certs.pem: {{ .Files.Get "hono-demo-certs-jar/trusted-certs.pem" | b64enc }}
   adapter.credentials: {{ .Files.Get "example/lora-adapter.credentials" | b64enc }}
-{{- end }}
 {{- end }}

--- a/charts/hono/templates/hono-adapter-mqtt/hono-adapter-mqtt-vertx-secret.yaml
+++ b/charts/hono/templates/hono-adapter-mqtt/hono-adapter-mqtt-vertx-secret.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -34,10 +34,8 @@ stringData:
         {{- end }}
       {{- include "hono.healthServerConfig" .Values.adapters.mqtt.hono.healthCheck | nindent 6 }}
       {{- include "hono.serviceClientConfig" $args | nindent 6 }}
-{{- if not .Values.adapters.mqtt.extraSecretMounts }}
 data:
   key.pem: {{ .Files.Get "hono-demo-certs-jar/mqtt-adapter-key.pem" | b64enc }}
   cert.pem: {{ .Files.Get "hono-demo-certs-jar/mqtt-adapter-cert.pem" | b64enc }}
   trusted-certs.pem: {{ .Files.Get "hono-demo-certs-jar/trusted-certs.pem" | b64enc }}
   adapter.credentials: {{ .Files.Get "example/mqtt-adapter.credentials" | b64enc }}
-{{- end }}

--- a/charts/hono/templates/hono-service-auth/hono-service-auth-secret.yaml
+++ b/charts/hono/templates/hono-service-auth/hono-service-auth-secret.yaml
@@ -38,10 +38,8 @@ stringData:
           {{- . | toYaml | nindent 10 }}
           {{- end }}
       {{- include "hono.healthServerConfig" .Values.authServer.hono.healthServer | nindent 6 }}
-{{- if not .Values.authServer.extraSecretMounts }}
 data:
   key.pem: {{ .Files.Get "hono-demo-certs-jar/auth-server-key.pem" | b64enc }}
   cert.pem: {{ .Files.Get "hono-demo-certs-jar/auth-server-cert.pem" | b64enc }}
   trusted-certs.pem: {{ .Files.Get "hono-demo-certs-jar/trusted-certs.pem" | b64enc }}
   permissions.json: {{ .Files.Get "example/example-permissions.json" | b64enc }}
-{{- end }}

--- a/charts/hono/templates/hono-service-device-connection/hono-service-device-connection-secret.yaml
+++ b/charts/hono/templates/hono-service-device-connection/hono-service-device-connection-secret.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.deviceConnectionService.enabled }}
 #
-# Copyright (c) 2019 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -60,11 +60,9 @@ stringData:
           {{- end }}
         {{- end }}
       {{- include "hono.healthServerConfig" .Values.deviceConnectionService.hono.healthCheck | nindent 6 }}
-{{- if not .Values.deviceConnectionService.extraSecretMounts }}
 data:
   key.pem: {{ .Files.Get "hono-demo-certs-jar/device-connection-key.pem" | b64enc }}
   cert.pem: {{ .Files.Get "hono-demo-certs-jar/device-connection-cert.pem" | b64enc }}
   trusted-certs.pem: {{ .Files.Get "hono-demo-certs-jar/trusted-certs.pem" | b64enc }}
   auth-server-cert.pem: {{ .Files.Get "hono-demo-certs-jar/auth-server-cert.pem" | b64enc }}
-{{- end }}
 {{- end }}

--- a/charts/hono/templates/hono-service-device-registry/hono-service-device-registry-secret.yaml
+++ b/charts/hono/templates/hono-service-device-registry/hono-service-device-registry-secret.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.deviceRegistryExample.enabled }}
 #
-# Copyright (c) 2019 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -75,11 +75,9 @@ stringData:
           filename: "/var/lib/hono/device-registry/tenants.json"
           saveToFile: true
       {{- include "hono.healthServerConfig" .Values.deviceRegistryExample.hono.healthCheck | nindent 6 }}
-{{- if not .Values.deviceRegistryExample.extraSecretMounts }}
 data:
   key.pem: {{ .Files.Get "hono-demo-certs-jar/device-registry-key.pem" | b64enc }}
   cert.pem: {{ .Files.Get "hono-demo-certs-jar/device-registry-cert.pem" | b64enc }}
   trusted-certs.pem: {{ .Files.Get "hono-demo-certs-jar/trusted-certs.pem" | b64enc }}
   auth-server-cert.pem: {{ .Files.Get "hono-demo-certs-jar/auth-server-cert.pem" | b64enc }}
-{{- end }}
 {{- end }}

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -242,11 +242,7 @@ adapters:
     # then be used in e.g. the service client specs.
     # The secrets are expected to exist in the same Kubernetes namespace
     # as the one that the adapter has been deployed to.
-    # If this property is set then the example key, cert, trust store and credentials
-    # will not be included in the adapters "config" secret, i.e. the extra
-    # secret(s) defined here need to include these artifacts if the adapter should
-    # use TLS and/or credentials for authentication.
-    extraSecretMounts:
+    extraSecretMounts: {}
     #  passwords:
     #    secretName: "my-passwords"
     #    mountPath: "/etc/pwd"
@@ -314,11 +310,7 @@ adapters:
     # then be used in e.g. the service client specs.
     # The secrets are expected to exist in the same Kubernetes namespace
     # as the one that the adapter has been deployed to.
-    # If this property is set then the example key, cert, trust store and credentials
-    # will not be included in the adapters "config" secret, i.e. the extra
-    # secret(s) defined here need to include these artifacts if the adapter should
-    # use TLS and/or credentials for authentication.
-    extraSecretMounts:
+    extraSecretMounts: {}
     #  passwords:
     #    secretName: "my-passwords"
     #    mountPath: "/etc/pwd"
@@ -373,11 +365,7 @@ adapters:
     # then be used in e.g. the service client specs.
     # The secrets are expected to exist in the same Kubernetes namespace
     # as the one that the adapter has been deployed to.
-    # If this property is set then the example key, cert, trust store and credentials
-    # will not be included in the adapters "config" secret, i.e. the extra
-    # secret(s) defined here need to include these artifacts if the adapter should
-    # use TLS and/or credentials for authentication.
-    extraSecretMounts:
+    extraSecretMounts: {}
     #  passwords:
     #    secretName: "my-passwords"
     #    mountPath: "/etc/pwd"
@@ -443,11 +431,7 @@ adapters:
     # then be used in e.g. the service client specs.
     # The secrets are expected to exist in the same Kubernetes namespace
     # as the one that the adapter has been deployed to.
-    # If this property is set then the example key, cert, trust store and credentials
-    # will not be included in the adapters "config" secret, i.e. the extra
-    # secret(s) defined here need to include these artifacts if the adapter should
-    # use TLS and/or credentials for authentication.
-    extraSecretMounts:
+    extraSecretMounts: {}
     #  passwords:
     #    secretName: "my-passwords"
     #    mountPath: "/etc/pwd"
@@ -513,11 +497,7 @@ adapters:
     # then be used in e.g. the service client specs.
     # The secrets are expected to exist in the same Kubernetes namespace
     # as the one that the adapter has been deployed to.
-    # If this property is set then the example key, cert, trust store and credentials
-    # will not be included in the adapters "config" secret, i.e. the extra
-    # secret(s) defined here need to include these artifacts if the adapter should
-    # use TLS and/or credentials for authentication.
-    extraSecretMounts:
+    extraSecretMounts: {}
     #  passwords:
     #    secretName: "my-passwords"
     #    mountPath: "/etc/pwd"
@@ -580,11 +560,7 @@ adapters:
     # then be used in e.g. the service client specs.
     # The secrets are expected to exist in the same Kubernetes namespace
     # as the one that the adapter has been deployed to.
-    # If this property is set then the example key, cert, trust store and credentials
-    # will not be included in the adapters "config" secret, i.e. the extra
-    # secret(s) defined here need to include these artifacts if the adapter should
-    # use TLS and/or credentials for authentication.
-    extraSecretMounts:
+    extraSecretMounts: {}
     #  passwords:
     #    secretName: "my-passwords"
     #    mountPath: "/etc/pwd"
@@ -647,11 +623,7 @@ authServer:
   # then be used in e.g. the configuration of the server's exposed ports.
   # The secrets are expected to exist in the same Kubernetes namespace
   # as the one that the server has been deployed to.
-  # If this property is set then the example key, cert, trust store and credentials
-  # will not be included in the Auth Server's' "config" secret, i.e. the extra
-  # secret(s) defined here need to include these artifacts if the Auth Server should
-  # use TLS and/or credentials for authentication.
-  extraSecretMounts:
+  extraSecretMounts: {}
   #  passwords:
   #    secretName: "my-passwords"
   #    mountPath: "/etc/pwd"
@@ -738,11 +710,7 @@ deviceRegistryExample:
   # then be used in e.g. the configuration of the server's exposed ports.
   # The secrets are expected to exist in the same Kubernetes namespace
   # as the one that the server has been deployed to.
-  # If this property is set then the example key, cert, trust store and example
-  # data files will not be included in the Registry's "config" secret, i.e. the extra
-  # secret(s) defined here need to include these artifacts if the Device Registry should
-  # use TLS and/or other example data.
-  extraSecretMounts:
+  extraSecretMounts: {}
   #  tls:
   #    secretName: "key-material"
   #    mountPath: "/etc/tls"
@@ -853,11 +821,7 @@ deviceConnectionService:
   # then be used in e.g. the configuration of the service's exposed ports.
   # The secrets are expected to exist in the same Kubernetes namespace
   # as the one that the service has been deployed to.
-  # If this property is set then the example key, cert and trust store will not be
-  # included in the service's "config" secret, i.e. the extra
-  # secret(s) defined here need to include these artifacts if the service should
-  # use TLS and/or other credentials.
-  extraSecretMounts:
+  extraSecretMounts: {}
   #  tls:
   #    secretName: "key-material"
   #    mountPath: "/etc/tls"


### PR DESCRIPTION
This allows for users to create and mount extra secrets for e.g.
providing device registry data and or custom permission definitions used
by the Auth Server while still using the example keys for TLS.

Also adapted the NOTES.txt to display some more useful information.
