### PR TITLE
Upon restart, file base device registry configuration is overwritten

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.3.0
+version: 1.3.1
 # Version of Hono being deployed by the chart
 appVersion: 1.1.1
 keywords:

--- a/charts/hono/templates/hono-service-device-registry/hono-service-device-registry-statefulset.yaml
+++ b/charts/hono/templates/hono-service-device-registry/hono-service-device-registry-statefulset.yaml
@@ -35,9 +35,9 @@ spec:
         command:
         - sh
         - -c
-        - cp -u /tmp/hono/{{ .Values.deviceRegistryExample.data.devicesFile }} /var/lib/hono/device-registry/device-identities.json;
-          cp -u /tmp/hono/{{ .Values.deviceRegistryExample.data.credentialsFile }} /var/lib/hono/device-registry/credentials.json;
-          cp -u /tmp/hono/{{ .Values.deviceRegistryExample.data.tenantsFile }} /var/lib/hono/device-registry/tenants.json
+        - if [ ! -f "/var/lib/hono/device-registry/device-identities.json" ]; then cp -u /tmp/hono/{{ .Values.deviceRegistryExample.data.devicesFile }} /var/lib/hono/device-registry/device-identities.json; fi;
+          if [ ! -f "/var/lib/hono/device-registry/credentials.json" ]; then cp -u /tmp/hono/{{ .Values.deviceRegistryExample.data.credentialsFile }} /var/lib/hono/device-registry/credentials.json; fi;
+          if [ ! -f "/var/lib/hono/device-registry/tenants.json" ]; then cp -u /tmp/hono/{{ .Values.deviceRegistryExample.data.tenantsFile }} /var/lib/hono/device-registry/tenants.json; fi;
         volumeMounts:
         - name: {{ default ( printf "%s-conf" $args.name ) .Values.deviceRegistryExample.data.volumeName | quote }}
           mountPath: "/tmp/hono"


### PR DESCRIPTION
Somehow, this slipped back in: https://github.com/eclipse/hono/issues/1007
Signed-off-by: Bob Claerhout <claerhout.bob@gmail.com>