### PR TITLE
Fix repo URLs in GitHub Actions workflow

### DIFF
--- a/.github/ct.yaml
+++ b/.github/ct.yaml
@@ -10,12 +10,15 @@
 # SPDX-License-Identifier: EPL-2.0
 
 # consider helm install to be failed after 10 minutes
-helm-extra-args: --timeout 600
+helm-extra-args: --timeout 600s
 check-version-increment: true
 debug: true
 chart-dirs: 
   - charts
   - packages
 chart-repos:
-  - stable=https://kubernetes-charts.storage.googleapis.com/
+  - stable=https://charts.helm.sh/stable
+  - packages=https://eclipse.org/packages/charts
   - bitnami=https://charts.bitnami.com/bitnami
+  - prometheus-community=https://prometheus-community.github.io/helm-charts
+  - grafana=https://grafana.github.io/helm-charts

--- a/.github/kubeval.sh
+++ b/.github/kubeval.sh
@@ -3,7 +3,7 @@
 # use kubeval to validate helm generated kubernetes manifest
 #
 
-# Copyright (c) 2019 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -32,8 +32,11 @@ curl --silent --show-error --fail --location --output /tmp/kubeval.tar.gz https:
 sudo tar -C /usr/local/bin -xf /tmp/kubeval.tar.gz kubeval
 
 # add helm repos to resolve dependencies
+helm repo add stable https://charts.helm.sh/stable
+helm repo add packages https://eclipse.org/packages/charts
 helm repo add bitnami https://charts.bitnami.com/bitnami
-helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo add grafana https://grafana.github.io/helm-charts
 
 # validate charts
 for CHART_DIR in ${CHART_DIRS};do

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Fetch history for chart testing
         run: git fetch --prune --unshallow
       - name: Run chart-testing (lint)
-        uses: helm/chart-testing-action@v1.0.0-rc.2
+        uses: helm/chart-testing-action@v1.0.0
         with:
           command: lint
           config: .github/ct.yaml
@@ -96,7 +96,7 @@ jobs:
           config: .github/kind-config.yaml
           node_image: kindest/node:${{ matrix.k8s }}
       - name: Run chart-testing (install)
-        uses: helm/chart-testing-action@v1.0.0-alpha.3
+        uses: helm/chart-testing-action@v1.0.0
         with:
           command: install
           config: .github/ct.yaml


### PR DESCRIPTION
Replacing the obsolete "https://kubernetes-charts.storage.googleapis.com"
location and adding prometheus and grafana repos.