### PR TITLE
[#61] Use hotrod port for readiness probe

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.1.5
+version: 1.1.6
 # Version of Hono being deployed by the chart
 appVersion: 1.1.1
 keywords:

--- a/charts/hono/templates/example-data-grid/service.yaml
+++ b/charts/hono/templates/example-data-grid/service.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.dataGridExample.enabled }}
 #
-# Copyright (c) 2019 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -18,14 +18,14 @@ metadata:
   {{- include "hono.metadata" $args | nindent 2 }}
 spec:
   ports:
-  - name: rest
+  - name: http
     port: 8080
     protocol: TCP
-    targetPort: 8080
+    targetPort: http
   - name: hotrod
     port: 11222
     protocol: TCP
-    targetPort: 11222
+    targetPort: hotrod
   selector:
     {{- include "hono.matchLabels" $args | nindent 4 }}
   sessionAffinity: None

--- a/charts/hono/templates/example-data-grid/statefulset.yaml
+++ b/charts/hono/templates/example-data-grid/statefulset.yaml
@@ -43,27 +43,25 @@ spec:
         imagePullPolicy: IfNotPresent
         name: hono-data-grid
         ports:
-        - containerPort: 8080
+        - name: http
+          containerPort: 8080
           protocol: TCP
-        - containerPort: 8181
-          protocol: TCP
-        - containerPort: 8888
+        - name: https
+          containerPort: 8443
           protocol: TCP
         - containerPort: 9990
           protocol: TCP
-        - containerPort: 11211
-          protocol: TCP
-        - containerPort: 11222
+        - name: hotrod
+          containerPort: 11222
           protocol: TCP
         volumeMounts:
         - mountPath: /opt/jboss/infinispan-server/standalone/configuration/hono
           name: conf
           readOnly: true
         readinessProbe:
-          exec:
-            command:
-            - /usr/local/bin/is_healthy.sh
-          initialDelaySeconds: 10
+          tcpSocket:
+            port: hotrod
+          initialDelaySeconds: 60
           periodSeconds: 10
           successThreshold: 1
           failureThreshold: 5


### PR DESCRIPTION
The `is_healthy.sh` script for some reason took >= 30 secs to complete.
Changed the readiness probe to connect to the hotrod port instead.
