### PR TITLE
[#142] Use updated Hono chart; fix credentials json

### DIFF
--- a/packages/cloud2edge/Chart.yaml
+++ b/packages/cloud2edge/Chart.yaml
@@ -11,8 +11,8 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 apiVersion: v1
-version: 0.1.1
-appVersion: 0.1.1
+version: 0.1.2
+appVersion: 0.1.2
 name: cloud2edge
 description: |
   Eclipse IoT Cloud2Edge (C2E) is an integrated suite of services developers can use to build IoT applications

--- a/packages/cloud2edge/post-install/demo-device-credentials.json
+++ b/packages/cloud2edge/post-install/demo-device-credentials.json
@@ -1,6 +1,5 @@
 [
   {
-    "device-id": "{{ .Values.demoDevice.tenant }}:{{ .Values.demoDevice.deviceId }}",
     "type": "hashed-password",
     "auth-id": "{{ .Values.demoDevice.deviceId }}",
     "enabled": true,
@@ -12,7 +11,6 @@
     ]
   },
   {
-    "device-id": "{{ .Values.demoDevice.tenant }}:{{ .Values.demoDevice.deviceId }}",
     "type": "psk",
     "auth-id": "{{ .Values.demoDevice.deviceId }}",
     "enabled": true,

--- a/packages/cloud2edge/requirements.yaml
+++ b/packages/cloud2edge/requirements.yaml
@@ -12,7 +12,7 @@
 #
 dependencies:
   - name: hono
-    version: ~1.3.16
+    version: ~1.3.19
     repository: "https://eclipse.org/packages/charts/"
   - name: ditto
     version: ~1.3.0


### PR DESCRIPTION
This fixes #142.
Use updated Hono chart with fix to allow device identifiers to contain a colon, as required by Ditto.
Remove invalid "device-id" fields in credentials json.