### PR TITLE
[#129] Support configuring the container registry for Hono images

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.3.16
+version: 1.3.17
 # Version of Hono being deployed by the chart
 appVersion: 1.3.0
 keywords:

--- a/charts/hono/README.md
+++ b/charts/hono/README.md
@@ -166,8 +166,8 @@ pulled from a different (private) container registry.
 
 The `values.yaml` file contains configuration properties for setting the container
 image and tag names to use for Hono's components. The easiest way to override the version
-of all Hono components simultaneously is to set the `honoImagesTag` property to the desired
-value during installation.
+of all Hono components simultaneously is to set the `honoImagesTag` and/or `honoContainerRegistry`
+properties to the desired values during installation.
 
 The following command installs Hono using the standard images published on Docker Hub with tag
 *1.3.0-M3* images instead of the ones indicated by the chart's *appVersion* property:
@@ -175,18 +175,30 @@ The following command installs Hono using the standard images published on Docke
 ```bash
 helm install --dependency-update -n hono --set honoImagesTag=1.3.0-M3 eclipse-hono eclipse-iot/hono
 ```
-It is also possible to define the image and tag names for each component individually. The easiest way
-to do that is to create a YAML file that specifies the particular image and tag names:
+
+The following command installs Hono using custom built images published on a private registry with tag
+*1.3.0-custom* instead of the ones indicated by the chart's *appVersion* property:
+
+```bash
+helm install --dependency-update -n hono --set honoImagesTag=1.3.0-custom --set honoContainerRegistry=my-registry:9090 eclipse-hono eclipse-iot/hono
+```
+
+It is also possible to define the image and tag names and container registry for each component separately.
+The easiest way to do that is to create a YAML file that specifies the particular properties:
 
 ```yaml
 deviceRegistryExample:
-  imageName: my-custom-registry/hono-service-device-registry-custom
+  # pull custom Device Registry image from private container registry
+  imageName: my-hono/hono-service-device-registry-custom
   imageTag: 1.0.0
+  containerRegistry: my-private-registry
 
 authServer:
+  # pull milestone release from Docker Hub
   imageName: eclipse/hono-service-auth
   imageTag: 1.3.0-M3
 
+# pull standard adapter images in version 1.2.3 from Docker Hub
 adapters:
   amqp:
     imageName: eclipse/hono-adapter-amqp-vertx

--- a/charts/hono/templates/_helpers.tpl
+++ b/charts/hono/templates/_helpers.tpl
@@ -55,7 +55,7 @@ The scope passed in is expected to be a dict with keys
 */}}
 {{- define "hono.image" }}
   {{- $tag := default .dot.Chart.AppVersion ( default .dot.Values.honoImagesTag .component.imageTag ) }}
-  {{- $registry := default "index.docker.io" ( default .dot.Values.honoContainerRegistry .component.containerRegistry ) }}
+  {{- $registry := default .dot.Values.honoContainerRegistry .component.containerRegistry }}
   {{- printf "%s/%s:%s" $registry .component.imageName $tag }}
 {{- end }}
 

--- a/charts/hono/templates/_helpers.tpl
+++ b/charts/hono/templates/_helpers.tpl
@@ -45,6 +45,21 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
+Create container image name.
+The scope passed in is expected to be a dict with keys
+- (mandatory) "dot": the root (".") scope
+- (mandatory) "component": a dict with keys
+  - (mandatory) "imageName"
+  - (optional) "imageTag"
+  - (optional) "containerRegistry"
+*/}}
+{{- define "hono.image" }}
+  {{- $tag := default .dot.Chart.AppVersion ( default .dot.Values.honoImagesTag .component.imageTag ) }}
+  {{- $registry := default "index.docker.io" ( default .dot.Values.honoContainerRegistry .component.containerRegistry ) }}
+  {{- printf "%s/%s:%s" $registry .component.imageName $tag }}
+{{- end }}
+
+{{/*
 Add standard labels for resources as recommended by Helm best practices.
 */}}
 {{- define "hono.std.labels" -}}

--- a/charts/hono/templates/hono-adapter-amqp/hono-adapter-amqp-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-amqp/hono-adapter-amqp-vertx-deployment.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
-      - image: {{ printf "%s:%s" .Values.adapters.amqp.imageName ( default .Chart.AppVersion ( default .Values.honoImagesTag .Values.adapters.amqp.imageTag ) ) }}
+      - image: {{ include "hono.image" ( dict "dot" . "component" .Values.adapters.amqp ) }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-adapter-amqp-vertx
         ports:

--- a/charts/hono/templates/hono-adapter-coap/hono-adapter-coap-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-coap/hono-adapter-coap-vertx-deployment.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
-      - image: {{ printf "%s:%s" .Values.adapters.coap.imageName ( default .Chart.AppVersion ( default .Values.honoImagesTag .Values.adapters.coap.imageTag ) ) }}
+      - image: {{ include "hono.image" ( dict "dot" . "component" .Values.adapters.coap ) }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-adapter-coap-vertx
         ports:

--- a/charts/hono/templates/hono-adapter-http/hono-adapter-http-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-http/hono-adapter-http-vertx-deployment.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
-      - image: {{ printf "%s:%s" .Values.adapters.http.imageName ( default .Chart.AppVersion ( default .Values.honoImagesTag .Values.adapters.http.imageTag ) ) }}
+      - image: {{ include "hono.image" ( dict "dot" . "component" .Values.adapters.http ) }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-adapter-http-vertx
         ports:

--- a/charts/hono/templates/hono-adapter-kura/hono-adapter-kura-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-kura/hono-adapter-kura-deployment.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
-      - image: {{ printf "%s:%s" .Values.adapters.kura.imageName ( default .Chart.AppVersion ( default .Values.honoImagesTag .Values.adapters.kura.imageTag ) ) }}
+      - image: {{ include "hono.image" ( dict "dot" . "component" .Values.adapters.kura ) }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-adapter-kura
         ports:

--- a/charts/hono/templates/hono-adapter-lora/hono-adapter-lora-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-lora/hono-adapter-lora-vertx-deployment.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
-      - image: {{ printf "%s:%s" .Values.adapters.lora.imageName ( default .Chart.AppVersion ( default .Values.honoImagesTag .Values.adapters.lora.imageTag ) ) }}
+      - image: {{ include "hono.image" ( dict "dot" . "component" .Values.adapters.lora ) }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-adapter-lora-vertx
         ports:

--- a/charts/hono/templates/hono-adapter-mqtt/hono-adapter-mqtt-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-mqtt/hono-adapter-mqtt-vertx-deployment.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
-      - image: {{ printf "%s:%s" .Values.adapters.mqtt.imageName ( default .Chart.AppVersion ( default .Values.honoImagesTag .Values.adapters.mqtt.imageTag ) ) }}
+      - image: {{ include "hono.image" ( dict "dot" . "component" .Values.adapters.mqtt ) }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-adapter-mqtt-vertx
         ports:

--- a/charts/hono/templates/hono-service-auth/hono-service-auth-deployment.yaml
+++ b/charts/hono/templates/hono-service-auth/hono-service-auth-deployment.yaml
@@ -27,7 +27,7 @@ spec:
         {{- include "hono.monitoringAnnotations" . | nindent 8 }}
     spec:
       containers:
-      - image: {{ printf "%s:%s" .Values.authServer.imageName ( default .Chart.AppVersion ( default .Values.honoImagesTag .Values.authServer.imageTag ) ) }}
+      - image: {{ include "hono.image" ( dict "dot" . "component" .Values.authServer ) }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-service-auth
         ports:

--- a/charts/hono/templates/hono-service-device-connection/hono-service-device-connection-deployment.yaml
+++ b/charts/hono/templates/hono-service-device-connection/hono-service-device-connection-deployment.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
-      - image: {{ printf "%s:%s" .Values.deviceConnectionService.imageName ( default .Chart.AppVersion ( default .Values.honoImagesTag .Values.deviceConnectionService.imageTag ) ) }}
+      - image: {{ include "hono.image" ( dict "dot" . "component" .Values.deviceConnectionService ) }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-service-device-connection
         ports:

--- a/charts/hono/templates/hono-service-device-registry/hono-service-device-registry-statefulset.yaml
+++ b/charts/hono/templates/hono-service-device-registry/hono-service-device-registry-statefulset.yaml
@@ -48,7 +48,7 @@ spec:
     {{- end }}
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
-      - image: {{ printf "%s:%s" .Values.deviceRegistryExample.imageName ( default .Chart.AppVersion ( default .Values.honoImagesTag .Values.deviceRegistryExample.imageTag ) ) }}
+      - image: {{ include "hono.image" ( dict "dot" . "component" .Values.deviceRegistryExample ) }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-service-device-registry
         ports:

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -20,6 +20,12 @@
 # Alternatively, the tag name can also be set per component image.
 # honoImagesTag:
 
+# honoContainerRegistry contains the name of the container registry that
+# the container images for Hono's components should be pulled from.
+# If not set explicitly, images are pulled from Docker Hub, which means that
+# 'index.docker.io' is used as the registry name.
+# honoContainerRegistry
+
 amqpMessagingNetworkExample:
   # enabled indicates whether the example AMQP Messaging Network
   # consisting of a single Dispatch Router and Broker should be
@@ -332,12 +338,16 @@ adapters:
   amqp:
     # enabled indicates if Hono's AMQP 1.0 adapter should be deployed.
     enabled: true
-    # imageName contains the name (including registry and tag)
+    # imageName contains the name (exluding registry)
     # of the container image to use for the AMQP adapter
-    imageName: index.docker.io/eclipse/hono-adapter-amqp-vertx
+    imageName: eclipse/hono-adapter-amqp-vertx
     # imageTag contains the tag of the container image to deploy.
     # If not specified, the value of the honoImagesTag property is used.
     # imageTag:
+    # containerRegistry contains the name of the container registry to pull
+    # the image from.
+    # If not specified, the value of the "honoContainerRegistry"" property is used.
+    # containerRegistry:
     # javaOptions contains options to pass to the JVM when starting
     # up the service
     javaOptions: -XX:MinRAMPercentage=80 -XX:MaxRAMPercentage=80
@@ -401,12 +411,16 @@ adapters:
   coap:
     # enabled indicates if Hono's (experimental) CoAP adapter should be deployed.
     enabled: false
-    # imageName contains the name (including registry and tag)
+    # imageName contains the name (excluding registry)
     # of the container image to use for the CoAP adapter
-    imageName: index.docker.io/eclipse/hono-adapter-coap-vertx
+    imageName: eclipse/hono-adapter-coap-vertx
     # imageTag contains the tag of the container image to deploy.
     # If not specified, the value of the honoImagesTag property is used.
     # imageTag:
+    # containerRegistry contains the name of the container registry to pull
+    # the image from.
+    # If not specified, the value of the "honoContainerRegistry"" property is used.
+    # containerRegistry:
     # javaOptions contains options to pass to the JVM when starting
     # up the service
     javaOptions: -XX:MinRAMPercentage=80 -XX:MaxRAMPercentage=80
@@ -461,12 +475,16 @@ adapters:
   http:
     # enabled indicates if Hono's HTTP adapter should be deployed.
     enabled: true
-    # imageName contains the name (including registry and tag)
+    # imageName contains the name (excluding registry)
     # of the container image to use for the HTTP adapter
-    imageName: index.docker.io/eclipse/hono-adapter-http-vertx
+    imageName: eclipse/hono-adapter-http-vertx
     # imageTag contains the tag of the container image to deploy.
     # If not specified, the value of the honoImagesTag property is used.
     # imageTag:
+    # containerRegistry contains the name of the container registry to pull
+    # the image from.
+    # If not specified, the value of the "honoContainerRegistry"" property is used.
+    # containerRegistry:
     # javaOptions contains options to pass to the JVM when starting
     # up the service
     javaOptions: -XX:MinRAMPercentage=80 -XX:MaxRAMPercentage=80
@@ -530,12 +548,16 @@ adapters:
   kura:
     # enabled indicates if Hono's (deprecated) Kura adapter should be deployed.
     enabled: false
-    # imageName contains the name (including registry and tag)
+    # imageName contains the name (excluding registry)
     # of the container image to use for the Kura adapter
-    imageName: index.docker.io/eclipse/hono-adapter-kura
+    imageName: eclipse/hono-adapter-kura
     # imageTag contains the tag of the container image to deploy.
     # If not specified, the value of the honoImagesTag property is used.
     # imageTag:
+    # containerRegistry contains the name of the container registry to pull
+    # the image from.
+    # If not specified, the value of the "honoContainerRegistry"" property is used.
+    # containerRegistry:
     # javaOptions contains options to pass to the JVM when starting
     # up the service
     javaOptions: -XX:MinRAMPercentage=80 -XX:MaxRAMPercentage=80
@@ -599,12 +621,16 @@ adapters:
   lora:
     # enabled indicates if Hono's Lora adapter should be deployed.
     enabled: false
-    # imageName contains the name (including registry and tag)
+    # imageName contains the name (excluding registry)
     # of the container image to use for the LoRa adapter
-    imageName: index.docker.io/eclipse/hono-adapter-lora-vertx
+    imageName: eclipse/hono-adapter-lora-vertx
     # imageTag contains the tag of the container image to deploy.
     # If not specified, the value of the honoImagesTag property is used.
     # imageTag:
+    # containerRegistry contains the name of the container registry to pull
+    # the image from.
+    # If not specified, the value of the "honoContainerRegistry"" property is used.
+    # containerRegistry:
     # javaOptions contains options to pass to the JVM when starting
     # up the service
     javaOptions: -XX:MinRAMPercentage=80 -XX:MaxRAMPercentage=80
@@ -667,12 +693,16 @@ adapters:
   mqtt:
     # enabled indicates if Hono's MQTTP 3.1.1 adapter should be deployed.
     enabled: true
-    # imageName contains the name (including registry and tag)
+    # imageName contains the name (excluding registry)
     # of the container image to use for the MQTT adapter
-    imageName: index.docker.io/eclipse/hono-adapter-mqtt-vertx
+    imageName: eclipse/hono-adapter-mqtt-vertx
     # imageTag contains the tag of the container image to deploy.
     # If not specified, the value of the honoImagesTag property is used.
     # imageTag:
+    # containerRegistry contains the name of the container registry to pull
+    # the image from.
+    # If not specified, the value of the "honoContainerRegistry"" property is used.
+    # containerRegistry:
     # javaOptions contains options to pass to the JVM when starting
     # up the service
     javaOptions: -XX:MinRAMPercentage=80 -XX:MaxRAMPercentage=80
@@ -737,12 +767,16 @@ adapters:
 # authServer contains configuration properties for the Auth Server component.
 authServer:
 
-  # imageName contains the name (including registry and tag)
+  # imageName contains the name (excluding registry)
   # of the container image to use for the Auth Server
-  imageName: index.docker.io/eclipse/hono-service-auth
+  imageName: eclipse/hono-service-auth
   # imageTag contains the tag of the container image to deploy.
   # If not specified, the value of the honoImagesTag property is used.
   # imageTag:
+  # containerRegistry contains the name of the container registry to pull
+  # the image from.
+  # If not specified, the value of the "honoContainerRegistry"" property is used.
+  # containerRegistry:
   # javaOptions contains options to pass to the JVM when starting
   # up the service
   javaOptions: -XX:MinRAMPercentage=80 -XX:MaxRAMPercentage=80
@@ -823,12 +857,16 @@ deviceRegistryExample:
   # - "adapters.deviceConnectionSpec"
   enabled: true
 
-  # imageName contains the name (including registry and tag)
+  # imageName contains the name (excluding registry)
   # of the container image to use for the example Device Registry
-  imageName: index.docker.io/eclipse/hono-service-device-registry-file
+  imageName: eclipse/hono-service-device-registry-file
   # imageTag contains the tag of the container image to deploy.
   # If not specified, the value of the honoImagesTag property is used.
   # imageTag:
+  # containerRegistry contains the name of the container registry to pull
+  # the image from.
+  # If not specified, the value of the "honoContainerRegistry"" property is used.
+  # containerRegistry:
   # javaOptions contains options to pass to the JVM when starting
   # up the service
   javaOptions: -XX:MinRAMPercentage=80 -XX:MaxRAMPercentage=80
@@ -938,12 +976,16 @@ deviceConnectionService:
   # Hono client config properties to connect to an already existing Device Connection service.
   enabled: false
 
-  # imageName contains the name (including registry and tag)
+  # imageName contains the name (excluding registry)
   # of the container image to use for the Device Connection service
-  imageName: index.docker.io/eclipse/hono-service-device-connection
+  imageName: eclipse/hono-service-device-connection
   # imageTag contains the tag of the container image to deploy.
   # If not specified, the value of the honoImagesTag property is used.
   # imageTag:
+  # containerRegistry contains the name of the container registry to pull
+  # the image from.
+  # If not specified, the value of the "honoContainerRegistry"" property is used.
+  # containerRegistry:
   # javaOptions contains options to pass to the JVM when starting
   # up the service
   javaOptions: -XX:MinRAMPercentage=80 -XX:MaxRAMPercentage=80

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -22,9 +22,9 @@
 
 # honoContainerRegistry contains the name of the container registry that
 # the container images for Hono's components should be pulled from.
-# If not set explicitly, images are pulled from Docker Hub, which means that
-# 'index.docker.io' is used as the registry name.
-# honoContainerRegistry
+# The registry can also be set separately for each component, overriding
+# the value specified here.
+honoContainerRegistry: index.docker.io
 
 amqpMessagingNetworkExample:
   # enabled indicates whether the example AMQP Messaging Network
@@ -338,7 +338,7 @@ adapters:
   amqp:
     # enabled indicates if Hono's AMQP 1.0 adapter should be deployed.
     enabled: true
-    # imageName contains the name (exluding registry)
+    # imageName contains the name (excluding registry)
     # of the container image to use for the AMQP adapter
     imageName: eclipse/hono-adapter-amqp-vertx
     # imageTag contains the tag of the container image to deploy.
@@ -346,7 +346,7 @@ adapters:
     # imageTag:
     # containerRegistry contains the name of the container registry to pull
     # the image from.
-    # If not specified, the value of the "honoContainerRegistry"" property is used.
+    # If not specified, the value of the "honoContainerRegistry" property is used.
     # containerRegistry:
     # javaOptions contains options to pass to the JVM when starting
     # up the service
@@ -419,7 +419,7 @@ adapters:
     # imageTag:
     # containerRegistry contains the name of the container registry to pull
     # the image from.
-    # If not specified, the value of the "honoContainerRegistry"" property is used.
+    # If not specified, the value of the "honoContainerRegistry" property is used.
     # containerRegistry:
     # javaOptions contains options to pass to the JVM when starting
     # up the service
@@ -483,7 +483,7 @@ adapters:
     # imageTag:
     # containerRegistry contains the name of the container registry to pull
     # the image from.
-    # If not specified, the value of the "honoContainerRegistry"" property is used.
+    # If not specified, the value of the "honoContainerRegistry" property is used.
     # containerRegistry:
     # javaOptions contains options to pass to the JVM when starting
     # up the service
@@ -556,7 +556,7 @@ adapters:
     # imageTag:
     # containerRegistry contains the name of the container registry to pull
     # the image from.
-    # If not specified, the value of the "honoContainerRegistry"" property is used.
+    # If not specified, the value of the "honoContainerRegistry" property is used.
     # containerRegistry:
     # javaOptions contains options to pass to the JVM when starting
     # up the service
@@ -629,7 +629,7 @@ adapters:
     # imageTag:
     # containerRegistry contains the name of the container registry to pull
     # the image from.
-    # If not specified, the value of the "honoContainerRegistry"" property is used.
+    # If not specified, the value of the "honoContainerRegistry" property is used.
     # containerRegistry:
     # javaOptions contains options to pass to the JVM when starting
     # up the service
@@ -701,7 +701,7 @@ adapters:
     # imageTag:
     # containerRegistry contains the name of the container registry to pull
     # the image from.
-    # If not specified, the value of the "honoContainerRegistry"" property is used.
+    # If not specified, the value of the "honoContainerRegistry" property is used.
     # containerRegistry:
     # javaOptions contains options to pass to the JVM when starting
     # up the service
@@ -775,7 +775,7 @@ authServer:
   # imageTag:
   # containerRegistry contains the name of the container registry to pull
   # the image from.
-  # If not specified, the value of the "honoContainerRegistry"" property is used.
+  # If not specified, the value of the "honoContainerRegistry" property is used.
   # containerRegistry:
   # javaOptions contains options to pass to the JVM when starting
   # up the service
@@ -865,7 +865,7 @@ deviceRegistryExample:
   # imageTag:
   # containerRegistry contains the name of the container registry to pull
   # the image from.
-  # If not specified, the value of the "honoContainerRegistry"" property is used.
+  # If not specified, the value of the "honoContainerRegistry" property is used.
   # containerRegistry:
   # javaOptions contains options to pass to the JVM when starting
   # up the service
@@ -984,7 +984,7 @@ deviceConnectionService:
   # imageTag:
   # containerRegistry contains the name of the container registry to pull
   # the image from.
-  # If not specified, the value of the "honoContainerRegistry"" property is used.
+  # If not specified, the value of the "honoContainerRegistry" property is used.
   # containerRegistry:
   # javaOptions contains options to pass to the JVM when starting
   # up the service


### PR DESCRIPTION
The container registry to pull Hono images from can now be configured
for each image separately, falling back to a globally defined Hono
container registry.
