### PR TITLE
Add support for mounting additional secrets in broker and router

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.2.1
+version: 1.3.0
 # Version of Hono being deployed by the chart
 appVersion: 1.1.1
 keywords:

--- a/charts/hono/README.md
+++ b/charts/hono/README.md
@@ -315,7 +315,7 @@ The Device Connection service can also be configured to connect to an already ex
 corresponding configuration properties.
 
 
-## Installing optional Adapters
+## Enabling or disabling Protocol Adapters
 
 The Helm chart by default installs the HTTP, MQTT and AMQP protocol adapters.
 However, the chart also supports deployment of additional protocol adapters which are still considered experimental or
@@ -324,9 +324,12 @@ The following table provides an overview of the corresponding configuration prop
 
 | Property                     | Default  | Description                              |
 | :--------------------------- | :------- | :--------------------------------------- |
+| *adapters.amqp.enabled*      | `true`  | Indicates if the AMQP protocol adapter should be deployed. |
 | *adapters.coap.enabled*      | `false` | Indicates if the (experimental) CoAP protocol adapter should be deployed. |
+| *adapters.http.enabled*      | `true`  | Indicates if the HTTP protocol adapter should be deployed. |
 | *adapters.kura.enabled*      | `false` | Indicates if the deprecated Kura protocol adapter should be deployed. |
 | *adapters.lora.enabled*      | `false` | Indicates if the (experimental) LoRa WAN protocol adapter should be deployed. |
+| *adapters.mqtt.enabled*      | `true`  | Indicates if the MQTT protocol adapter should be deployed. |
 
 The following command will deploy the LoRa adapter along with Hono's standard adapters
 

--- a/charts/hono/config/router/qdrouterd.json
+++ b/charts/hono/config/router/qdrouterd.json
@@ -19,23 +19,6 @@
     "privateKeyFile": "{{ .Values.amqpMessagingNetworkExample.dispatchRouter.keyFile }}"
   }],
 
-  ["sslProfile", {
-    "name": "broker-connection",
-    {{- if not .Values.amqpMessagingNetworkExample.broker.servicebus.host }}
-    "caCertFile": "{{ .Values.amqpMessagingNetworkExample.dispatchRouter.trustStore }}",
-    {{- end }}
-    "protocols": "TLSv1.2"
-  }],
-
-  ["sslProfile", {
-    "name": "internal",
-    "protocols": "TLSv1.2",
-    "caCertFile": "{{ .Values.amqpMessagingNetworkExample.dispatchRouter.trustStore }}",
-    "certFile": "{{ .Values.amqpMessagingNetworkExample.dispatchRouter.certFile }}",
-    "privateKeyFile": "{{ .Values.amqpMessagingNetworkExample.dispatchRouter.keyFile }}",
-    "uidFormat": "ou"
-  }],
-
   ["listener", {
     "sslProfile": "server",
     "requireSsl": true,
@@ -56,6 +39,15 @@
     "saslPlugin": "Hono Auth"
   }],
 
+  ["sslProfile", {
+    "name": "internal",
+    "protocols": "TLSv1.2",
+    "caCertFile": "{{ .Values.amqpMessagingNetworkExample.dispatchRouter.trustStore }}",
+    "certFile": "{{ .Values.amqpMessagingNetworkExample.dispatchRouter.certFile }}",
+    "privateKeyFile": "{{ .Values.amqpMessagingNetworkExample.dispatchRouter.keyFile }}",
+    "uidFormat": "{{ .Values.amqpMessagingNetworkExample.dispatchRouter.uidFormat }}"
+  }],
+
   ["listener", {
     "sslProfile": "internal",
     "requireSsl": true,
@@ -72,14 +64,22 @@
     "http": true
   }],
 
+  ["sslProfile", {
+    "name": "broker-profile",
+    {{- if not .Values.amqpMessagingNetworkExample.broker.servicebus.host }}
+    "caCertFile": "{{ .Values.amqpMessagingNetworkExample.dispatchRouter.serverTrustStore }}",
+    {{- end }}
+    "protocols": "TLSv1.2"
+  }],
+
   ["connector", {
-    "sslProfile": "broker-connection",
-    "name": "broker",
+    "name": "broker-connection",
+    "sslProfile": "broker-profile",
     "role": "route-container",
     "port": {{ .Values.amqpMessagingNetworkExample.broker.port }},
     "saslMechanisms": "PLAIN",
     "saslUsername": "{{ .Values.amqpMessagingNetworkExample.broker.saslUsername }}",
-    "saslPassword": "{{ .Values.amqpMessagingNetworkExample.broker.saslPassword }}",
+    "saslPassword": "file:/etc/hono/broker-password",
     {{- if .Values.amqpMessagingNetworkExample.broker.servicebus.host }}
     "host": "{{ .Values.amqpMessagingNetworkExample.broker.serviceBus.host }}",
     "idleTimeoutSeconds": 120
@@ -95,7 +95,7 @@
     {{- if .Values.amqpMessagingNetworkExample.broker.servicebus.host }}
     "delExternalPrefix": "event/",
     {{- end }}
-    "connection": "broker"
+    "connection": "broker-connection"
   }],
 
   ["linkRoute", {
@@ -104,7 +104,7 @@
     {{- if .Values.amqpMessagingNetworkExample.broker.servicebus.host }}
     "delExternalPrefix": "event/",
     {{- end }}
-    "connection": "broker"
+    "connection": "broker-connection"
   }],
 
   ["address", {
@@ -142,8 +142,8 @@
       "hostname": "hono-internal",
       "maxConnections": 50,
       "groups": {
-        "Hono": {
-          "users": "Eclipse IoT;Hono",
+        "Adapters": {
+          "users": "{{ .Values.amqpMessagingNetworkExample.dispatchRouter.adapterUids }}",
           "remoteHosts": "*",
           "maxSessions": 4,
           "maxSessionWindow": 8192000,

--- a/charts/hono/templates/_helpers.tpl
+++ b/charts/hono/templates/_helpers.tpl
@@ -327,10 +327,17 @@ Adds volume mounts to a component's container.
 The scope passed in is expected to be a dict with keys
 - "conf": the component's configuration properties as defined in .Values
 - "name": the name of the component.
+Optionally, the scope my contain key
+- "configMountPath": the mount path to use for the component's config secret
+                     instead of the default "/etc/hono"
 */}}
 {{- define "hono.container.secretVolumeMounts" }}
 - name: {{ printf "%s-conf" .name | quote }}
+  {{- if .configMountPath }}
+  mountPath: {{ .configMountPath | quote }}
+  {{- else }}
   mountPath: "/etc/hono"
+  {{- end }}
   readOnly: true
 {{- with .conf.extraSecretMounts }}
 {{- range $name,$spec := . }}

--- a/charts/hono/templates/artemis/artemis-deployment.yaml
+++ b/charts/hono/templates/artemis/artemis-deployment.yaml
@@ -68,11 +68,7 @@ spec:
         securityContext:
           privileged: false
         volumeMounts:
-        - mountPath: /opt/apache-artemis/conf
-          name: config
-          readOnly: true
+        {{- include "hono.container.secretVolumeMounts" ( dict "name" $args.name "conf" .Values.amqpMessagingNetworkExample.broker "configMountPath" "/opt/apache-artemis/conf" ) | indent 8 }}
       volumes:
-      - name: config
-        secret:
-          secretName: {{ .Release.Name }}-artemis-conf
+      {{- include "hono.pod.secretVolumes" ( dict "releaseName" .Release.Name "name" $args.name "conf" .Values.amqpMessagingNetworkExample.broker ) | indent 6 }}
 {{- end }}

--- a/charts/hono/templates/dispatch-router/dispatch-router-deployment.yaml
+++ b/charts/hono/templates/dispatch-router/dispatch-router-deployment.yaml
@@ -70,11 +70,7 @@ spec:
         securityContext:
           privileged: false
         volumeMounts:
-        - mountPath: /etc/hono
-          name: config
-          readOnly: true
+        {{- include "hono.container.secretVolumeMounts" ( dict "name" $args.name "conf" .Values.amqpMessagingNetworkExample.dispatchRouter ) | indent 8 }}
       volumes:
-      - name: config
-        secret:
-          secretName: {{ .Release.Name }}-dispatch-router-conf
+      {{- include "hono.pod.secretVolumes" ( dict "releaseName" .Release.Name "name" $args.name "conf" .Values.amqpMessagingNetworkExample.dispatchRouter ) | indent 6 }}
 {{- end }}

--- a/charts/hono/templates/dispatch-router/dispatch-router-secret.yaml
+++ b/charts/hono/templates/dispatch-router/dispatch-router-secret.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.amqpMessagingNetworkExample.enabled }}
 #
-# Copyright (c) 2019 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -24,4 +24,5 @@ data:
   "qdrouter-key.pem": {{ .Files.Get "hono-demo-certs-jar/qdrouter-key.pem" | b64enc }}
   "qdrouter-cert.pem": {{ .Files.Get "hono-demo-certs-jar/qdrouter-cert.pem" | b64enc }}
   "trusted-certs.pem": {{ .Files.Get "hono-demo-certs-jar/trusted-certs.pem" | b64enc }}
+  "broker-password" : {{ .Values.amqpMessagingNetworkExample.broker.saslPassword | b64enc }}
 {{- end }}

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -20,6 +20,8 @@ amqpMessagingNetworkExample:
   # deployed and used. By default an internal Broker is deployed.
   # As alternative an external Broker can be configured as well.
   enabled: true
+
+  # dispatchRouter contains properties for configuring the QPid Dispatch Router
   dispatchRouter:
     # imageName contains the name (including tag) of the container image
     # to use for the example AQMP Messaging Network's Dispatch Router.
@@ -34,12 +36,31 @@ amqpMessagingNetworkExample:
     keyFile: "/etc/hono/qdrouter-key.pem"
     # trustStore contains the absolute path to a PEM file containing
     # the X.509 certificates that the router should use as trust anchors
-    # when authentitcating peers
+    # when authentitcating clients connecting to the router in a TLS
+    # handshake
     trustStore: "/etc/hono/trusted-certs.pem"
+    # serverTrustStore contains the absolute path to a PEM file containing
+    # the X.509 certificates that the router should use as trust anchors
+    # when authentitcating to servers as part of a TLS handshake
+    serverTrustStore: "/etc/hono/trusted-certs.pem"
+    # uidFormat contains the format string to use for extracting the user ID from
+    # the subject DN of certificates that clients use for authenticating to the router's
+    # "internal" listener.
+    # See http://qpid.apache.org/releases/qpid-dispatch-1.10.0/man/qdrouterd.conf.html
+    # for details regarding the syntax.
+    # The default value ("ou") extracts the Organization ("O") and the Org Unit ("OU")
+    # and concatenates them using a semicolon, e.g. "Eclipse IoT;Hono"
+    uidFormat: "ou"
+    # adapterUids contains a comma separated list of uids of protocol adapters that authenticate
+    # by means of a client certificate.
+    # The default value ("Eclipse IoT;Hono") includes all adapters that authenticate with their
+    # demo certificate.
+    adapterUids: "Eclipse IoT;Hono"
+
     svc:
       annotations: {}
       loadBalancerIP:
-    # resources contains the container's 'requests and limits for CPU and memory
+    # resources contains the container's requests and limits for CPU and memory
     # as defined by the Kubernetes API.
     # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
     # for a description of the properties' semantics.
@@ -50,6 +71,20 @@ amqpMessagingNetworkExample:
       limits:
         cpu: "1"
         memory: "256Mi"
+
+    # extraSecretMounts describes additional secrets that should be mounted into the
+    # router's container filesystem. The files from the secret(s) can
+    # then be used in the router configuration, e.g. for using custom key material and certificates.
+    # The secrets are expected to exist in the same Kubernetes namespace
+    # as the one that the router has been deployed to.
+    extraSecretMounts: {}
+    #  passwords:
+    #    secretName: "my-passwords"
+    #    mountPath: "/etc/pwd"
+    #  other:
+    #    secretName: "other-stuff"
+    #    mountPath: "/etc/other"
+
   # AMQP Messaging Network Broker configuration.
   broker:
     # saslUsername contains the username that the Dispatch Router should use
@@ -77,6 +112,20 @@ amqpMessagingNetworkExample:
         limits:
           cpu: "1"
           memory: "512Mi"
+
+      # extraSecretMounts describes additional secrets that should be mounted into the
+      # Artemis container's filesystem. The files from the secret(s) can
+      # then be used in the Artemis configuration, e.g. for using custom key material and certificates.
+      # The secrets are expected to exist in the same Kubernetes namespace
+      # as the one that the router has been deployed to.
+      extraSecretMounts: {}
+      #  passwords:
+      #    secretName: "my-passwords"
+      #    mountPath: "/etc/pwd"
+      #  other:
+      #    secretName: "other-stuff"
+      #    mountPath: "/etc/other"
+
     # servicebus contains configuration properties for the Azure ServiceBus instance that
     # should be used instead of the example Artemis broker.
     servicebus:


### PR DESCRIPTION
The example registry's Dispatch Router and Artemis containers can now be
configured to mount additional secret volumes. This way, the router and
broker can be configured with custom key material.
The example regstry's Dispatch Router's "internal" listener can now be
configured with the uidFormat and to use for extracting user IDs from
client certificate subject DNs. This is needed in order to properly
configure the protocol adapter uids when using custom certificates from
your own PKI.
