### PR TITLE
allow overriding logconfig

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.4.0
+version: 1.4.1
 # Version of Hono being deployed by the chart
 appVersion: 1.4.0
 keywords:

--- a/charts/hono/templates/hono-adapter-amqp/hono-adapter-amqp-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-amqp/hono-adapter-amqp-vertx-deployment.yaml
@@ -50,7 +50,7 @@ spec:
         - name: SPRING_PROFILES_ACTIVE
           value: dev
         - name: LOGGING_CONFIG
-          value: classpath:logback-spring.xml
+          value: {{ default "classpath:logback-spring.xml" .Values.adapters.amqp.loggingConfig | quote }}
         - name: JDK_JAVA_OPTIONS
           value: {{ .Values.adapters.amqp.javaOptions | quote }}
         - name: KUBERNETES_NAMESPACE

--- a/charts/hono/templates/hono-adapter-coap/hono-adapter-coap-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-coap/hono-adapter-coap-vertx-deployment.yaml
@@ -50,7 +50,7 @@ spec:
         - name: SPRING_PROFILES_ACTIVE
           value: dev
         - name: LOGGING_CONFIG
-          value: classpath:logback-spring.xml
+          value: {{ default "classpath:logback-spring.xml" .Values.adapters.coap.loggingConfig | quote }}
         - name: JDK_JAVA_OPTIONS
           value: {{ .Values.adapters.coap.javaOptions | quote }}
         - name: KUBERNETES_NAMESPACE

--- a/charts/hono/templates/hono-adapter-http/hono-adapter-http-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-http/hono-adapter-http-vertx-deployment.yaml
@@ -50,7 +50,7 @@ spec:
         - name: SPRING_PROFILES_ACTIVE
           value: dev
         - name: LOGGING_CONFIG
-          value: classpath:logback-spring.xml
+          value: {{ default "classpath:logback-spring.xml" .Values.adapters.http.loggingConfig | quote }}
         - name: JDK_JAVA_OPTIONS
           value: {{ .Values.adapters.http.javaOptions | quote }}
         - name: KUBERNETES_NAMESPACE

--- a/charts/hono/templates/hono-adapter-kura/hono-adapter-kura-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-kura/hono-adapter-kura-deployment.yaml
@@ -50,7 +50,7 @@ spec:
         - name: SPRING_PROFILES_ACTIVE
           value: dev
         - name: LOGGING_CONFIG
-          value: classpath:logback-spring.xml
+          value: {{ default "classpath:logback-spring.xml" .Values.adapters.kura.loggingConfig | quote }}
         - name: JDK_JAVA_OPTIONS
           value: {{ .Values.adapters.kura.javaOptions | quote }}
         - name: KUBERNETES_NAMESPACE

--- a/charts/hono/templates/hono-adapter-lora/hono-adapter-lora-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-lora/hono-adapter-lora-vertx-deployment.yaml
@@ -50,7 +50,7 @@ spec:
         - name: SPRING_PROFILES_ACTIVE
           value: dev
         - name: LOGGING_CONFIG
-          value: classpath:logback-spring.xml
+          value: {{ default "classpath:logback-spring.xml" .Values.adapters.lora.loggingConfig | quote }}
         - name: JDK_JAVA_OPTIONS
           value: {{ .Values.adapters.lora.javaOptions | quote }}
         - name: KUBERNETES_NAMESPACE

--- a/charts/hono/templates/hono-adapter-mqtt/hono-adapter-mqtt-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-mqtt/hono-adapter-mqtt-vertx-deployment.yaml
@@ -50,7 +50,7 @@ spec:
         - name: SPRING_PROFILES_ACTIVE
           value: dev
         - name: LOGGING_CONFIG
-          value: classpath:logback-spring.xml
+          value: {{ default "classpath:logback-spring.xml" .Values.adapters.mqtt.loggingConfig | quote }}
         - name: JDK_JAVA_OPTIONS
           value: {{ .Values.adapters.mqtt.javaOptions | quote }}
         - name: KUBERNETES_NAMESPACE

--- a/charts/hono/templates/hono-service-auth/hono-service-auth-deployment.yaml
+++ b/charts/hono/templates/hono-service-auth/hono-service-auth-deployment.yaml
@@ -48,7 +48,7 @@ spec:
         - name: SPRING_PROFILES_ACTIVE
           value: authentication-impl,dev
         - name: LOGGING_CONFIG
-          value: classpath:logback-spring.xml
+          value: {{ default "classpath:logback-spring.xml" .Values.authServer.loggingConfig | quote }}
         - name: JDK_JAVA_OPTIONS
           value: {{ .Values.authServer.javaOptions | quote }}
         - name: KUBERNETES_NAMESPACE

--- a/charts/hono/templates/hono-service-device-connection/hono-service-device-connection-deployment.yaml
+++ b/charts/hono/templates/hono-service-device-connection/hono-service-device-connection-deployment.yaml
@@ -50,7 +50,7 @@ spec:
         - name: SPRING_PROFILES_ACTIVE
           value: prod
         - name: LOGGING_CONFIG
-          value: classpath:logback-spring.xml
+          value: {{ default "classpath:logback-spring.xml" .Values.deviceConnectionService.loggingConfig | quote }}
         - name: JDK_JAVA_OPTIONS
           value: {{ .Values.deviceConnectionService.javaOptions | quote }}
         - name: KUBERNETES_NAMESPACE

--- a/charts/hono/templates/hono-service-device-registry-mongodb/hono-service-device-registry-deployment.yaml
+++ b/charts/hono/templates/hono-service-device-registry-mongodb/hono-service-device-registry-deployment.yaml
@@ -52,7 +52,7 @@ spec:
         - name: SPRING_PROFILES_ACTIVE
           value: dev
         - name: LOGGING_CONFIG
-          value: classpath:logback-spring.xml
+          value: {{ default "classpath:logback-spring.xml" .Values.deviceRegistryExample.loggingConfig | quote }}
         - name: JDK_JAVA_OPTIONS
           value: {{ .Values.deviceRegistryExample.javaOptions | quote }}
         - name: KUBERNETES_NAMESPACE


### PR DESCRIPTION
We'd like for Hono format its logging in json. The least intrusive way to do that is to just provide a custom log config. The biggest drawback I see here is that we (at Aloxy) have to maintain our own logconfig.

Alternatively, Hono could include a configuration for json logging, where you could switch between normal/json with a single variable here.