### PR TITLE
updated cloud2edge package to latest Ditto+Hono

### DIFF
--- a/packages/cloud2edge/Chart.yaml
+++ b/packages/cloud2edge/Chart.yaml
@@ -11,8 +11,8 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 apiVersion: v1
-version: 0.0.10
-appVersion: 0.0.10
+version: 0.1.0
+appVersion: 0.1.0
 name: cloud2edge
 description: |
   Eclipse IoT Cloud2Edge (C2E) is an integrated suite of services developers can use to build IoT applications

--- a/packages/cloud2edge/post-install/hono-connection.json
+++ b/packages/cloud2edge/post-install/hono-connection.json
@@ -23,12 +23,30 @@
           "enforcement": {
             "input": {{ "{{ header:device_id }}" | quote }},
             "filters": [
-              {{ "{{ thing:id }}" | quote }}
+              {{ "{{ entity:id }}" | quote }}
             ]
           },
           "headerMapping": {
             "hono-device-id": {{ "{{ header:device_id }}" | quote }},
             "content-type": {{ "{{ header:content-type }}" | quote }}
+          },
+          "replyTarget": {
+            "enabled": true,
+            "address": {{ "{{ header:reply-to }}" | quote }},
+            "headerMapping": {
+              "to": {{ printf "command/%s/{{ header:hono-device-id }}" .Values.demoDevice.tenant | quote }},
+              "subject": {{ "{{ header:subject | fn:default(topic:action-subject) | fn:default(topic:criterion) }}-response" | quote }},
+              "correlation-id": {{ "{{ header:correlation-id }}" | quote }},
+              "content-type": {{ "{{ header:content-type | fn:default('application/vnd.eclipse.ditto+json') }}" | quote }}
+            },
+            "expectedResponseTypes": [
+              "response",
+              "error"
+            ]
+          },
+          "acknowledgementRequests": {
+            "includes": [],
+            "filter": "fn:filter(header:qos,'eq','1')"
           }
         },
         {
@@ -42,12 +60,19 @@
             "content-type": {{ "{{ header:content-type }}" | quote }},
             "correlation-id": {{ "{{ header:correlation-id }}" | quote }},
             "status": {{ "{{ header:status }}" | quote }}
+          },
+          "replyTarget": {
+            "enabled": false,
+            "expectedResponseTypes": [
+              "response",
+              "error"
+            ]
           }
         }
       ],
       "targets": [
         {
-          "address": {{ printf "command/%s" .Values.demoDevice.tenant | quote }},
+          "address": "command/{{ .Values.demoDevice.tenant }}",
           "authorizationContext": [
             "pre-authenticated:hono-connection"
           ],
@@ -60,11 +85,11 @@
             "subject": {{ "{{ header:subject | fn:default(topic:action-subject) }}" | quote }},
             "content-type": {{ "{{ header:content-type | fn:default('application/vnd.eclipse.ditto+json') }}" | quote }},
             "correlation-id": {{ "{{ header:correlation-id }}" | quote }},
-            "reply-to": "command_response/{{ .Values.demoDevice.tenant }}/replies"
+            "reply-to": {{ printf "{{ fn:default('command_response/%s/replies') | fn:filter(header:response-required,'ne','false') }}" .Values.demoDevice.tenant | quote }}
           }
         },
         {
-          "address": {{ printf "command/%s" .Values.demoDevice.tenant | quote }},
+          "address": "command/{{ .Values.demoDevice.tenant }}",
           "authorizationContext": [
             "pre-authenticated:hono-connection"
           ],

--- a/packages/cloud2edge/requirements.yaml
+++ b/packages/cloud2edge/requirements.yaml
@@ -12,8 +12,8 @@
 #
 dependencies:
   - name: hono
-    version: ~1.1.3
+    version: ~1.3.15
     repository: "https://eclipse.org/packages/charts/"
   - name: ditto
-    version: ~1.2.0
+    version: ~1.3.0
     repository: "https://eclipse.org/packages/charts/"


### PR DESCRIPTION
* use Hono 1.3.0
* use Ditto 1.2.0
* configure Ditto/Hono connection template to:
   * configure Ditto "acknowledgementRequests" to activate QoS 1 processing for Hono messages with "qos" header set to "1"
   * configure a "replyTarget" for consumed telemetry/event messages from Hono - when the Ditto Protocol payload message contains a "reply-to" header, a response is sent back to that address

I thought using the newest minor versions of Hono/Ditto is worth a minor update of the c2e package, so I chose version `0.1.0`.
What do you think?