### PR TITLE
Use annotation based Prometheus scraping configuration

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.3.12
+version: 1.3.13
 # Version of Hono being deployed by the chart
 appVersion: 1.2.4
 keywords:

--- a/charts/hono/requirements.yaml
+++ b/charts/hono/requirements.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -12,7 +12,7 @@
 #
 dependencies:
   - name: prometheus
-    version: ~10.4.0
+    version: ~11.7.0
     repository: "https://kubernetes-charts.storage.googleapis.com/"
     condition: prometheus.createInstance
   - name: grafana

--- a/charts/hono/templates/_helpers.tpl
+++ b/charts/hono/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -86,6 +86,15 @@ The scope passed in is expected to be a dict with keys
 app.kubernetes.io/name: {{ template "hono.name" .dot }}
 app.kubernetes.io/instance: {{ .dot.Release.Name }}
 app.kubernetes.io/component: {{ .component }}
+{{- end }}
+
+{{/*
+Add annotations for marking an object to be scraped by Prometheus.
+*/}}
+{{- define "hono.monitoringAnnotations" -}}
+prometheus.io/scrape: "true"
+prometheus.io/path: "/prometheus"
+prometheus.io/port: {{ default .Values.healthCheckPort .Values.monitoring.prometheus.port | quote }}
 {{- end }}
 
 
@@ -255,27 +264,6 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 
-
-{{/*
-Create a scrape job for a service name.
-The scope passed in is expected to be a dict with keys
-- "dot": the root scope (".") and
-- "serviceName": the name of the service to scrape
-
-*/}}
-{{- define "hono.prometheus.scrapeJob" }}
-- job_name: {{ printf "%s-%s" .dot.Release.Name .serviceName }}
-  metrics_path: /prometheus
-  scheme: https
-  tls_config:
-    insecure_skip_verify: true
-  dns_sd_configs:
-  - names:
-    - {{ printf "%s-%s-headless" .dot.Release.Name .serviceName }}
-    type: A
-    port: {{ default 8088 .dot.Values.monitoring.prometheus.port }}
-    refresh_interval: 10s
-{{- end }}
 
 {{/*
 Adds a Jaeger Agent container to a template spec.

--- a/charts/hono/templates/hono-adapter-amqp/hono-adapter-amqp-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-amqp/hono-adapter-amqp-vertx-deployment.yaml
@@ -24,6 +24,8 @@ spec:
   template:
     metadata:
       {{- include "hono.metadata" $args | nindent 6 }}
+      annotations:
+        {{- include "hono.monitoringAnnotations" . | nindent 8 }}
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}

--- a/charts/hono/templates/hono-adapter-coap/hono-adapter-coap-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-coap/hono-adapter-coap-vertx-deployment.yaml
@@ -24,6 +24,8 @@ spec:
   template:
     metadata:
       {{- include "hono.metadata" $args | nindent 6 }}
+      annotations:
+        {{- include "hono.monitoringAnnotations" . | nindent 8 }}
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}

--- a/charts/hono/templates/hono-adapter-http/hono-adapter-http-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-http/hono-adapter-http-vertx-deployment.yaml
@@ -24,6 +24,8 @@ spec:
   template:
     metadata:
       {{- include "hono.metadata" $args | nindent 6 }}
+      annotations:
+        {{- include "hono.monitoringAnnotations" . | nindent 8 }}
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}

--- a/charts/hono/templates/hono-adapter-kura/hono-adapter-kura-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-kura/hono-adapter-kura-deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.adapters.kura.enabled }}
 #
-# Copyright (c) 2019 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -24,6 +24,8 @@ spec:
   template:
     metadata:
       {{- include "hono.metadata" $args | nindent 6 }}
+      annotations:
+        {{- include "hono.monitoringAnnotations" . | nindent 8 }}
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}

--- a/charts/hono/templates/hono-adapter-lora/hono-adapter-lora-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-lora/hono-adapter-lora-vertx-deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.adapters.lora.enabled }}
 #
-# Copyright (c) 2019 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -24,6 +24,8 @@ spec:
   template:
     metadata:
       {{- include "hono.metadata" $args | nindent 6 }}
+      annotations:
+        {{- include "hono.monitoringAnnotations" . | nindent 8 }}
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}

--- a/charts/hono/templates/hono-adapter-mqtt/hono-adapter-mqtt-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-mqtt/hono-adapter-mqtt-vertx-deployment.yaml
@@ -24,6 +24,8 @@ spec:
   template:
     metadata:
       {{- include "hono.metadata" $args | nindent 6 }}
+      annotations:
+        {{- include "hono.monitoringAnnotations" . | nindent 8 }}
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}

--- a/charts/hono/templates/hono-service-auth/hono-service-auth-deployment.yaml
+++ b/charts/hono/templates/hono-service-auth/hono-service-auth-deployment.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -23,6 +23,8 @@ spec:
   template:
     metadata:
       {{- include "hono.metadata" $args | nindent 6 }}
+      annotations:
+        {{- include "hono.monitoringAnnotations" . | nindent 8 }}
     spec:
       containers:
       - image: {{ printf "%s:%s" .Values.authServer.imageName ( default .Chart.AppVersion ( default .Values.honoImagesTag .Values.authServer.imageTag ) ) }}

--- a/charts/hono/templates/hono-service-device-connection/hono-service-device-connection-deployment.yaml
+++ b/charts/hono/templates/hono-service-device-connection/hono-service-device-connection-deployment.yaml
@@ -24,6 +24,8 @@ spec:
   template:
     metadata:
       {{- include "hono.metadata" $args | nindent 6 }}
+      annotations:
+        {{- include "hono.monitoringAnnotations" . | nindent 8 }}
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}

--- a/charts/hono/templates/hono-service-device-registry/hono-service-device-registry-statefulset.yaml
+++ b/charts/hono/templates/hono-service-device-registry/hono-service-device-registry-statefulset.yaml
@@ -25,6 +25,8 @@ spec:
   template:
     metadata:
       {{- include "hono.metadata" $args | nindent 6 }}
+      annotations:
+        {{- include "hono.monitoringAnnotations" . | nindent 8 }}
     spec:
     {{- if .Values.deviceRegistryExample.data.resetOnStartup }}
       initContainers:

--- a/charts/hono/templates/prometheus/prometheus-config.yaml
+++ b/charts/hono/templates/prometheus/prometheus-config.yaml
@@ -29,29 +29,47 @@ data:
     - /etc/config/alerts
 
     scrape_configs:
-    {{- include "hono.prometheus.scrapeJob" (dict "dot" . "serviceName" "service-auth") | nindent 4 }}
-    {{- if .Values.deviceRegistryExample.enabled }}
-      {{- include "hono.prometheus.scrapeJob" (dict "dot" . "serviceName" "service-device-registry") | nindent 4 }}
-    {{- end }}
-    {{- if .Values.deviceConnectionService.enabled }}
-      {{- include "hono.prometheus.scrapeJob" (dict "dot" . "serviceName" "service-device-connection") | nindent 4 }}
-    {{- end }}
-    {{- if .Values.adapters.amqp.enabled }}
-      {{- include "hono.prometheus.scrapeJob" (dict "dot" . "serviceName" "adapter-amqp-vertx") | nindent 4 }}
-    {{- end }}
-    {{- if .Values.adapters.coap.enabled }}
-      {{- include "hono.prometheus.scrapeJob" (dict "dot" . "serviceName" "adapter-coap-vertx") | nindent 4 }}
-    {{- end }}
-    {{- if .Values.adapters.http.enabled }}
-      {{- include "hono.prometheus.scrapeJob" (dict "dot" . "serviceName" "adapter-http-vertx") | nindent 4 }}
-    {{- end }}
-    {{- if .Values.adapters.kura.enabled }}
-      {{- include "hono.prometheus.scrapeJob" (dict "dot" . "serviceName" "adapter-kura") | nindent 4 }}
-    {{- end }}
-    {{- if .Values.adapters.lora.enabled }}
-      {{- include "hono.prometheus.scrapeJob" (dict "dot" . "serviceName" "adapter-lora-vertx") | nindent 4 }}
-    {{- end }}
-    {{- if .Values.adapters.mqtt.enabled }}
-      {{- include "hono.prometheus.scrapeJob" (dict "dot" . "serviceName" "adapter-mqtt-vertx") | nindent 4 }}
-    {{- end }}
+        # Example scrape config for pods
+        #
+        # The relabeling allows the actual pod scrape endpoint to be configured via the
+        # following annotations:
+        #
+        # * `prometheus.io/scrape`: Only scrape pods that have a value of `true`
+        # * `prometheus.io/path`: If the metrics path is not `/metrics` override this.
+        # * `prometheus.io/port`: Scrape the pod on the indicated port instead of the default of `9102`.
+      - job_name: 'hono-pods'
+        scheme: https
+        tls_config:
+          insecure_skip_verify: true
+        kubernetes_sd_configs:
+          - role: pod
+            # make sure to only scrape pods of this release
+            namespaces:
+              names:
+              - {{ .Release.Namespace }}
+            selectors:
+            - role: pod
+              label: {{ printf "app.kubernetes.io/instance=%s,helm.sh/chart=%s" .Release.Name ( include "hono.chart" . ) }}
+
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+            action: keep
+            regex: true
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+            action: replace
+            target_label: __metrics_path__
+            regex: (.+)
+          - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+            action: replace
+            regex: ([^:]+)(?::\d+)?;(\d+)
+            replacement: $1:$2
+            target_label: __address__
+          - action: labelmap
+            regex: __meta_kubernetes_pod_label_(.+)
+          - source_labels: [__meta_kubernetes_namespace]
+            action: replace
+            target_label: kubernetes_namespace
+          - source_labels: [__meta_kubernetes_pod_name]
+            action: replace
+            target_label: kubernetes_pod_name
 {{ end }}


### PR DESCRIPTION
Changed Prometheus server config to discover pods to be scraped
dynamically using the k8s API server.
Also updated to Prometheus 2.19.0.
