### PR TITLE
Add iot-chart key word to hawkBit Chart.yaml

### DIFF
--- a/charts/hawkbit/Chart.yaml
+++ b/charts/hawkbit/Chart.yaml
@@ -1,8 +1,24 @@
+# Copyright (c) 2020 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+---
 apiVersion: v1
-version: 1.0.0
+version: 1.0.1
 appVersion: "0.3.0M6-mysql"
-description: A Helm chart for hawkBit update server
+description: |
+   Eclipse hawkBit™ is a domain independent back-end framework for rolling out software updates
+   to constrained edge devices as well as more powerful controllers and gateways connected to
+   IP based networking infrastructure.
 name: hawkbit
+keywords:
+  - iot-chart
 home: https://www.eclipse.org/hawkbit/
 sources:
 - https://github.com/eclipse/hawkbit


### PR DESCRIPTION
The key word can be used to filter for project charts when searching the
repository.
