### PR TITLE
Use node port in ditto

### DIFF
--- a/homepage/_packages/cloud2edge/installation.md
+++ b/homepage/_packages/cloud2edge/installation.md
@@ -26,7 +26,7 @@ This should print out the version of the client, but must also print out the ver
     Server Version: version.Info{Major:"1", Minor:"13+", GitVersion:"v1.13.4+c2a5caf", GitCommit:"c2a5caf", GitTreeState:"clean", BuildDate:"2019-09-21T02:12:52Z", GoVersion:"go1.11.13", Compiler:"gc", Platform:"linux/amd64"}
 {% enddetails %}
 
-## Run the installation
+## Install the package
 
 The Cloud2Edge package consists of multiple components. In order to keep them together and separate
 from other components running in your Kubernetes cluster, it is feasible to install them into
@@ -34,21 +34,40 @@ their own name space. The following command creates the `cloud2edge` name space 
 other name as well.
 
 {% clipboard %}
-kubectl create namespace cloud2edge
+NS=cloud2edge
+kubectl create namespace $NS
 {% endclipboard %}
 
-Next, install the package to the name space using Helm
+Next, install the package to the name space using Helm.
+
+{% variants %}
+
+{% variant NodePort %}
+Kubernetes variants like *kind* or *Minikube* do not support exposing service endpoints via load balancers
+out of the box. Instead, services are exposed via *NodePorts*.
 
 {% clipboard %}
-helm install -n cloud2edge c2e eclipse-iot/cloud2edge
+RELEASE=c2e
+helm install -n $NS $RELEASE eclipse-iot/cloud2edge
 {% endclipboard %}
+{% endvariant %}
 
-and follow the instructions on screen regarding installation progress and next steps.
+{% variant LoadBalancer %}
+Managed Kubernetes variants usually support exposing service endpoints via load balancers on public
+IP addresses. To install the Cloud2Edge package using load balancers, run the following command:
+
+{% clipboard %}
+RELEASE=c2e
+helm install -n $NS --set hono.useLoadBalancer=true --set ditto.nginx.service.type=LoadBalancer $RELEASE eclipse-iot/cloud2edge
+{% endclipboard %}
+{% endvariant %}
+
+{% endvariants %}
 
 ## Ready to run
 
-Once the packages pods are all up and running, you can start using the package's services.
-For an initial walk-through of the functionality [take a tour](../tour) of the Cloud2Edge package ...
+Once the package's pods are all up and running, you can start using its services.
+The easiest way of getting to know the Cloud2Edge package is by [taking a little tour](../tour).
 
 {% endcapture %}
 

--- a/homepage/_packages/cloud2edge/scripts/setCloud2EdgeEnv.sh
+++ b/homepage/_packages/cloud2edge/scripts/setCloud2EdgeEnv.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+#*******************************************************************************
+# Copyright (c) 2020 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+#*******************************************************************************
+
+RELEASE=$1
+NS=${2:-default}
+
+NODE_IP=$(kubectl get node -n $NS --output jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}' 2> /dev/null)
+
+function getPorts {
+  SERVICENAME=$1
+  PORT_NAMES=$2
+  ENV_VAR_PREFIX=$3
+  TYPE=$4
+
+  for NAME in $PORT_NAMES
+  do
+    PORT=$(kubectl get service $SERVICENAME -n $NS --output jsonpath='{.spec.ports[?(@.name=='"'$NAME'"')].'$TYPE'}' 2> /dev/null)
+    if [ $? -eq 0 -a "$PORT" != '' ]
+    then
+      UPPERCASE_PORT_NAME=$(echo $NAME | tr [a-z\-] [A-Z_])
+      echo "export ${ENV_VAR_PREFIX}_PORT_${UPPERCASE_PORT_NAME}=\"$PORT\""
+    fi
+  done
+
+}
+
+function getService {
+  SERVICENAME=${RELEASE}-$1
+  PORT_NAMES=$2
+  ENV_VAR_PREFIX=$3
+
+  SERVICE_TYPE=$(kubectl get service $SERVICENAME -n $NS --output jsonpath='{.spec.type}' 2> /dev/null)
+  if [ $? -eq 0 ]
+  then
+    case $SERVICE_TYPE in
+      NodePort)
+        echo "export ${ENV_VAR_PREFIX}_IP=\"$NODE_IP\""
+        getPorts $SERVICENAME "$PORT_NAMES" $ENV_VAR_PREFIX nodePort
+        ;;
+      LoadBalancer)
+        IP=$(kubectl get service $SERVICENAME --output='jsonpath={.status.loadBalancer.ingress[0].ip}' -n $NS 2> /dev/null)
+        if [ $? -eq 0 -a "$IP" != '' ]
+        then
+          echo "export ${ENV_VAR_PREFIX}_IP=\"$IP\""
+          getPorts $SERVICENAME $PORT_NAMES $ENV_VAR_PREFIX port
+        fi
+        ;;
+    esac
+  fi
+}
+
+getService dispatch-router-ext "amqp amqps" AMQP_NETWORK
+getService service-device-registry-ext "http https" REGISTRY
+getService adapter-amqp-vertx "amqp amqps" AMQP_ADAPTER
+getService adapter-coap-vertx "coap coaps" COAP_ADAPTER
+getService adapter-http-vertx "http https" HTTP_ADAPTER
+getService adapter-mqtt-vertx "mqtt secure-mqtt" MQTT_ADAPTER
+getService ditto-nginx "http" DITTO_API
+
+echo "# Run this command to populate environment variables"
+echo "# with the NodePorts of Hono's API endpoints:"
+echo "# eval \"\$(./nodePorts.sh RELEASE_NAME [NAMESPACE])\""
+echo "# with NAMESPACE being the Kubernetes name space that you installed Hono to"
+echo "# if no name space is given, the default name space is used"
+

--- a/packages/cloud2edge/Chart.yaml
+++ b/packages/cloud2edge/Chart.yaml
@@ -11,8 +11,8 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 apiVersion: v1
-version: 0.0.2
-appVersion: 0.0.2
+version: 0.0.3
+appVersion: 0.0.3
 name: cloud2edge
 description: |
   Eclipse IoT Cloud2Edge (C2E) is an integrated suite of services developers can use to build IoT applications

--- a/packages/cloud2edge/example-credentials.json
+++ b/packages/cloud2edge/example-credentials.json
@@ -60,10 +60,10 @@
     ]
   },
   {
-    "tenant": "C2E",
+    "tenant": "org.eclipse.packages.c2e",
     "credentials": [
       {
-        "device-id": "org.eclipse.packages.c2e:demo-device",
+        "device-id": "demo-device",
         "type": "hashed-password",
         "auth-id": "demo-device",
         "enabled": true,
@@ -76,7 +76,7 @@
         ]
       },
       {
-        "device-id": "org.eclipse.packages.c2e:demo-device",
+        "device-id": "demo-device",
         "type": "psk",
         "auth-id": "demo-device",
         "enabled": true,

--- a/packages/cloud2edge/example-device-identities.json
+++ b/packages/cloud2edge/example-device-identities.json
@@ -34,10 +34,10 @@
     ]
   },
   {
-    "tenant": "C2E",
+    "tenant": "org.eclipse.packages.c2e",
     "devices": [
       {
-        "device-id": "org.eclipse.packages.c2e:demo-device",
+        "device-id": "demo-device",
         "data": {
           "enabled": true
         }

--- a/packages/cloud2edge/example-permissions.json
+++ b/packages/cloud2edge/example-permissions.json
@@ -80,19 +80,19 @@
     ],
     "application_c2e": [
       {
-        "resource": "telemetry/C2E",
+        "resource": "telemetry/org.eclipse.packages.c2e",
         "activities": [ "READ" ]
       },
       {
-        "resource": "event/C2E",
+        "resource": "event/org.eclipse.packages.c2e",
         "activities": [ "READ" ]
       },
       {
-        "resource": "command/C2E",
+        "resource": "command/org.eclipse.packages.c2e",
         "activities": [ "WRITE" ]
       },
       {
-        "resource": "command_response/C2E",
+        "resource": "command_response/org.eclipse.packages.c2e",
         "activities": [ "READ" ]
       }
     ]

--- a/packages/cloud2edge/example-tenants.json
+++ b/packages/cloud2edge/example-tenants.json
@@ -13,7 +13,7 @@
     "enabled": true
   },
   {
-    "tenant-id": "C2E",
+    "tenant-id": "org.eclipse.packages.c2e",
     "enabled": true
   }
 ]

--- a/packages/cloud2edge/values.yaml
+++ b/packages/cloud2edge/values.yaml
@@ -106,6 +106,8 @@ ditto:
         memory: "512Mi"
 
   nginx:
+    service:
+      type: NodePort
     resources:
       requests:
         cpu: 100m


### PR DESCRIPTION
Use NodePort for Ditto's nginx service by default.
Updated installation instructions accordingly.