### PR TITLE
[#155] Fix mounting of additional secrets into the Artemis container's filesystem

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.4.4
+version: 1.4.5
 # Version of Hono being deployed by the chart
 appVersion: 1.4.0
 keywords:

--- a/charts/hono/templates/artemis/artemis-deployment.yaml
+++ b/charts/hono/templates/artemis/artemis-deployment.yaml
@@ -68,7 +68,7 @@ spec:
         securityContext:
           privileged: false
         volumeMounts:
-        {{- include "hono.container.secretVolumeMounts" ( dict "name" $args.name "conf" .Values.amqpMessagingNetworkExample.broker "configMountPath" "/opt/apache-artemis/conf" ) | indent 8 }}
+        {{- include "hono.container.secretVolumeMounts" ( dict "name" $args.name "conf" .Values.amqpMessagingNetworkExample.broker.artemis "configMountPath" "/opt/apache-artemis/conf" ) | indent 8 }}
       volumes:
-      {{- include "hono.pod.secretVolumes" ( dict "releaseName" .Release.Name "name" $args.name "conf" .Values.amqpMessagingNetworkExample.broker ) | indent 6 }}
+      {{- include "hono.pod.secretVolumes" ( dict "releaseName" .Release.Name "name" $args.name "conf" .Values.amqpMessagingNetworkExample.broker.artemis ) | indent 6 }}
 {{- end }}


### PR DESCRIPTION
With this fix, now it should be able to mount the additional secrets specified in `values.yaml` into the Artemis container's file system.