### PR TITLE
[#136] Use Hono chart with new demo keys/certs in c2e

### DIFF
--- a/packages/cloud2edge/Chart.yaml
+++ b/packages/cloud2edge/Chart.yaml
@@ -11,8 +11,8 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 apiVersion: v1
-version: 0.1.0
-appVersion: 0.1.0
+version: 0.1.1
+appVersion: 0.1.1
 name: cloud2edge
 description: |
   Eclipse IoT Cloud2Edge (C2E) is an integrated suite of services developers can use to build IoT applications

--- a/packages/cloud2edge/requirements.yaml
+++ b/packages/cloud2edge/requirements.yaml
@@ -12,7 +12,7 @@
 #
 dependencies:
   - name: hono
-    version: ~1.3.15
+    version: ~1.3.16
     repository: "https://eclipse.org/packages/charts/"
   - name: ditto
     version: ~1.3.0


### PR DESCRIPTION
Upgrade Hono dependency in Cloud2Edge package to the one with the recreated demo keys/certs (#136).