### PR TITLE
Fix repo URLs in Hawkbit requirements

### DIFF
--- a/charts/hawkbit/.gitignore
+++ b/charts/hawkbit/.gitignore
@@ -1,0 +1,1 @@
+/requirements.lock

--- a/charts/hawkbit/Chart.yaml
+++ b/charts/hawkbit/Chart.yaml
@@ -10,7 +10,7 @@
 # SPDX-License-Identifier: EPL-2.0
 ---
 apiVersion: v1
-version: 1.2.2
+version: 1.2.3
 appVersion: "0.3.0M6-mysql"
 description: |
    Eclipse hawkBit™ is a domain independent back-end framework for rolling out software updates

--- a/charts/hawkbit/requirements.lock
+++ b/charts/hawkbit/requirements.lock
@@ -1,9 +1,0 @@
-dependencies:
-- name: mysql
-  repository: https://charts.bitnami.com
-  version: 6.7.4
-- name: rabbitmq
-  repository: https://charts.bitnami.com
-  version: 6.16.0
-digest: sha256:515ffc3c905c6b32413d8089e297c1f38151a225203a5c1b0cb17c157e55625d
-generated: "2020-01-15T11:04:01.389753897+01:00"

--- a/charts/hawkbit/requirements.yaml
+++ b/charts/hawkbit/requirements.yaml
@@ -1,9 +1,9 @@
 dependencies:
   - name: mysql
     version: 6.7.4
-    repository: https://charts.bitnami.com
+    repository: https://charts.bitnami.com/bitnami
     condition: mysql.enabled
   - name: rabbitmq
     version: 6.16.0
-    repository: https://charts.bitnami.com
+    repository: https://charts.bitnami.com/bitnami
     condition: rabbitmq.enabled


### PR DESCRIPTION
This fixes errors when packaging the Hawkbit chart:
````
Downloading mysql from repo https://charts.bitnami.com
Save error occurred:  could not find : chart mysql not found in https://charts.bitnami.com
Deleting newly downloaded charts, restoring pre-update state
Error: could not find : chart mysql not found in https://charts.bitnami.com
````
I've also removed the `requirements.lock` file and added it to `.gitignore` (in analogy to how it's done in the Hono chart).