### PR TITLE
make service ports configurable

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.4.3
+version: 1.4.4
 # Version of Hono being deployed by the chart
 appVersion: 1.4.0
 keywords:

--- a/charts/hono/templates/_helpers.tpl
+++ b/charts/hono/templates/_helpers.tpl
@@ -415,3 +415,29 @@ Optionally, the scope my contain key
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+Adds port type declarations to a component's service spec.
+*/}}
+{{- define "hono.serviceType" }}
+{{- if eq .Values.platform "openshift" }}
+  type: ClusterIP
+{{- else if eq .Values.useLoadBalancer true }}
+  type: LoadBalancer
+{{- else }}
+  type: NodePort
+{{- end }}
+{{- end }}
+
+{{/*
+Configures NodePort on component's service spec.
+*/}}
+{{- define "hono.nodePort" }}
+{{- if ne .dot.Values.platform "openshift" }}
+nodePort: {{ .port  }}
+{{- end }}
+{{- end }}
+
+
+
+

--- a/charts/hono/templates/dispatch-router/dispatch-router-ext-svc.yaml
+++ b/charts/hono/templates/dispatch-router/dispatch-router-ext-svc.yaml
@@ -26,26 +26,25 @@ spec:
     port: 15671
     protocol: TCP
     targetPort: amqps
-    nodePort: 30671
+    {{- $amqpsArgs := dict "dot" . "port" 30671 }}
+    {{- include "hono.nodePort" $amqpsArgs | nindent 4 }}
   - name: amqp
     port: 15672
     protocol: TCP
     targetPort: amqp
-    nodePort: 30672
+    {{- $amqpArgs := dict "dot" . "port" 30672 }}
+    {{- include "hono.nodePort" $amqpArgs | nindent 4 }}
   {{- if .Values.adapters.externalAdaptersEnabled }}
   - name: internal
     port: 15673
     protocol: TCP
     targetPort: internal
-    nodePort: 30673
+    {{- $internalArgs := dict "dot" . "port" 30673 }}
+    {{- include "hono.nodePort" $internalArgs | nindent 4 }}
   {{- end }}
   selector:
     {{- include "hono.matchLabels" $args | nindent 4 }}
-{{- if and ( eq .Values.useLoadBalancer true ) ( ne .Values.platform "openshift" ) }}
-  type: LoadBalancer
-{{- else }}
-  type: NodePort
-{{- end }}
+  {{- include "hono.serviceType" . }}
 {{- with .Values.amqpMessagingNetworkExample.dispatchRouter.svc.loadBalancerIP }}
   loadBalancerIP: {{ . | quote }}
 {{- end }}

--- a/charts/hono/templates/hono-adapter-amqp/hono-adapter-amqp-vertx-svc.yaml
+++ b/charts/hono/templates/hono-adapter-amqp/hono-adapter-amqp-vertx-svc.yaml
@@ -26,19 +26,17 @@ spec:
     port: 5672
     protocol: TCP
     targetPort: amqp
-    nodePort: 32672
+    {{- $amqpArgs := dict "dot" . "port" 32672 }}
+    {{- include "hono.nodePort" $amqpArgs | nindent 4 }}
   - name: amqps
     port: 5671
     protocol: TCP
     targetPort: amqps
-    nodePort: 32671
+    {{- $amqpsArgs := dict "dot" . "port" 32671 }}
+    {{- include "hono.nodePort" $amqpsArgs | nindent 4 }}
   selector:
     {{- include "hono.matchLabels" $args | nindent 4 }}
-{{- if and ( eq .Values.useLoadBalancer true ) ( ne .Values.platform "openshift" ) }}
-  type: LoadBalancer
-{{- else }}
-  type: NodePort
-{{- end }}
+  {{- include "hono.serviceType" . }}
 {{- with .Values.adapters.amqp.svc.loadBalancerIP }}
   loadBalancerIP: {{ . | quote }}
 {{- end }}

--- a/charts/hono/templates/hono-adapter-coap/hono-adapter-coap-vertx-svc.yaml
+++ b/charts/hono/templates/hono-adapter-coap/hono-adapter-coap-vertx-svc.yaml
@@ -27,19 +27,17 @@ spec:
     port: 5683
     protocol: UDP
     targetPort: coap
-    nodePort: 30683
+    {{- $coapArgs := dict "dot" . "port" 30683 }}
+    {{- include "hono.nodePort" $coapArgs | nindent 4 }}
   - name: coaps
     port: 5684
     protocol: UDP
     targetPort: coaps
-    nodePort: 30684
+    {{- $coapsArgs := dict "dot" . "port" 30684 }}
+    {{- include "hono.nodePort" $coapsArgs | nindent 4 }}
   selector:
     {{- include "hono.matchLabels" $args | nindent 4 }}
-{{- if and ( eq .Values.useLoadBalancer true ) ( ne .Values.platform "openshift" ) }}
-  type: LoadBalancer
-{{- else }}
-  type: NodePort
-{{- end }}
+  {{- include "hono.serviceType" . }}
 {{- with .Values.adapters.coap.svc.loadBalancerIP }}
   loadBalancerIP: {{ . | quote }}
 {{- end }}

--- a/charts/hono/templates/hono-adapter-http/hono-adapter-http-vertx-svc.yaml
+++ b/charts/hono/templates/hono-adapter-http/hono-adapter-http-vertx-svc.yaml
@@ -26,19 +26,17 @@ spec:
     port: 8080
     protocol: TCP
     targetPort: http
-    nodePort: 30080
+    {{- $httpArgs := dict "dot" . "port" 30080 }}
+    {{- include "hono.nodePort" $httpArgs | nindent 4 }}
   - name: https
     port: 8443
     protocol: TCP
     targetPort: https
-    nodePort: 30443
+    {{- $httpsArgs := dict "dot" . "port" 30443 }}
+    {{- include "hono.nodePort" $httpsArgs | nindent 4 }}
   selector:
     {{- include "hono.matchLabels" $args | nindent 4 }}
-{{- if and ( eq .Values.useLoadBalancer true ) ( ne .Values.platform "openshift" ) }}
-  type: LoadBalancer
-{{- else }}
-  type: NodePort
-{{- end }}
+  {{- include "hono.serviceType" . }}
 {{- with .Values.adapters.http.svc.loadBalancerIP }}
   loadBalancerIP: {{ . | quote }}
 {{- end }}

--- a/charts/hono/templates/hono-adapter-kura/hono-adapter-kura-svc.yaml
+++ b/charts/hono/templates/hono-adapter-kura/hono-adapter-kura-svc.yaml
@@ -26,19 +26,17 @@ spec:
     port: 1883
     protocol: TCP
     targetPort: mqtt
-    nodePort: 31884
+    {{- $mqttArgs := dict "dot" . "port" 31884 }}
+    {{- include "hono.nodePort" $mqttArgs | nindent 4 }}
   - name: secure-mqtt
     port: 8883
     protocol: TCP
     targetPort: secure-mqtt
-    nodePort: 30884
+    {{- $mqttsArgs := dict "dot" . "port" 30884 }}
+    {{- include "hono.nodePort" $mqttsArgs | nindent 4 }}
   selector:
     {{- include "hono.matchLabels" $args | nindent 4 }}
-{{- if and ( eq .Values.useLoadBalancer true ) ( ne .Values.platform "openshift" ) }}
-  type: LoadBalancer
-{{- else }}
-  type: NodePort
-{{- end }}
+  {{- include "hono.serviceType" . }}
 {{- with .Values.adapters.kura.svc.loadBalancerIP }}
   loadBalancerIP: {{ . | quote }}
 {{- end }}

--- a/charts/hono/templates/hono-adapter-lora/hono-adapter-lora-vertx-svc.yaml
+++ b/charts/hono/templates/hono-adapter-lora/hono-adapter-lora-vertx-svc.yaml
@@ -26,19 +26,17 @@ spec:
     port: 8080
     protocol: TCP
     targetPort: http
-    nodePort: 32080
+    {{- $httpArgs := dict "dot" . "port" 32080 }}
+    {{- include "hono.nodePort" $httpArgs | nindent 4 }}
   - name: https
     port: 8443
     protocol: TCP
     targetPort: https
-    nodePort: 32443
+    {{- $httpsArgs := dict "dot" . "port" 32443 }}
+    {{- include "hono.nodePort" $httpsArgs | nindent 4 }}
   selector:
     {{- include "hono.matchLabels" $args | nindent 4 }}
-{{- if and ( eq .Values.useLoadBalancer true ) ( ne .Values.platform "openshift" ) }}
-  type: LoadBalancer
-{{- else }}
-  type: NodePort
-{{- end }}
+  {{- include "hono.serviceType" . }}
 {{- with .Values.adapters.lora.svc.loadBalancerIP }}
   loadBalancerIP: {{ . | quote }}
 {{- end }}

--- a/charts/hono/templates/hono-adapter-mqtt/hono-adapter-mqtt-vertx-svc.yaml
+++ b/charts/hono/templates/hono-adapter-mqtt/hono-adapter-mqtt-vertx-svc.yaml
@@ -26,19 +26,17 @@ spec:
     port: 1883
     protocol: TCP
     targetPort: mqtt
-    nodePort: 31883
+    {{- $mqttArgs := dict "dot" . "port" 31883 }}
+    {{- include "hono.nodePort" $mqttArgs | nindent 4 }}
   - name: secure-mqtt
     port: 8883
     protocol: TCP
     targetPort: secure-mqtt
-    nodePort: 30883
+    {{- $mqttsArgs := dict "dot" . "port" 30883 }}
+    {{- include "hono.nodePort" $mqttsArgs | nindent 4 }}
   selector:
     {{- include "hono.matchLabels" $args | nindent 4 }}
-{{- if and ( eq .Values.useLoadBalancer true ) ( ne .Values.platform "openshift" ) }}
-  type: LoadBalancer
-{{- else }}
-  type: NodePort
-{{- end }}
+  {{- include "hono.serviceType" . }}
 {{- with .Values.adapters.mqtt.svc.loadBalancerIP }}
   loadBalancerIP: {{ . | quote }}
 {{- end }}

--- a/charts/hono/templates/hono-service-device-connection/hono-service-device-connection-svc.yaml
+++ b/charts/hono/templates/hono-service-device-connection/hono-service-device-connection-svc.yaml
@@ -28,11 +28,7 @@ spec:
     targetPort: amqps
   selector:
     {{- include "hono.matchLabels" $args | nindent 4 }}
-{{- if and ( eq .Values.useLoadBalancer true ) ( ne .Values.platform "openshift" ) }}
-  type: LoadBalancer
-{{- else }}
-  type: NodePort
-{{- end }}
+  {{- include "hono.serviceType" . }}
 {{- with .Values.deviceConnectionService.svc.loadBalancerIP }}
   loadBalancerIP: {{ . | quote }}
 {{- end }}

--- a/charts/hono/templates/hono-service-device-registry-base/hono-service-device-registry-ext-svc.yaml
+++ b/charts/hono/templates/hono-service-device-registry-base/hono-service-device-registry-ext-svc.yaml
@@ -26,12 +26,14 @@ spec:
     port: 28080
     protocol: TCP
     targetPort: http
-    nodePort: 31080
+    {{- $httpArgs := dict "dot" . "port" 31080 }}
+    {{- include "hono.nodePort" $httpArgs | nindent 4 }}
   - name: https
     port: 28443
     protocol: TCP
     targetPort: https
-    nodePort: 31443
+    {{- $httpsArgs := dict "dot" . "port" 31443 }}
+    {{- include "hono.nodePort" $httpsArgs | nindent 4 }}
   {{- if .Values.adapters.externalAdaptersEnabled }}
   - name: amqps
     port: 5671
@@ -40,11 +42,7 @@ spec:
   {{- end }}
   selector:
     {{- include "hono.matchLabels" $args | nindent 4 }}
-{{- if and ( eq .Values.useLoadBalancer true ) ( ne .Values.platform "openshift" ) }}
-  type: LoadBalancer
-{{- else }}
-  type: NodePort
-{{- end }}
+  {{- include "hono.serviceType" . }}
 {{- with .Values.deviceRegistryExample.svc.loadBalancerIP }}
   loadBalancerIP: {{ . | quote }}
 {{- end }}


### PR DESCRIPTION
We'd like to run this in 2 separate namespaces in a single cluster, so ports have to be configurable.

Also; all of these services are configured as either LoadBalancer or NodePort. Why is that? It would be far easier if this would be either LoadBalancer or ClusterIp, for http at least.

Any ideas @ctron @dejanb? 

Signed-off-by: Dirk Van Haerenborgh <dirk.vanhaerenborgh@aloxy.io>