### PR TITLE
[#167] adds configuration option for certificates in dispatch router of Eclipse Hono Chart

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.4.17
+version: 1.4.18
 # Version of Hono being deployed by the chart
 appVersion: 1.5.0
 keywords:

--- a/charts/hono/templates/_helpers.tpl
+++ b/charts/hono/templates/_helpers.tpl
@@ -174,10 +174,10 @@ messaging:
   amqpHostname: hono-internal
   host: {{ .dot.Release.Name }}-dispatch-router
   port: 5673
-  keyPath: /etc/hono/key.pem
-  certPath: /etc/hono/cert.pem
-  trustStorePath: /etc/hono/trusted-certs.pem
-  hostnameVerificationRequired: false
+  keyPath: {{ .dot.Values.adapters.amqpMessagingNetworkSpec.keyPath }}
+  certPath: {{ .dot.Values.adapters.amqpMessagingNetworkSpec.certPath }}
+  trustStorePath: {{ .dot.Values.adapters.amqpMessagingNetworkSpec.trustStorePath }}
+  hostnameVerificationRequired: {{ .dot.Values.adapters.amqpMessagingNetworkSpec.hostnameVerificationRequired }}
 {{- else }}
   {{- required ".Values.adapters.amqpMessagingNetworkSpec MUST be set if example AQMP Messaging Network is disabled" .dot.Values.adapters.amqpMessagingNetworkSpec | toYaml | nindent 2 }}
 {{- end }}
@@ -187,10 +187,10 @@ command:
   amqpHostname: hono-internal
   host: {{ .dot.Release.Name }}-dispatch-router
   port: 5673
-  keyPath: /etc/hono/key.pem
-  certPath: /etc/hono/cert.pem
-  trustStorePath: /etc/hono/trusted-certs.pem
-  hostnameVerificationRequired: false
+  keyPath: {{ .dot.Values.adapters.commandAndControlSpec.keyPath }}
+  certPath: {{ .dot.Values.adapters.commandAndControlSpec.certPath }}
+  trustStorePath: {{ .dot.Values.adapters.commandAndControlSpec.trustStorePath }}
+  hostnameVerificationRequired: {{ .dot.Values.adapters.commandAndControlSpec.hostnameVerificationRequired }}
 {{- else }}
   {{- required ".Values.adapters.commandAndControlSpec MUST be set if example AQMP Messaging Network is disabled" .dot.Values.adapters.commandAndControlSpec | toYaml | nindent 2 }}
 {{- end }}

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -294,10 +294,15 @@ adapters:
   # This property MUST be set if "amqpMessagingNetworkExample.enabled" is set to false.
   # Please refer to https://www.eclipse.org/hono/docs/admin-guide/hono-client-configuration/
   # for a description of supported properties.
+  # However, if "amqpMessagingNetworkExample.enabled" is set to true, only
+  # "keyPath", "keyPath", "trustStorePath", "hostnameVerificationRequired" can be set.
   amqpMessagingNetworkSpec:
+    keyPath: /etc/hono/key.pem
+    certPath: /etc/hono/cert.pem
+    trustStorePath: /etc/hono/trusted-certs.pem
+    hostnameVerificationRequired: false
   #  host: my-amqp-host
   #  port: 5671
-  #  trustStorePath: /etc/conf/amqp-trust-store.pem
   #  credentialsPath: /etc/conf/amqp-credentials.properties
 
   # commandAndControlSpec contains Hono client properties used by all protocol
@@ -306,7 +311,13 @@ adapters:
   # This property MUST be set if "amqpMessagingNetworkExample.enabled" is set to false.
   # Please refer to https://www.eclipse.org/hono/docs/admin-guide/hono-client-configuration/
   # for a description of supported properties.
+  # However, if "amqpMessagingNetworkExample.enabled" is set to true, only
+  # "keyPath", "keyPath", "trustStorePath", "hostnameVerificationRequired" can be set.
   commandAndControlSpec:
+    keyPath: /etc/hono/key.pem
+    certPath: /etc/hono/cert.pem
+    trustStorePath: /etc/hono/trusted-certs.pem
+    hostnameVerificationRequired: false
 
   # tenantSpec contains Hono client properties used by all protocol adapters for
   # connecting to the Tenant service.


### PR DESCRIPTION
This PR addresses #167 and enables the user to set the certificate configuration and respective paths of the amqpMessagingNetworkSpec through the values.yaml file of the Hono Chart. Please note, that @LuLeRoemer joined the work on this PR. 