### PR TITLE
Make tag name of Hono images configurable

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.3.8
+version: 1.3.9
 # Version of Hono being deployed by the chart
 appVersion: 1.2.3
 keywords:

--- a/charts/hono/README.md
+++ b/charts/hono/README.md
@@ -181,31 +181,31 @@ to do that is to create a YAML file that specifies the particular image and tag 
 ```yaml
 deviceRegistryExample:
   imageName: my-custom-registry/hono-service-device-registry-custom
-    tagName: 1.0.0
+  imageTag: 1.0.0
 
 authServer:
   imageName: eclipse/hono-service-auth
-  tagName: 1.3.0-M3
+  imageTag: 1.3.0-M3
 
 adapters:
   amqp:
     imageName: eclipse/hono-adapter-amqp-vertx
-    tagName: 1.2.3
+    imageTag: 1.2.3
   coap:
     imageName: eclipse/hono-adapter-coap-vertx
-    tagName: 1.2.3
+    imageTag: 1.2.3
   http:
     imageName: eclipse/hono-adapter-http-vertx
-    tagName: 1.2.3
+    imageTag: 1.2.3
   kura:
     imageName: eclipse/hono-adapter-kura
-    tagName: 1.2.3
+    imageTag: 1.2.3
   mqtt:
     imageName: eclipse/hono-adapter-mqtt-vertx
-    tagName: 1.2.3
+    imageTag: 1.2.3
   lora:
     imageName: eclipse/hono-adapter-lora-vertx
-    tagName: 1.2.3
+    imageTag: 1.2.3
 ```
 
 Assuming that the file is named `customImages.yaml`, the values can then be passed in to the

--- a/charts/hono/README.md
+++ b/charts/hono/README.md
@@ -160,38 +160,56 @@ helm install --dependency-update -n hono --set prometheus.createInstance=false -
 ## Using specific Container Images
 
 The chart can be customized to use container images other than the default ones.
-This can be used to install an older version of the images or to install a milestone
+This can be used to install an older version of the images or to install a Hono milestone
 using the chart. It can also be used to install custom built images that need to be
 pulled from a different (private) container registry.
 
 The `values.yaml` file contains configuration properties for setting the container
-image names and tags to use for Hono's components.
-The easiest way to override these values is to create a YAML file with the following content:
+image and tag names to use for Hono's components. The easiest way to override the version
+of all Hono components simultaneously is to set the `honoImagesTag` property to the desired
+value during installation.
+
+The following command installs Hono using the standard images published on Docker Hub with tag
+*1.3.0-M3* images instead of the ones indicated by the chart's *appVersion* property:
+
+```bash
+helm install --dependency-update -n hono --set honoImagesTag=1.3.0-M3 eclipse-hono eclipse-iot/hono
+```
+It is also possible to define the image and tag names for each component individually. The easiest way
+to do that is to create a YAML file that specifies the particular image and tag names:
 
 ```yaml
 deviceRegistryExample:
-  imageName: eclipse/hono-service-device-registry-file:1.2.0
+  imageName: my-custom-registry/hono-service-device-registry-custom
+    tagName: 1.0.0
 
 authServer:
-  imageName: eclipse/hono-service-auth:1.2.0
+  imageName: eclipse/hono-service-auth
+  tagName: 1.3.0-M3
 
 adapters:
   amqp:
-    imageName: eclipse/hono-adapter-amqp-vertx:1.2.0
+    imageName: eclipse/hono-adapter-amqp-vertx
+    tagName: 1.2.3
   coap:
-    imageName: eclipse/hono-adapter-coap-vertx:1.2.0
+    imageName: eclipse/hono-adapter-coap-vertx
+    tagName: 1.2.3
   http:
-    imageName: eclipse/hono-adapter-http-vertx:1.2.0
+    imageName: eclipse/hono-adapter-http-vertx
+    tagName: 1.2.3
   kura:
-    imageName: eclipse/hono-adapter-kura:1.2.0
+    imageName: eclipse/hono-adapter-kura
+    tagName: 1.2.3
   mqtt:
-    imageName: eclipse/hono-adapter-mqtt-vertx:1.2.0
+    imageName: eclipse/hono-adapter-mqtt-vertx
+    tagName: 1.2.3
   lora:
-    imageName: eclipse/hono-adapter-lora-vertx:1.2.0
+    imageName: eclipse/hono-adapter-lora-vertx
+    tagName: 1.2.3
 ```
 
-The names and tags can be set per component. Assuming that the file is named `customImages.yaml`,
-the values can then be passed in to the Helm `install` command as follows:
+Assuming that the file is named `customImages.yaml`, the values can then be passed in to the
+Helm `install` command as follows:
 
 ```bash
 helm install --dependency-update -n hono -f /path/to/customImages.yaml eclipse-hono eclipse-iot/hono

--- a/charts/hono/templates/hono-adapter-amqp/hono-adapter-amqp-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-amqp/hono-adapter-amqp-vertx-deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
-      - image: {{ printf "%s:%s" .Values.adapters.amqp.imageName ( default .Chart.AppVersion ( default .Values.honoImagesTag .Values.adapters.amqp.tagName ) ) }}
+      - image: {{ printf "%s:%s" .Values.adapters.amqp.imageName ( default .Chart.AppVersion ( default .Values.honoImagesTag .Values.adapters.amqp.imageTag ) ) }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-adapter-amqp-vertx
         ports:

--- a/charts/hono/templates/hono-adapter-amqp/hono-adapter-amqp-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-amqp/hono-adapter-amqp-vertx-deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
-      - image: {{ .Values.adapters.amqp.imageName }}
+      - image: {{ printf "%s:%s" .Values.adapters.amqp.imageName ( default .Chart.AppVersion ( default .Values.honoImagesTag .Values.adapters.amqp.tagName ) ) }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-adapter-amqp-vertx
         ports:

--- a/charts/hono/templates/hono-adapter-coap/hono-adapter-coap-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-coap/hono-adapter-coap-vertx-deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
-      - image: {{ printf "%s:%s" .Values.adapters.coap.imageName ( default .Chart.AppVersion ( default .Values.honoImagesTag .Values.adapters.coap.tagName ) ) }}
+      - image: {{ printf "%s:%s" .Values.adapters.coap.imageName ( default .Chart.AppVersion ( default .Values.honoImagesTag .Values.adapters.coap.imageTag ) ) }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-adapter-coap-vertx
         ports:

--- a/charts/hono/templates/hono-adapter-coap/hono-adapter-coap-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-coap/hono-adapter-coap-vertx-deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
-      - image: {{ .Values.adapters.coap.imageName }}
+      - image: {{ printf "%s:%s" .Values.adapters.coap.imageName ( default .Chart.AppVersion ( default .Values.honoImagesTag .Values.adapters.coap.tagName ) ) }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-adapter-coap-vertx
         ports:

--- a/charts/hono/templates/hono-adapter-http/hono-adapter-http-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-http/hono-adapter-http-vertx-deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
-      - image: {{ printf "%s:%s" .Values.adapters.http.imageName ( default .Chart.AppVersion ( default .Values.honoImagesTag .Values.adapters.http.tagName ) ) }}
+      - image: {{ printf "%s:%s" .Values.adapters.http.imageName ( default .Chart.AppVersion ( default .Values.honoImagesTag .Values.adapters.http.imageTag ) ) }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-adapter-http-vertx
         ports:

--- a/charts/hono/templates/hono-adapter-http/hono-adapter-http-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-http/hono-adapter-http-vertx-deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
-      - image: {{ .Values.adapters.http.imageName }}
+      - image: {{ printf "%s:%s" .Values.adapters.http.imageName ( default .Chart.AppVersion ( default .Values.honoImagesTag .Values.adapters.http.tagName ) ) }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-adapter-http-vertx
         ports:

--- a/charts/hono/templates/hono-adapter-kura/hono-adapter-kura-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-kura/hono-adapter-kura-deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
-      - image: {{ printf "%s:%s" .Values.adapters.kura.imageName ( default .Chart.AppVersion ( default .Values.honoImagesTag .Values.adapters.kura.tagName ) ) }}
+      - image: {{ printf "%s:%s" .Values.adapters.kura.imageName ( default .Chart.AppVersion ( default .Values.honoImagesTag .Values.adapters.kura.imageTag ) ) }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-adapter-kura
         ports:

--- a/charts/hono/templates/hono-adapter-kura/hono-adapter-kura-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-kura/hono-adapter-kura-deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
-      - image: {{ .Values.adapters.kura.imageName }}
+      - image: {{ printf "%s:%s" .Values.adapters.kura.imageName ( default .Chart.AppVersion ( default .Values.honoImagesTag .Values.adapters.kura.tagName ) ) }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-adapter-kura
         ports:

--- a/charts/hono/templates/hono-adapter-lora/hono-adapter-lora-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-lora/hono-adapter-lora-vertx-deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
-      - image: {{ .Values.adapters.lora.imageName }}
+      - image: {{ printf "%s:%s" .Values.adapters.lora.imageName ( default .Chart.AppVersion ( default .Values.honoImagesTag .Values.adapters.lora.tagName ) ) }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-adapter-lora-vertx
         ports:

--- a/charts/hono/templates/hono-adapter-lora/hono-adapter-lora-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-lora/hono-adapter-lora-vertx-deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
-      - image: {{ printf "%s:%s" .Values.adapters.lora.imageName ( default .Chart.AppVersion ( default .Values.honoImagesTag .Values.adapters.lora.tagName ) ) }}
+      - image: {{ printf "%s:%s" .Values.adapters.lora.imageName ( default .Chart.AppVersion ( default .Values.honoImagesTag .Values.adapters.lora.imageTag ) ) }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-adapter-lora-vertx
         ports:

--- a/charts/hono/templates/hono-adapter-mqtt/hono-adapter-mqtt-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-mqtt/hono-adapter-mqtt-vertx-deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
-      - image: {{ .Values.adapters.mqtt.imageName }}
+      - image: {{ printf "%s:%s" .Values.adapters.mqtt.imageName ( default .Chart.AppVersion ( default .Values.honoImagesTag .Values.adapters.mqtt.tagName ) ) }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-adapter-mqtt-vertx
         ports:

--- a/charts/hono/templates/hono-adapter-mqtt/hono-adapter-mqtt-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-mqtt/hono-adapter-mqtt-vertx-deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
-      - image: {{ printf "%s:%s" .Values.adapters.mqtt.imageName ( default .Chart.AppVersion ( default .Values.honoImagesTag .Values.adapters.mqtt.tagName ) ) }}
+      - image: {{ printf "%s:%s" .Values.adapters.mqtt.imageName ( default .Chart.AppVersion ( default .Values.honoImagesTag .Values.adapters.mqtt.imageTag ) ) }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-adapter-mqtt-vertx
         ports:

--- a/charts/hono/templates/hono-service-auth/hono-service-auth-deployment.yaml
+++ b/charts/hono/templates/hono-service-auth/hono-service-auth-deployment.yaml
@@ -25,7 +25,7 @@ spec:
       {{- include "hono.metadata" $args | nindent 6 }}
     spec:
       containers:
-      - image: {{ printf "%s:%s" .Values.authServer.imageName ( default .Chart.AppVersion ( default .Values.honoImagesTag .Values.authServer.tagName ) ) }}
+      - image: {{ printf "%s:%s" .Values.authServer.imageName ( default .Chart.AppVersion ( default .Values.honoImagesTag .Values.authServer.imageTag ) ) }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-service-auth
         ports:

--- a/charts/hono/templates/hono-service-auth/hono-service-auth-deployment.yaml
+++ b/charts/hono/templates/hono-service-auth/hono-service-auth-deployment.yaml
@@ -25,7 +25,7 @@ spec:
       {{- include "hono.metadata" $args | nindent 6 }}
     spec:
       containers:
-      - image: {{ .Values.authServer.imageName }}
+      - image: {{ printf "%s:%s" .Values.authServer.imageName ( default .Chart.AppVersion ( default .Values.honoImagesTag .Values.authServer.tagName ) ) }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-service-auth
         ports:

--- a/charts/hono/templates/hono-service-device-connection/hono-service-device-connection-deployment.yaml
+++ b/charts/hono/templates/hono-service-device-connection/hono-service-device-connection-deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
-      - image: {{ .Values.deviceConnectionService.imageName }}
+      - image: {{ printf "%s:%s" .Values.deviceConnectionService.imageName ( default .Chart.AppVersion ( default .Values.honoImagesTag .Values.deviceConnectionService.tagName ) ) }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-service-device-connection
         ports:

--- a/charts/hono/templates/hono-service-device-connection/hono-service-device-connection-deployment.yaml
+++ b/charts/hono/templates/hono-service-device-connection/hono-service-device-connection-deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
-      - image: {{ printf "%s:%s" .Values.deviceConnectionService.imageName ( default .Chart.AppVersion ( default .Values.honoImagesTag .Values.deviceConnectionService.tagName ) ) }}
+      - image: {{ printf "%s:%s" .Values.deviceConnectionService.imageName ( default .Chart.AppVersion ( default .Values.honoImagesTag .Values.deviceConnectionService.imageTag ) ) }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-service-device-connection
         ports:

--- a/charts/hono/templates/hono-service-device-registry/hono-service-device-registry-statefulset.yaml
+++ b/charts/hono/templates/hono-service-device-registry/hono-service-device-registry-statefulset.yaml
@@ -46,7 +46,7 @@ spec:
     {{- end }}
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
-      - image: {{ .Values.deviceRegistryExample.imageName }}
+      - image: {{ printf "%s:%s" .Values.deviceRegistryExample.imageName ( default .Chart.AppVersion ( default .Values.honoImagesTag .Values.deviceRegistryExample.tagName ) ) }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-service-device-registry
         ports:

--- a/charts/hono/templates/hono-service-device-registry/hono-service-device-registry-statefulset.yaml
+++ b/charts/hono/templates/hono-service-device-registry/hono-service-device-registry-statefulset.yaml
@@ -46,7 +46,7 @@ spec:
     {{- end }}
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
-      - image: {{ printf "%s:%s" .Values.deviceRegistryExample.imageName ( default .Chart.AppVersion ( default .Values.honoImagesTag .Values.deviceRegistryExample.tagName ) ) }}
+      - image: {{ printf "%s:%s" .Values.deviceRegistryExample.imageName ( default .Chart.AppVersion ( default .Values.honoImagesTag .Values.deviceRegistryExample.imageTag ) ) }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-service-device-registry
         ports:

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -14,6 +14,12 @@
 # Default values for eclipse-hono.
 # Declare variables to be passed into your templates.
 
+# honoImagesTag contains the (common) tag name of the Hono component
+# container images to deploy.
+# If not set explicitly, the chart's appVersion is used as the tag name.
+# Alternatively, the tag name can also be set per component image.
+# honoImagesTag:
+
 amqpMessagingNetworkExample:
   # enabled indicates whether the example AMQP Messaging Network
   # consisting of a single Dispatch Router and Broker should be
@@ -328,7 +334,10 @@ adapters:
     enabled: true
     # imageName contains the name (including registry and tag)
     # of the container image to use for the AMQP adapter
-    imageName: index.docker.io/eclipse/hono-adapter-amqp-vertx:1.2.3
+    imageName: index.docker.io/eclipse/hono-adapter-amqp-vertx
+    # imageTag contains the tag of the container image to deploy.
+    # If not specified, the value of the honoImagesTag property is used.
+    # imageTag:
     # javaOptions contains options to pass to the JVM when starting
     # up the service
     javaOptions: -XX:MinRAMPercentage=80 -XX:MaxRAMPercentage=80
@@ -394,7 +403,10 @@ adapters:
     enabled: false
     # imageName contains the name (including registry and tag)
     # of the container image to use for the CoAP adapter
-    imageName: index.docker.io/eclipse/hono-adapter-coap-vertx:1.2.3
+    imageName: index.docker.io/eclipse/hono-adapter-coap-vertx
+    # imageTag contains the tag of the container image to deploy.
+    # If not specified, the value of the honoImagesTag property is used.
+    # imageTag:
     # javaOptions contains options to pass to the JVM when starting
     # up the service
     javaOptions: -XX:MinRAMPercentage=80 -XX:MaxRAMPercentage=80
@@ -451,7 +463,10 @@ adapters:
     enabled: true
     # imageName contains the name (including registry and tag)
     # of the container image to use for the HTTP adapter
-    imageName: index.docker.io/eclipse/hono-adapter-http-vertx:1.2.3
+    imageName: index.docker.io/eclipse/hono-adapter-http-vertx
+    # imageTag contains the tag of the container image to deploy.
+    # If not specified, the value of the honoImagesTag property is used.
+    # imageTag:
     # javaOptions contains options to pass to the JVM when starting
     # up the service
     javaOptions: -XX:MinRAMPercentage=80 -XX:MaxRAMPercentage=80
@@ -517,7 +532,10 @@ adapters:
     enabled: false
     # imageName contains the name (including registry and tag)
     # of the container image to use for the Kura adapter
-    imageName: index.docker.io/eclipse/hono-adapter-kura:1.2.3
+    imageName: index.docker.io/eclipse/hono-adapter-kura
+    # imageTag contains the tag of the container image to deploy.
+    # If not specified, the value of the honoImagesTag property is used.
+    # imageTag:
     # javaOptions contains options to pass to the JVM when starting
     # up the service
     javaOptions: -XX:MinRAMPercentage=80 -XX:MaxRAMPercentage=80
@@ -583,7 +601,10 @@ adapters:
     enabled: false
     # imageName contains the name (including registry and tag)
     # of the container image to use for the LoRa adapter
-    imageName: index.docker.io/eclipse/hono-adapter-lora-vertx:1.2.3
+    imageName: index.docker.io/eclipse/hono-adapter-lora-vertx
+    # imageTag contains the tag of the container image to deploy.
+    # If not specified, the value of the honoImagesTag property is used.
+    # imageTag:
     # javaOptions contains options to pass to the JVM when starting
     # up the service
     javaOptions: -XX:MinRAMPercentage=80 -XX:MaxRAMPercentage=80
@@ -648,7 +669,10 @@ adapters:
     enabled: true
     # imageName contains the name (including registry and tag)
     # of the container image to use for the MQTT adapter
-    imageName: index.docker.io/eclipse/hono-adapter-mqtt-vertx:1.2.3
+    imageName: index.docker.io/eclipse/hono-adapter-mqtt-vertx
+    # imageTag contains the tag of the container image to deploy.
+    # If not specified, the value of the honoImagesTag property is used.
+    # imageTag:
     # javaOptions contains options to pass to the JVM when starting
     # up the service
     javaOptions: -XX:MinRAMPercentage=80 -XX:MaxRAMPercentage=80
@@ -715,7 +739,10 @@ authServer:
 
   # imageName contains the name (including registry and tag)
   # of the container image to use for the Auth Server
-  imageName: index.docker.io/eclipse/hono-service-auth:1.2.3
+  imageName: index.docker.io/eclipse/hono-service-auth
+  # imageTag contains the tag of the container image to deploy.
+  # If not specified, the value of the honoImagesTag property is used.
+  # imageTag:
   # javaOptions contains options to pass to the JVM when starting
   # up the service
   javaOptions: -XX:MinRAMPercentage=80 -XX:MaxRAMPercentage=80
@@ -798,7 +825,10 @@ deviceRegistryExample:
 
   # imageName contains the name (including registry and tag)
   # of the container image to use for the example Device Registry
-  imageName: index.docker.io/eclipse/hono-service-device-registry-file:1.2.3
+  imageName: index.docker.io/eclipse/hono-service-device-registry-file
+  # imageTag contains the tag of the container image to deploy.
+  # If not specified, the value of the honoImagesTag property is used.
+  # imageTag:
   # javaOptions contains options to pass to the JVM when starting
   # up the service
   javaOptions: -XX:MinRAMPercentage=80 -XX:MaxRAMPercentage=80
@@ -910,7 +940,10 @@ deviceConnectionService:
 
   # imageName contains the name (including registry and tag)
   # of the container image to use for the Device Connection service
-  imageName: index.docker.io/eclipse/hono-service-device-connection:1.2.3
+  imageName: index.docker.io/eclipse/hono-service-device-connection
+  # imageTag contains the tag of the container image to deploy.
+  # If not specified, the value of the honoImagesTag property is used.
+  # imageTag:
   # javaOptions contains options to pass to the JVM when starting
   # up the service
   javaOptions: -XX:MinRAMPercentage=80 -XX:MaxRAMPercentage=80


### PR DESCRIPTION
The chart has supported configuration of the container image name for
all components already. However, the tag name has been part of the image
name so far. In order to allow setting the version of all Hono
components in one go, the honoImagesTag property has been introduced
which defaults to the chart's appVersion. The property can be used for
example to use not yet released (milestone) images for experimenting
purposes. All of Hono's components also support a specific *imageTag*
property to set the image's tag name per component.