### PR TITLE
Support connecting external protocol adapters

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.1.6
+version: 1.2.0
 # Version of Hono being deployed by the chart
 appVersion: 1.1.1
 keywords:

--- a/charts/hono/config/router/qdrouterd.json
+++ b/charts/hono/config/router/qdrouterd.json
@@ -41,7 +41,6 @@
     "requireSsl": true,
     "host": "0.0.0.0",
     "port": 5671,
-    "maxSessionFrames": 200,
     "linkCapacity": 100,
     "authenticatePeer": true,
     "saslMechanisms": "PLAIN",
@@ -51,7 +50,6 @@
   ["listener", {
     "host": "0.0.0.0",
     "port": 5672,
-    "maxSessionFrames": 200,
     "linkCapacity": 100,
     "authenticatePeer": true,
     "saslMechanisms": "PLAIN",
@@ -63,7 +61,6 @@
     "requireSsl": true,
     "host": "0.0.0.0",
     "port": 5673,
-    "maxSessionFrames": 500,
     "linkCapacity": 100,
     "authenticatePeer": true,
     "saslMechanisms": "EXTERNAL"
@@ -135,6 +132,7 @@
       "groups": {
         "$default": {
           "remoteHosts": "*",
+          "maxSessionWindow": 3276800,
           "maxSessions": 10
         }
       }
@@ -148,11 +146,12 @@
           "users": "Eclipse IoT;Hono",
           "remoteHosts": "*",
           "maxSessions": 4,
+          "maxSessionWindow": 8192000,
           "maxMessageSize": 131072,
           "allowUserIdProxy": true,
           "allowAnonymousSender": true,
-          "sources": "control/*, command/*",
-          "targets": "telemetry/*, event/*, control/*, command_response/*"
+          "sources": "command/*",
+          "targets": "telemetry/*, event/*, command_response/*"
         }
       }
   }],

--- a/charts/hono/config/router/qdrouterd.json
+++ b/charts/hono/config/router/qdrouterd.json
@@ -150,8 +150,8 @@
           "maxMessageSize": 131072,
           "allowUserIdProxy": true,
           "allowAnonymousSender": true,
-          "sources": "command/*",
-          "targets": "telemetry/*, event/*, command_response/*"
+          "sources": "control/*, command/*",
+          "targets": "telemetry/*, event/*, control/*, command_response/*"
         }
       }
   }],

--- a/charts/hono/templates/dispatch-router/dispatch-router-ext-svc.yaml
+++ b/charts/hono/templates/dispatch-router/dispatch-router-ext-svc.yaml
@@ -32,6 +32,13 @@ spec:
     protocol: TCP
     targetPort: amqp
     nodePort: 30672
+  {{- if .Values.adapters.externalAdaptersEnabled }}
+  - name: internal
+    port: 15673
+    protocol: TCP
+    targetPort: internal
+    nodePort: 30673
+  {{- end }}
   selector:
     {{- include "hono.matchLabels" $args | nindent 4 }}
 {{- if and ( eq .Values.useLoadBalancer true ) ( ne .Values.platform "openshift" ) }}

--- a/charts/hono/templates/hono-service-device-registry/hono-service-device-registry-ext-svc.yaml
+++ b/charts/hono/templates/hono-service-device-registry/hono-service-device-registry-ext-svc.yaml
@@ -32,6 +32,12 @@ spec:
     protocol: TCP
     targetPort: https
     nodePort: 31443
+  {{- if .Values.adapters.externalAdaptersEnabled }}
+  - name: amqps
+    port: 5671
+    protocol: TCP
+    targetPort: amqps
+  {{- end }}
   selector:
     {{- include "hono.matchLabels" $args | nindent 4 }}
 {{- if and ( eq .Values.useLoadBalancer true ) ( ne .Values.platform "openshift" ) }}

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -188,16 +188,17 @@ adapters:
   # The default setting is 'false' which prevents access from outside of the
   # cluster.
   # Setting this property to 'true' allows external adapters to connect to
-  # the Dispatch Router's 'interal' endpoint and the Device Registry's
+  # the Dispatch Router's 'internal' endpoint and the Device Registry's
   # service endpoints via AMQPS, i.e. AMQP over TLS.
-  # The Dispatch Router requires adapters to authenticate using SASL EXTERNAL,
-  # i.e. an adapter needs to provide a client certificate that has been signed
-  # by one of the CA certs contained in the router's trust store.
+  # The Dispatch Router's 'internal' endoint listens on port 15673 and requires
+  # adapters to authenticate using SASL EXTERNAL, i.e. an adapter needs to provide
+  # a client certificate that has been signed by one of the CA certs contained in
+  # the router's trust store.
   # When opening the AMQP connection to the router, the adapter needs to indicate
   # the 'hono-internal' virtual host name in its AMQP 1.0 'open' frame.
-  # The example Device Registry requires adapters to authenticate using SASL PLAIN,
-  # i.e. an adapter needs to provide a username and password which can be verified
-  # by the Auth Server component.
+  # The example Device Registry's AMQPS endpoint requires adapters to authenticate
+  # using SASL PLAIN, i.e. an adapter needs to provide a username and password which
+  # can be verified by the Auth Server component.
   externalAdaptersEnabled: false
 
   # amqpMessagingNetworkSpec contains Hono client properties used by all protocol

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -182,6 +182,24 @@ useLoadBalancer: true
 # Configuration properties for protocol adapters.
 adapters:
 
+  # externalAdaptersEnabled indicates whether protocol adapters that
+  # run outside of the kubernetes cluster should be allowed to connect to
+  # the Dispatch Router and the example device registry's service endpoints.
+  # The default setting is 'false' which prevents access from outside of the
+  # cluster.
+  # Setting this property to 'true' allows external adapters to connect to
+  # the Dispatch Router's 'interal' endpoint and the Device Registry's
+  # service endpoints via AMQPS, i.e. AMQP over TLS.
+  # The Dispatch Router requires adapters to authenticate using SASL EXTERNAL,
+  # i.e. an adapter needs to provide a client certificate that has been signed
+  # by one of the CA certs contained in the router's trust store.
+  # When opening the AMQP connection to the router, the adapter needs to indicate
+  # the 'hono-internal' virtual host name in its AMQP 1.0 'open' frame.
+  # The example Device Registry requires adapters to authenticate using SASL PLAIN,
+  # i.e. an adapter needs to provide a username and password which can be verified
+  # by the Auth Server component.
+  externalAdaptersEnabled: false
+
   # amqpMessagingNetworkSpec contains Hono client properties used by all protocol
   # adapters for connecting to the AMQP Messaging Network to forward downstream messages to.
   # This property MUST be set if "amqpMessagingNetworkDeployExample" is set to false.


### PR DESCRIPTION
The example AMQP Messaging Network and Device Registry can now be
configured to allow protocol adapters that run outside of the cluster to
connect to their secure endpoints.
This is helpful e.g. for connecting edge nodes which run a Hono protocol
adapter to connect to a Hono instance running in a back end.
