### PR TITLE
Reduce default CPU requests for Ditto chart

### DIFF
--- a/charts/ditto/Chart.yaml
+++ b/charts/ditto/Chart.yaml
@@ -17,7 +17,7 @@ description: |
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids,
   EV charging stations etc).
 name: ditto
-version: 1.1.4
+version: 1.1.5
 keywords:
   - iot-chart
 home: https://www.eclipse.org/ditto

--- a/charts/ditto/values.yaml
+++ b/charts/ditto/values.yaml
@@ -138,7 +138,7 @@ concierge:
   ## resources for the concierge container
   resources:
     requests:
-      cpu: 250m
+      cpu: 200m
       memory: 256Mi
     # limits:
     #   ## no cpu limit to avoid CFS scheduler limits
@@ -301,7 +301,7 @@ gateway:
   ## resources for the gateway container
   resources:
     requests:
-      cpu: 250m
+      cpu: 200m
       memory: 256Mi
     # limits:
     #   ## no cpu limit to avoid CFS scheduler limits
@@ -439,7 +439,7 @@ policies:
   ## resources for the policies container
   resources:
     requests:
-      cpu: 250m
+      cpu: 150m
       memory: 256Mi
     # limits:
     #   ## no cpu limit to avoid CFS scheduler limits
@@ -557,7 +557,7 @@ things:
   ## resources for the things container
   resources:
     requests:
-      cpu: 250m
+      cpu: 150m
       memory: 256Mi
     # limits:
     #   ## no cpu limit to avoid CFS scheduler limits
@@ -631,7 +631,7 @@ thingsSearch:
   ## resources for the things-search container
   resources:
     requests:
-      cpu: 250m
+      cpu: 150m
       memory: 256Mi
     # limits:
     #   ## no cpu limit to avoid CFS scheduler limits


### PR DESCRIPTION
adjusted defaults for CPU requests for Ditto chart in order to be able to start on a 2 CPU core machine