### PR TITLE
fixed that Ditto-Hono connection in c2e package contained wrong address

### DIFF
--- a/packages/cloud2edge/Chart.yaml
+++ b/packages/cloud2edge/Chart.yaml
@@ -11,8 +11,8 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 apiVersion: v1
-version: 0.0.4
-appVersion: 0.0.4
+version: 0.0.5
+appVersion: 0.0.5
 name: cloud2edge
 description: |
   Eclipse IoT Cloud2Edge (C2E) is an integrated suite of services developers can use to build IoT applications
@@ -28,3 +28,5 @@ sources:
 maintainers:
   - name: sophokles73
     email: kai.hudalla@bosch.io
+  - name: thjaeckle
+    email: thomas.jaeckle@bosch.io

--- a/packages/cloud2edge/post-install/hono-connection.json
+++ b/packages/cloud2edge/post-install/hono-connection.json
@@ -47,7 +47,7 @@
       ],
       "targets": [
         {
-          "address": {{ printf "command/%s/{{ thing:id }}" .Values.demoDevice.tenant | quote }},
+          "address": {{ printf "command/%s" .Values.demoDevice.tenant | quote }},
           "authorizationContext": [
             "pre-authenticated:hono-connection"
           ],
@@ -64,7 +64,7 @@
           }
         },
         {
-          "address": {{ printf "command/%s/{{ thing:id }}" .Values.demoDevice.tenant | quote }},
+          "address": {{ printf "command/%s" .Values.demoDevice.tenant | quote }},
           "authorizationContext": [
             "pre-authenticated:hono-connection"
           ],


### PR DESCRIPTION
Regarding the target address for cloud-2-device direction (commands).

The used address pattern `command/<tenant>/<device-id>` was still the pattern used in older versions of Hono.
Removed the `/<device-id>` part.