### PR TITLE
Avoid config property name clash

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.4.1
+version: 1.4.2
 # Version of Hono being deployed by the chart
 appVersion: 1.4.0
 keywords:

--- a/charts/hono/example/add_example_data_device_registry.sh
+++ b/charts/hono/example/add_example_data_device_registry.sh
@@ -11,7 +11,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #*******************************************************************************
-HTTP_BASE_URL="http://{{ .Release.Name }}-service-device-registry-ext:28080/v1"
+HTTP_BASE_URL="http://{{ .Release.Name }}-service-device-registry:8080/v1"
 
 check_status() {
   EXIT_STATUS=$1
@@ -35,7 +35,7 @@ add_tenant(){
   HTTP_REQUEST_BODY=$2
 
   echo "Adding tenant [$TENANT_ID]"
-  HTTP_RESPONSE=$(curl -o /dev/null -sw "%{http_code}" \
+  HTTP_RESPONSE=$(curl -w "%{http_code}" \
                     -X POST "$HTTP_BASE_URL/tenants/$TENANT_ID" \
                     --header 'Content-Type: application/json' \
                     --data-raw "$HTTP_REQUEST_BODY")
@@ -49,7 +49,7 @@ register_device(){
   HTTP_REQUEST_BODY=$3
 
   echo "Registering device [$TENANT_ID:$DEVICE_ID]"
-  HTTP_RESPONSE=$(curl -o /dev/null -sw "%{http_code}" \
+  HTTP_RESPONSE=$(curl -w "%{http_code}" \
                   -X POST "$HTTP_BASE_URL/devices/$TENANT_ID/$DEVICE_ID" \
                   --header 'Content-Type: application/json' \
                   --data-raw "$HTTP_REQUEST_BODY")
@@ -64,7 +64,7 @@ add_credentials(){
   HTTP_REQUEST_BODY=$3
 
   echo "Adding credentials [$TENANT_ID:$DEVICE_ID]"
-  HTTP_RESPONSE=$(curl -o /dev/null -sw "%{http_code}" \
+  HTTP_RESPONSE=$(curl -w "%{http_code}" \
                 -X PUT "$HTTP_BASE_URL/credentials/$1/$2" \
                 --header 'Content-Type: application/json' \
                 --data-raw "$3")

--- a/charts/hono/templates/hono-service-device-registry-base/hono-service-device-registry-svc.yaml
+++ b/charts/hono/templates/hono-service-device-registry-base/hono-service-device-registry-svc.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.deviceRegistryExample.enabled }}
 #
-# Copyright (c) 2019 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -22,6 +22,10 @@ spec:
     port: 5671
     protocol: TCP
     targetPort: amqps
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: http
   - name: https
     port: 8443
     protocol: TCP

--- a/charts/hono/templates/hono-service-device-registry-mongodb/hono-service-device-registry-secret.yaml
+++ b/charts/hono/templates/hono-service-device-registry-mongodb/hono-service-device-registry-secret.yaml
@@ -61,7 +61,7 @@ stringData:
         {{- if .Values.deviceRegistryExample.mongoDBBasedDeviceRegistry.mongodb}}
         {{- .Values.deviceRegistryExample.mongoDBBasedDeviceRegistry.mongodb}}
         {{- else }}
-        host: {{ printf "%s-mongodb" .Release.Name | quote }}
+        host: {{ printf "%s-%s" .Release.Name .Values.mongodb.nameOverride | quote }}
         port: 27017
         dbName: {{ .Values.mongodb.mongodbDatabase | quote }}
         username: {{ .Values.mongodb.mongodbUsername | quote }}

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -1012,6 +1012,9 @@ mongodb:
   # Whether to create a MongoDB replica set for high availability or not
   replicaSet:
     enabled: false
+  # do not use the default name ("mongodb") because it will lead to a config
+  # property name clash in the device registry pod when using "hono" as the release name
+  nameOverride: monogodb-server
 
 # deviceConnectionService contains configuration properties for the
 # Device Connection service.


### PR DESCRIPTION
The default name used by the MongoDB chart for creating the
corresponding Kubernetes Service will cause a name clash with the
"HONO_MONGO_DB" configuration variable of the MongoDB based registry
when using "hono" as the Helm release name during installation.

Overriding the chart's name with "mongodb-server" prevents this from
happening.
