### PR TITLE
[hono] Add support for JDBC device registry

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.4.16
+version: 1.4.17
 # Version of Hono being deployed by the chart
 appVersion: 1.5.0
 keywords:

--- a/charts/hono/templates/hono-service-device-registry-jdbc/hono-service-device-registry-deployment.yaml
+++ b/charts/hono/templates/hono-service-device-registry-jdbc/hono-service-device-registry-deployment.yaml
@@ -1,0 +1,85 @@
+{{- if and .Values.deviceRegistryExample.enabled ( eq .Values.deviceRegistryExample.type "jdbc" ) }}
+#
+# Copyright (c) 2020 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+{{- $args := dict "dot" . "component" "service-device-registry" "name" "service-device-registry" }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  {{- include "hono.metadata" $args | nindent 2 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "hono.matchLabels" $args | nindent 6 }}
+  template:
+    metadata:
+      {{- include "hono.metadata" $args | nindent 6 }}
+    spec:
+      containers:
+      {{- include "hono.jaeger.agent" . | indent 6 }}
+      - image: {{ include "hono.image" ( dict "dot" . "component" .Values.deviceRegistryExample.jdbcBasedDeviceRegistry ) }}
+        imagePullPolicy: IfNotPresent
+        name: eclipse-hono-service-device-registry
+        ports:
+          - name: health
+            containerPort: {{ .Values.healthCheckPort }}
+            protocol: TCP
+          - name: http
+            containerPort: 8080
+            protocol: TCP
+          - name: https
+            containerPort: 8443
+            protocol: TCP
+          - name: amqps
+            containerPort: 5671
+            protocol: TCP
+          - name: amqp
+            containerPort: 5672
+            protocol: TCP
+        env:
+        - name: SPRING_CONFIG_LOCATION
+          value: file:///etc/hono/
+        - name: SPRING_PROFILES_ACTIVE
+          value: registry-adapter,registry-management,tenant-service,dev
+        - name: LOGGING_CONFIG
+          value: {{ default "classpath:logback-spring.xml" .Values.deviceRegistryExample.loggingConfig | quote }}
+        - name: JDK_JAVA_OPTIONS
+          value: {{ .Values.deviceRegistryExample.javaOptions | quote }}
+        - name: KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        {{- include "hono.jaeger.clientConf" $args | indent 8 }}
+        securityContext:
+          privileged: false
+        volumeMounts:
+        {{- include "hono.container.secretVolumeMounts" ( dict "name" $args.name "conf" .Values.deviceRegistryExample ) | indent 8 }}
+        {{- with .Values.deviceRegistryExample.resources }}
+        resources:
+          {{- . | toYaml | nindent 10 }}
+        {{- end }}
+        livenessProbe:
+          httpGet:
+            path: /liveness
+            port: health
+            scheme: HTTPS
+          initialDelaySeconds: 180
+        readinessProbe:
+            httpGet:
+              path: /readiness
+              port: health
+              scheme: HTTPS
+            initialDelaySeconds: 100
+      volumes:
+      {{- include "hono.pod.secretVolumes" ( dict "releaseName" .Release.Name "name" $args.name "conf" .Values.deviceRegistryExample ) | indent 6 }}
+{{- end }}

--- a/charts/hono/templates/hono-service-device-registry-jdbc/hono-service-device-registry-secret.yaml
+++ b/charts/hono/templates/hono-service-device-registry-jdbc/hono-service-device-registry-secret.yaml
@@ -1,0 +1,75 @@
+{{- if and .Values.deviceRegistryExample.enabled ( eq .Values.deviceRegistryExample.type "jdbc" ) }}
+#
+# Copyright (c) 2020 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+{{- $args := dict "dot" . "component" "service-device-registry" "name" "service-device-registry-conf" }}
+apiVersion: v1
+kind: Secret
+metadata:
+  {{- include "hono.metadata" $args | nindent 2 }}
+type: Opaque
+stringData:
+  application.yml: |
+    hono:
+      app:
+        maxInstances: 1
+      auth:
+        {{- if .Values.deviceRegistryExample.hono.auth }}
+        {{- .Values.deviceRegistryExample.hono.auth | toYaml | nindent 8 }}
+        {{- else }}
+        host: {{ printf "%s-service-auth" .Release.Name | quote }}
+        port: 5671
+        trustStorePath: "/etc/hono/trusted-certs.pem"
+        hostnameVerificationRequired: false
+        name: {{ printf "Hono %s" $args.component | quote }}
+        supportedSaslMechanisms: "PLAIN"
+        validation:
+          certPath: "/etc/hono/auth-server-cert.pem"
+        connectTimeout: 2000
+        {{- end }}
+      registry:
+        amqp:
+          {{- if .Values.deviceRegistryExample.hono.registry.amqp }}
+          {{- .Values.deviceRegistryExample.hono.registry.amqp | toYaml | nindent 10 }}
+          {{- else }}
+          bindAddress: "0.0.0.0"
+          keyPath: "/etc/hono/key.pem"
+          certPath: "/etc/hono/cert.pem"
+          {{- end }}
+        http:
+          {{- if .Values.deviceRegistryExample.hono.registry.http }}
+          {{- .Values.deviceRegistryExample.hono.registry.http | toYaml | nindent 10 }}
+          {{- else }}
+          authenticationRequired: false
+          bindAddress: "0.0.0.0"
+          keyPath: "/etc/hono/key.pem"
+          certPath: "/etc/hono/cert.pem"
+          insecurePortEnabled: true
+          insecurePortBindAddress: "0.0.0.0"
+          {{- end }}
+          deviceIdPattern: "^[a-zA-Z0-9-_\\.\\:]+$"
+        jdbc:
+          {{- if .Values.deviceRegistryExample.jdbcBasedDeviceRegistry.registry.jdbc }}
+          {{- .Values.deviceRegistryExample.jdbcBasedDeviceRegistry.registry.jdbc | toYaml | nindent 10 }}
+          {{- end }}
+      tenant:
+        jdbc:
+          {{- if .Values.deviceRegistryExample.jdbcBasedDeviceRegistry.tenant.jdbc }}
+          {{- .Values.deviceRegistryExample.jdbcBasedDeviceRegistry.tenant.jdbc | toYaml | nindent 10 }}
+          {{- end }}
+      {{- include "hono.healthServerConfig" .Values.deviceRegistryExample.hono.healthCheck | nindent 6 }}
+data:
+  key.pem: {{ .Files.Get "example/certs/device-registry-key.pem" | b64enc }}
+  cert.pem: {{ .Files.Get "example/certs/device-registry-cert.pem" | b64enc }}
+  trusted-certs.pem: {{ .Files.Get "example/certs/trusted-certs.pem" | b64enc }}
+  auth-server-cert.pem: {{ .Files.Get "example/certs/auth-server-cert.pem" | b64enc }}
+{{- end }}

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -880,6 +880,8 @@ deviceRegistryExample:
   # for additional configuration.
   # - mongodb: MongoDB based device registry. Also refer to the section "mongoDBBasedDeviceRegistry"
   # for additional configuration.
+  # - jdbc: JDBC based device registry. Also refer to the section "jdbcBasedDeviceRegistry"
+  # for additional configuration.
   type: file
 
   # addExampleData indicates whether example data is inserted after the device registry is deployed
@@ -1000,6 +1002,68 @@ deviceRegistryExample:
     # username:
     # The password to use for authenticating to the MongoDB instance.
     # password:
+
+  # jdbcBasedDeviceRegistry contains configuration properties specific to the
+  # jdbc based device registry.
+  jdbcBasedDeviceRegistry:
+    # imageName contains the name (excluding registry)
+    # of the container image for the example jdbc based device registry.
+    imageName: eclipse/hono-service-device-registry-jdbc
+    # imageTag contains the tag of the container image to deploy.
+    # If not specified, the value of the honoImagesTag property is used.
+    # imageTag:
+    # containerRegistry contains the name of the container registry to pull
+    # the image from.
+    # If not specified, the value of the "honoContainerRegistry" property is used.
+    # containerRegistry:
+    # registry.jdbc contains the configuration properties for device registry
+    # to connect to the database.
+    registry:
+      jdbc:
+        # the jdbc properties for read-only operations
+        adapter:
+          # The jdbc URL for the database
+          url:
+          # The jdbc driver class name
+          driverClass:
+          # The user name to use for authenticating to the database
+          username:
+          # The password to use for authenticating to the database
+          password:
+        # the jdbc properties for write operations
+        management:
+          # The jdbc URL for the database. For SQLServer, ";SelectMethod=Cursor" is required in the management url.
+          url:
+          # The jdbc driver class name
+          driverClass:
+          # The user name to use for authenticating to the database
+          username:
+          # The password to use for authenticating to the database
+          password:
+    # tenant.jdbc contains the configuration properties for tenant registry
+    # to connect to the database.
+    tenant:
+      jdbc:
+        # the jdbc properties for read-only operations
+        adapter:
+          # The jdbc URL for the database
+          url:
+          # The jdbc driver class name
+          driverClass:
+          # The user name to use for authenticating to the database
+          username:
+          # The password to use for authenticating to the database
+          password:
+        # the jdbc properties for write operations
+        management:
+          # The jdbc URL for the database. For SQLServer, ";SelectMethod=Cursor" is required in the management url.
+          url:
+          # The jdbc driver class name
+          driverClass:
+          # The user name to use for authenticating to the database
+          username:
+          # The password to use for authenticating to the database
+          password:
 
 mongodb:
   # createInstance indicates whether a MongoDB database instance should be created,


### PR DESCRIPTION
## Motivation

Add support for using JDBC based device & tenant registry in the Hono Helm chart. 
JDBC based device registries will be part of the upcoming Hono 1.5.0 release.

Fixes #163 

## Dependencies
* Hono 1.5.0 (not release yet)
* For testing with custom images, this change helps:
  * https://github.com/eclipse/hono/pull/2322 
  * for example: `mvn clean install -Pbuild-docker-image,metrics-prometheus && ./push_hono_images.sh 1.5.0-SNAPSHOT mycustomcr.azurecr.io`
* For SQLServer support (works with Azure SQL Database)
  * https://github.com/eclipse/hono/pull/2317
* For fixes for Postgres support
  * https://github.com/eclipse/hono/pull/2317