### PR TITLE
Upgrade to Hono 1.5.0

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,9 +15,9 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.4.15
+version: 1.4.16
 # Version of Hono being deployed by the chart
-appVersion: 1.4.4
+appVersion: 1.5.0
 keywords:
   - iot-chart
   - IoT


### PR DESCRIPTION
I would like to bump the *chart* version to 1.5.0 once we use any of the new features introduced in Hono 1.5.0, e.g. supporting to configure the Command Router and/or the JDBC registry. For now, the chart's config properties all remain the same, we are just updating to the *latest and greatest* Hono ;-)