### PR TITLE
Fix location of Quarkus config file

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.4.12
+version: 1.4.13
 # Version of Hono being deployed by the chart
 appVersion: 1.4.4
 keywords:

--- a/charts/hono/templates/_helpers.tpl
+++ b/charts/hono/templates/_helpers.tpl
@@ -59,7 +59,7 @@ The scope passed in is expected to be a dict with keys
   {{- $registry := default .dot.Values.honoContainerRegistry .component.containerRegistry }}
 
   {{- if and .useImageType ( contains "quarkus" .dot.Values.honoImagesType ) }}
-  {{- printf "%s/%s-quarkus:%s" $registry .component.imageName $tag -}}
+  {{- printf "%s/%s-%s:%s" $registry .component.imageName .dot.Values.honoImagesType $tag -}}
   {{- else }}
   {{- printf "%s/%s:%s" $registry .component.imageName $tag -}}
   {{- end }}
@@ -287,6 +287,13 @@ quarkus:
     console:
       color: true
     level: INFO
+    category:
+      "org.eclipse.hono":
+        level: INFO
+      "org.eclipse.hono.adapter":
+        level: INFO
+      "org.eclipse.hono.service":
+        level: INFO
   vertx:
     prefer-native-transport: true
 {{- end }}

--- a/charts/hono/templates/hono-adapter-http/hono-adapter-http-vertx-secret.yaml
+++ b/charts/hono/templates/hono-adapter-http/hono-adapter-http-vertx-secret.yaml
@@ -35,6 +35,7 @@ stringData:
         {{- end }}
       {{- include "hono.healthServerConfig" .Values.adapters.http.hono.healthCheck | nindent 6 }}
       {{- include "hono.serviceClientConfig" $args | nindent 6 }}
+    {{- include "hono.quarkusConfig" $args | indent 4 }}
 data:
   key.pem: {{ .Files.Get "example/certs/http-adapter-key.pem" | b64enc }}
   cert.pem: {{ .Files.Get "example/certs/http-adapter-cert.pem" | b64enc }}

--- a/charts/hono/templates/hono-adapter-mqtt/hono-adapter-mqtt-vertx-secret.yaml
+++ b/charts/hono/templates/hono-adapter-mqtt/hono-adapter-mqtt-vertx-secret.yaml
@@ -39,6 +39,7 @@ stringData:
         {{- end }}
       {{- include "hono.healthServerConfig" .Values.adapters.mqtt.hono.healthCheck | nindent 6 }}
       {{- include "hono.serviceClientConfig" $args | nindent 6 }}
+    {{- include "hono.quarkusConfig" $args | indent 4 }}
 data:
   key.pem: {{ .Files.Get "example/certs/mqtt-adapter-key.pem" | b64enc }}
   cert.pem: {{ .Files.Get "example/certs/mqtt-adapter-cert.pem" | b64enc }}


### PR DESCRIPTION
The Quarkus based adapters expect to find the `application.yaml` file in
the `config` folder relative to the current working directory.
The working directory in the Quarkus based images had been changed to
`/opt/hono` recently so the mount path for the config secret has been adapted
accordingly.
