### PR TITLE
Set resource limits for all components

### DIFF
--- a/homepage/_packages/cloud2edge/installation.md
+++ b/homepage/_packages/cloud2edge/installation.md
@@ -7,7 +7,9 @@ description: Installations instructions for the Cloud2Edge package.
 
 {% capture main %}
 
-You will need a Kubernetes instance in order to deploy this package. If you haven't done so already, take a look at our [Kubernetes installation]({{ "/prereqs" | relative_url }}) page. Any Kubernetes compatible cluster will do, as long as it meets the requirements.
+You will need a Kubernetes instance, the `kubectl` and the `helm` tool in order to deploy this package.
+Please refer to our [pre-requisites]({{ "/prereqs" | relative_url }}) page for details.
+Any Kubernetes compatible cluster will do, as long as it meets the requirements.
 
 ## Check access
 
@@ -26,44 +28,27 @@ This should print out the version of the client, but must also print out the ver
 
 ## Run the installation
 
-First create a new namespace for the package:
+The Cloud2Edge package consists of multiple components. In order to keep them together and separate
+from other components running in your Kubernetes cluster, it is feasible to install them into
+their own name space. The following command creates the `cloud2edge` name space but you can select any
+other name as well.
 
 {% clipboard %}
 kubectl create namespace cloud2edge
 {% endclipboard %}
 
-Next, install the package using Helm:
+Next, install the package to the name space using Helm
 
 {% clipboard %}
-helm install --dependency-update -n cloud2edge c2e eclipse-iot/cloud2edge
+helm install -n cloud2edge c2e eclipse-iot/cloud2edge
 {% endclipboard %}
 
-## Monitor installation
-
-Installation and start-up of the package's services might take some minutes.
-You can track the start-up by means of the following command:
-
-{% clipboard %}
-kubectl get pods -n cloud2edge
-{% endclipboard %}
-
-You should see the pods being started and becoming ready.
-
-{% details Example of started pods %}
-    NAME                                               READY   STATUS    RESTARTS   AGE
-    c2e-adapter-amqp-vertx-57dc849d4c-tw25z            1/1     Running   0          148m
-    c2e-adapter-http-vertx-6bdffc59-t54h5              1/1     Running   0          148m
-    c2e-adapter-mqtt-vertx-74cdb9644b-6pgs6            1/1     Running   0          148m
-    c2e-artemis-54ffcff88f-7w85x                       1/1     Running   0          148m
-    c2e-dispatch-router-54d968954b-vrp7z               1/1     Running   0          148m
-    c2e-service-auth-6c9bcf8899-qmztm                  1/1     Running   0          148m
-    c2e-service-device-registry-0                      1/1     Running   0          148m
-{% enddetails %}
+and follow the instructions on screen regarding installation progress and next steps.
 
 ## Ready to run
 
-Once the pods are all ready, you can start using the package's services. For an initial walk-through of the functionality
-see the section [Take a tour](../tour).
+Once the packages pods are all up and running, you can start using the package's services.
+For an initial walk-through of the functionality [take a tour](../tour) of the Cloud2Edge package ...
 
 {% endcapture %}
 

--- a/packages/cloud2edge/Chart.yaml
+++ b/packages/cloud2edge/Chart.yaml
@@ -11,7 +11,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 apiVersion: v1
-version: 0.0.1-alpha2
+version: 0.0.1
 appVersion: 0.0.1
 name: cloud2edge
 description: |

--- a/packages/cloud2edge/values.yaml
+++ b/packages/cloud2edge/values.yaml
@@ -22,6 +22,16 @@ hono:
   grafana:
     enabled: false
 
+  amqpMessagingNetworkExample:
+    dispatchRouter:
+      resources:
+        requests:
+          cpu: 150m
+    broker:
+      resources:
+        requests:
+          cpu: 150m
+
   authServer:
     extraSecretMounts:
       permissions:
@@ -38,6 +48,9 @@ hono:
             tokenExpiration: 3600
 
   deviceRegistryExample:
+    resources:
+      requests:
+        cpu: 150m
     extraSecretMounts:
       registrydata:
         secretName: "c2e-registry-data"
@@ -49,3 +62,95 @@ hono:
       tenantsFile: "c2e-tenants.json"
       devicesFile: "c2e-devices.json"
       credentialsFile: "c2e-credentials.json"
+
+  adapters:
+    amqp:
+      resources:
+        requests:
+          cpu: 150m
+    http:
+      resources:
+        requests:
+          cpu: 150m
+    mqtt:
+      resources:
+        requests:
+          cpu: 150m
+
+
+# Configuration properties for Eclipse Ditto.
+ditto:
+
+  concierge:
+    resources:
+      requests:
+        cpu: 150m
+      limits:
+        cpu: 1
+        memory: "512Mi"
+
+  connectivity:
+    resources:
+      requests:
+        cpu: 150m
+      limits:
+        cpu: 1
+        memory: "512Mi"
+
+  gateway:
+    resources:
+      requests:
+        cpu: 150m
+      limits:
+        cpu: 1
+        memory: "512Mi"
+
+  nginx:
+    resources:
+      requests:
+        cpu: 100m
+      limits:
+        cpu: 250m
+        memory: "64Mi"
+
+  policies:
+    resources:
+      requests:
+        cpu: 150m
+      limits:
+        cpu: 1
+        memory: "512Mi"
+
+  swaggerui:
+    resources:
+      requests:
+        cpu: 100m
+      limits:
+        cpu: 250m
+        memory: "128Mi"
+
+  things:
+    resources:
+      requests:
+        cpu: 150m
+      limits:
+        cpu: 1
+        memory: "512Mi"
+
+  thingsSearch:
+    resources:
+      requests:
+        cpu: 150m
+      limits:
+        cpu: 1
+        memory: "512Mi"
+
+  mongodb:
+    resources:
+      requests:
+        cpu: 150m
+        memory: "256Mi"
+      limits:
+        cpu: 1
+        memory: "512Mi"
+


### PR DESCRIPTION
For a demo setup, the Ditto components should also be able to work with fewer resources than defined by the Ditto chart.
Adapt installation instructions on home page to refer to output of helm
install command.
Changed chart version to allow installation without --devel flag.
