### PR TITLE
[#86] Add kubernetes 1.18.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,13 +47,16 @@ jobs:
     needs: lint-chart
     strategy:
       matrix:
+        # the versions supported by kubeval are the ones for
+        # which a folder exists at
+        # https://github.com/instrumenta/kubernetes-json-schema
         k8s:
-          - v1.12.10
-          - v1.13.11
-          - v1.14.10
+          - v1.13.9
+          - v1.14.9
           - v1.15.7
           - v1.16.4
           - v1.17.0
+          # kubeval doesn't seem to support 1.18.0 yet'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -73,12 +76,12 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.12.10
           - v1.13.12
           - v1.14.10
-          - v1.15.7
-          - v1.16.4
-          - v1.17.2
+          - v1.15.11
+          - v1.16.8
+          - v1.17.4
+          - v1.18.0
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
The CI pipeline now verifies installation to kubernetes 1.18.0. Older
versions have beeen updated to their latest patch version.
1.12 has been removed.
