### PR TITLE
[#115] Fix issues connecting to Infinispan 11

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.3.9
+version: 1.3.10
 # Version of Hono being deployed by the chart
 appVersion: 1.2.3
 keywords:

--- a/charts/hono/templates/_helpers.tpl
+++ b/charts/hono/templates/_helpers.tpl
@@ -208,6 +208,7 @@ deviceConnection:
   authServerName: {{ $serverName | quote }}
   authUsername: {{ .dot.Values.dataGridExample.authUsername | quote }}
   authPassword: {{ .dot.Values.dataGridExample.authPassword | quote }}
+  authRealm: "ApplicationRealm"
   saslMechanism: "DIGEST-MD5"
   socketTimeout: 5000
   connectTimeout: 5000

--- a/charts/hono/templates/hono-service-device-connection/hono-service-device-connection-secret.yaml
+++ b/charts/hono/templates/hono-service-device-connection/hono-service-device-connection-secret.yaml
@@ -55,6 +55,8 @@ stringData:
           authServerName: {{ $serverName | quote }}
           authUsername: {{ .Values.dataGridExample.authUsername | quote }}
           authPassword: {{ .Values.dataGridExample.authPassword | quote }}
+          authRealm: "ApplicationRealm"
+          saslMechanism: "DIGEST-MD5"
           socketTimeout: 5000
           connectTimeout: 5000
         {{- else }}


### PR DESCRIPTION
The 10.1 Hotrod client used in the upcoming Hono 1.3.0 requires explicit
specification of the "auth_realm" when authenticating using the
DIGEST-MD5 SASL mechanism.
