### PR TITLE
Support existing Prometheus server

### DIFF
--- a/charts/hono/.gitignore
+++ b/charts/hono/.gitignore
@@ -1,0 +1,1 @@
+/requirements.lock

--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.3.13
+version: 1.3.14
 # Version of Hono being deployed by the chart
 appVersion: 1.2.4
 keywords:

--- a/charts/hono/templates/_helpers.tpl
+++ b/charts/hono/templates/_helpers.tpl
@@ -243,7 +243,12 @@ deviceConnection:
 {{- if .dot.Values.prometheus.createInstance }}
 resource-limits:
   prometheus-based:
-    host: {{ .dot.Release.Name }}-prometheus-server
+    host: {{ template "hono.prometheus.server.fullname" .dot }}
+{{- else if .dot.Values.prometheus.host }}
+resource-limits:
+  prometheus-based:
+    host: {{ .dot.Values.prometheus.host }}
+    port: {{ default "9090" .dot.Values.prometheus.port }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
The adapters can now also be configured to retrieve resource usage data
from an existing Prometheus server.
