### PR TITLE
update kubeval 1.17 and added 1.18

### DIFF
--- a/.github/kubeval.sh
+++ b/.github/kubeval.sh
@@ -18,8 +18,8 @@ set -o errexit
 set -o pipefail
 
 CHART_DIRS="$(git diff --find-renames --name-only "$(git rev-parse --abbrev-ref HEAD)" remotes/origin/master -- charts packages | grep '[cC]hart.yaml' | sed -e 's#/[Cc]hart.yaml##g')"
-HELM_VERSION="v3.1.1"
-KUBEVAL_VERSION="0.14.0"
+HELM_VERSION="v3.1.2"
+KUBEVAL_VERSION="0.15.0"
 SCHEMA_LOCATION="https://raw.githubusercontent.com/instrumenta/kubernetes-json-schema/master/"
 
 # install helm

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,8 +55,8 @@ jobs:
           - v1.14.9
           - v1.15.7
           - v1.16.4
-          - v1.17.0
-          # kubeval doesn't seem to support 1.18.0 yet'
+          - v1.17.4
+          - v1.18.1
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Signed-off-by: André Bauer <monotek23@gmail.com>

* updated kubeval config to use k8s 1.17.4
* added kubeval config for k8s 1.18.1
* updated helm client to 3.1.2
* updated kubeval to 01.5.0

this is a follow up to: https://github.com/eclipse/packages/pull/90

new kubeval configs available from:  https://github.com/instrumenta/kubernetes-json-schema