### PR TITLE
Update ingress to comply with kubernetes 1.16

### DIFF
--- a/charts/hawkbit/Chart.yaml
+++ b/charts/hawkbit/Chart.yaml
@@ -10,7 +10,7 @@
 # SPDX-License-Identifier: EPL-2.0
 ---
 apiVersion: v1
-version: 1.2.3
+version: 1.3.0
 appVersion: "0.3.0M6-mysql"
 description: |
    Eclipse hawkBit™ is a domain independent back-end framework for rolling out software updates

--- a/charts/hawkbit/requirements.yaml
+++ b/charts/hawkbit/requirements.yaml
@@ -1,9 +1,9 @@
 dependencies:
   - name: mysql
-    version: 6.7.4
+    version: 6.14.10
     repository: https://charts.bitnami.com/bitnami
     condition: mysql.enabled
   - name: rabbitmq
-    version: 6.16.0
+    version: 6.28.1
     repository: https://charts.bitnami.com/bitnami
     condition: rabbitmq.enabled

--- a/charts/hawkbit/templates/ingress.yaml
+++ b/charts/hawkbit/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "hawkbit.fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}


### PR DESCRIPTION
The previous api version is deprected and is removed on kubernetes 1.16, therefore, updating it.