### PR TITLE
Use gRPC for collecting spans

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.3.3
+version: 1.3.4
 # Version of Hono being deployed by the chart
 appVersion: 1.2.1
 keywords:

--- a/charts/hono/templates/_helpers.tpl
+++ b/charts/hono/templates/_helpers.tpl
@@ -282,7 +282,7 @@ Adds a Jaeger Agent container to a template spec.
 {{- $jaegerEnabled := or .Values.jaegerBackendExample.enabled .Values.jaegerAgentConf }}
 {{- if $jaegerEnabled }}
 - name: jaeger-agent-sidecar
-  image: {{ default "jaegertracing/jaeger-agent:1.13.1" .Values.jaegerAgentImage }}
+  image: {{ .Values.jaegerAgentImage }}
   ports:
   - name: agent-compact
     containerPort: 6831
@@ -300,11 +300,9 @@ Adds a Jaeger Agent container to a template spec.
     initialDelaySeconds: 5
   env:
   {{- if .Values.jaegerBackendExample.enabled }}
-  - name: REPORTER_TYPE
-    value: "tchannel"
-  - name: REPORTER_TCHANNEL_HOST_PORT
-    value: {{ printf "%s-jaeger-collector:14267" .Release.Name | quote }}
-  - name: REPORTER_TCHANNEL_DISCOVERY_MIN_PEERS
+  - name: REPORTER_GRPC_HOST_PORT
+    value: {{ printf "%s-jaeger-collector:14250" .Release.Name | quote }}
+  - name: REPORTER_GRPC_DISCOVERY_MIN_PEERS
     value: "1"
   {{- else }}
   {{- range $key, $value := .Values.jaegerAgentConf }}

--- a/charts/hono/templates/jaeger/jaeger-collector-service.yaml
+++ b/charts/hono/templates/jaeger/jaeger-collector-service.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.jaegerBackendExample.enabled }}
 #
-# Copyright (c) 2019 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -18,14 +18,10 @@ metadata:
   {{- include "hono.metadata" $args | nindent 2 }}
 spec:
   ports:
-  - name: jaeger-collector-tchannel
-    port: 14267
+  - name: collector-grpc
+    port: 14250
     protocol: TCP
-    targetPort: 14267
-  - name: jaeger-collector-http
-    port: 14268
-    protocol: TCP
-    targetPort: 14268
+    targetPort: collector-grpc
   selector:
     {{- include "hono.matchLabels" $args | nindent 4 }}
   type: ClusterIP

--- a/charts/hono/templates/jaeger/jaeger-deployment.yaml
+++ b/charts/hono/templates/jaeger/jaeger-deployment.yaml
@@ -37,18 +37,17 @@ spec:
         image: {{ .Values.jaegerBackendExample.allInOneImage }}
         name: jaeger
         ports:
-        - containerPort: 5775
-          protocol: UDP
-        - containerPort: 6831
-          protocol: UDP
-        - containerPort: 6832
-          protocol: UDP
-        - containerPort: 5778
+        - name: collector-grpc
+          containerPort: 14250
+          protocol: TCP
+        - name: server-http
+          containerPort: 5778
+          protocol: TCP
+        - name: query-http
+          containerPort: 16686
           protocol: TCP
         - name: health
           containerPort: {{ .Values.healthCheckPort }}
-          protocol: TCP
-        - containerPort: 16686
           protocol: TCP
         {{- with .Values.jaegerBackendExample.resources }}
         resources:

--- a/charts/hono/templates/jaeger/jaeger-query-service.yaml
+++ b/charts/hono/templates/jaeger/jaeger-query-service.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.jaegerBackendExample.enabled }}
 #
-# Copyright (c) 2019 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -25,7 +25,7 @@ spec:
     - name: query-http
       port: 80
       protocol: TCP
-      targetPort: 16686
+      targetPort: query-http
   selector:
     {{- include "hono.matchLabels" $args | nindent 4 }}
 {{- if and ( eq .Values.useLoadBalancer true ) ( ne .Values.platform "openshift" ) }}

--- a/charts/hono/templates/prometheus/prometheus-config.yaml
+++ b/charts/hono/templates/prometheus/prometheus-config.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.prometheus.createInstance }}
 #
-# Copyright (c) 2019 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -36,16 +36,22 @@ data:
     {{- if .Values.deviceConnectionService.enabled }}
       {{- include "hono.prometheus.scrapeJob" (dict "dot" . "serviceName" "service-device-connection") | nindent 4 }}
     {{- end }}
-    {{- include "hono.prometheus.scrapeJob" (dict "dot" . "serviceName" "adapter-amqp-vertx") | nindent 4 }}
-    {{- include "hono.prometheus.scrapeJob" (dict "dot" . "serviceName" "adapter-http-vertx") | nindent 4 }}
-    {{- if .Values.adapters.lora.enabled }}
-      {{- include "hono.prometheus.scrapeJob" (dict "dot" . "serviceName" "adapter-lora-vertx") | nindent 4 }}
-    {{- end }}
-    {{- include "hono.prometheus.scrapeJob" (dict "dot" . "serviceName" "adapter-mqtt-vertx") | nindent 4 }}
-    {{- if .Values.adapters.kura.enabled }}
-      {{- include "hono.prometheus.scrapeJob" (dict "dot" . "serviceName" "adapter-kura") | nindent 4 }}
+    {{- if .Values.adapters.amqp.enabled }}
+      {{- include "hono.prometheus.scrapeJob" (dict "dot" . "serviceName" "adapter-amqp-vertx") | nindent 4 }}
     {{- end }}
     {{- if .Values.adapters.coap.enabled }}
       {{- include "hono.prometheus.scrapeJob" (dict "dot" . "serviceName" "adapter-coap-vertx") | nindent 4 }}
+    {{- end }}
+    {{- if .Values.adapters.http.enabled }}
+      {{- include "hono.prometheus.scrapeJob" (dict "dot" . "serviceName" "adapter-http-vertx") | nindent 4 }}
+    {{- end }}
+    {{- if .Values.adapters.kura.enabled }}
+      {{- include "hono.prometheus.scrapeJob" (dict "dot" . "serviceName" "adapter-kura") | nindent 4 }}
+    {{- end }}
+    {{- if .Values.adapters.lora.enabled }}
+      {{- include "hono.prometheus.scrapeJob" (dict "dot" . "serviceName" "adapter-lora-vertx") | nindent 4 }}
+    {{- end }}
+    {{- if .Values.adapters.mqtt.enabled }}
+      {{- include "hono.prometheus.scrapeJob" (dict "dot" . "serviceName" "adapter-mqtt-vertx") | nindent 4 }}
     {{- end }}
 {{ end }}

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -188,7 +188,7 @@ jaegerBackendExample:
   enabled: false
   # allInOneImage contains the name (including tag)
   # of the container image to use for the example Jaeger back end.
-  allInOneImage: jaegertracing/all-in-one:1.13.1
+  allInOneImage: jaegertracing/all-in-one:1.17
   # resources contains the container's 'requests and limits for CPU and memory
   # as defined by the Kubernetes API.
   # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
@@ -207,19 +207,18 @@ jaegerBackendExample:
 # jaegerAgentImage contains the name (including tag)
 # of the container image to use for the Jaeger Agent sidecar deployed
 # with Hono's components.
-jaegerAgentImage: jaegertracing/jaeger-agent:1.13.1
+jaegerAgentImage: jaegertracing/jaeger-agent:1.17
 # jaegerAgentConf contains environment variables for configuring the Jaeger Agent sidecar container
 # that is deployed with each of Hono's components.
 # The Jaeger Agent sidecar container is deployed with standard properties if
 # "jaegerBackendExample.enabled" is set to true.
 # Otherwise the sidecar container is deployed using the environment variables contained
 # in this property (if not nil).
-# Please refer to https://www.jaegertracing.io/docs/1.13/cli/ for syntax and semantics
+# Please refer to https://www.jaegertracing.io/docs/1.17/cli/ for syntax and semantics
 # of environment variables.
 jaegerAgentConf:
-#  REPORTER_TYPE: tchannel
-#  REPORTER_TCHANNEL_HOST_PORT: my-jaeger-collector:14267
-#  REPORTER_TCHANNEL_DISCOVERY_MIN_PEERS: 1
+#  REPORTER_GRPC_HOST_PORT: my-jaeger-collector:14250
+#  REPORTER_GRPC_DISCOVERY_MIN_PEERS: 1
 
 # defaultJavaOptions contains options to pass to the JVM when starting
 # up Hono's containers


### PR DESCRIPTION
The tchannel protocol has been deprecated in Jaeger. The gRPC protocol
is the recommended way for collecting spans from Agents.

Updated to Jaeger 1.17 as well.
