### PR TITLE
Support configuration of Spring Boot environment variables

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.4.19
+version: 1.4.20
 # Version of Hono being deployed by the chart
 appVersion: 1.5.0
 keywords:

--- a/charts/hono/templates/_helpers.tpl
+++ b/charts/hono/templates/_helpers.tpl
@@ -275,10 +275,31 @@ resource-limits:
 
 
 {{/*
-Add Quarkus related configuration properties to YAML file.
+Adds environment variables for Spring Boot
+to a component's container.
+
 The scope passed in is expected to be a dict with keys
-- "dot": the root scope (".") and
-- "component": the name of the adapter
+- (mandatory) "dot": the root scope (".")
+- (mandatory) "componentConfig": the component's configuration properties from the values.yaml file
+- (optional) "useImageType": indicates if image type (Quarkus, Spring) should be considered (defaults to false)
+*/}}
+{{- define "hono.component.springEnv" }}
+{{- if not ( and ( default false .useImageType ) ( contains "quarkus" .dot.Values.honoImagesType ) ) }}
+- name: SPRING_CONFIG_LOCATION
+  value: {{ default "file:///etc/hono/" .componentConfig.springConfigLocation | quote }}
+- name: LOGGING_CONFIG
+  value: {{ default "classpath:logback-spring.xml" .componentConfig.loggingConfig | quote }}
+- name: SPRING_PROFILES_ACTIVE
+  value: {{ default "dev" ( default .dot.Values.adapters.applicationProfiles .componentConfig.applicationProfiles ) | quote }}
+{{- end }}
+{{- end }}
+
+
+{{/*
+Add Quarkus related configuration properties to YAML file.
+
+The scope passed in is expected to be a dict with keys
+- (mandatory ) "dot": the root scope (".")
 */}}
 {{- define "hono.quarkusConfig" -}}
 {{- if ( contains "quarkus" .dot.Values.honoImagesType ) }}

--- a/charts/hono/templates/artemis/artemis-deployment.yaml
+++ b/charts/hono/templates/artemis/artemis-deployment.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.amqpMessagingNetworkExample.enabled ( not .Values.amqpMessagingNetworkExample.broker.servicebus.host ) }}
 #
-# Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -14,7 +14,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  {{- $args := dict "dot" . "component" "amqp-messaging-network-broker" "name" "artemis" }}
+  {{- $args := dict "dot" . "component" "amqp-messaging-network-broker" "name" "artemis" "componentConfig" .Values.amqpMessagingNetworkExample.broker.artemis }}
   {{- include "hono.metadata" $args | nindent 2 }}
 spec:
   replicas: 1
@@ -68,7 +68,7 @@ spec:
         securityContext:
           privileged: false
         volumeMounts:
-        {{- include "hono.container.secretVolumeMounts" ( dict "name" $args.name "conf" .Values.amqpMessagingNetworkExample.broker.artemis "configMountPath" "/opt/apache-artemis/conf" ) | indent 8 }}
+        {{- include "hono.container.secretVolumeMounts" ( dict "name" $args.name "componentConfig" $args.componentConfig "configMountPath" "/opt/apache-artemis/conf" ) | indent 8 }}
       volumes:
-      {{- include "hono.pod.secretVolumes" ( dict "releaseName" .Release.Name "name" $args.name "conf" .Values.amqpMessagingNetworkExample.broker.artemis ) | indent 6 }}
+      {{- include "hono.pod.secretVolumes" $args | indent 6 }}
 {{- end }}

--- a/charts/hono/templates/dispatch-router/dispatch-router-deployment.yaml
+++ b/charts/hono/templates/dispatch-router/dispatch-router-deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.amqpMessagingNetworkExample.enabled -}}
 #
-# Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -14,7 +14,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  {{- $args := dict "dot" . "component" "amqp-messaging-network-router" "name" "dispatch-router" }}
+  {{- $args := dict "dot" . "component" "amqp-messaging-network-router" "name" "dispatch-router" "componentConfig" .Values.amqpMessagingNetworkExample.dispatchRouter }}
   {{- include "hono.metadata" $args | nindent 2 }}
 spec:
   replicas: 1
@@ -70,7 +70,7 @@ spec:
         securityContext:
           privileged: false
         volumeMounts:
-        {{- include "hono.container.secretVolumeMounts" ( dict "name" $args.name "conf" .Values.amqpMessagingNetworkExample.dispatchRouter ) | indent 8 }}
+        {{- include "hono.container.secretVolumeMounts" ( dict "name" $args.name "componentConfig" $args.componentConfig ) | indent 8 }}
       volumes:
-      {{- include "hono.pod.secretVolumes" ( dict "releaseName" .Release.Name "name" $args.name "conf" .Values.amqpMessagingNetworkExample.dispatchRouter ) | indent 6 }}
+      {{- include "hono.pod.secretVolumes" $args | indent 6 }}
 {{- end }}

--- a/charts/hono/templates/hono-adapter-amqp/hono-adapter-amqp-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-amqp/hono-adapter-amqp-vertx-deployment.yaml
@@ -45,18 +45,13 @@ spec:
         securityContext:
           privileged: false
         env:
-        - name: SPRING_CONFIG_LOCATION
-          value: file:///etc/hono/
-        - name: SPRING_PROFILES_ACTIVE
-          value: dev
-        - name: LOGGING_CONFIG
-          value: {{ default "classpath:logback-spring.xml" .Values.adapters.amqp.loggingConfig | quote }}
         - name: JDK_JAVA_OPTIONS
           value: {{ .Values.adapters.amqp.javaOptions | quote }}
         - name: KUBERNETES_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- include "hono.component.springEnv" $args | indent 8 }}
         {{- include "hono.jaeger.clientConf" $args | indent 8 }}
         volumeMounts:
         {{- include "hono.container.secretVolumeMounts" $args | indent 8 }}

--- a/charts/hono/templates/hono-adapter-amqp/hono-adapter-amqp-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-amqp/hono-adapter-amqp-vertx-deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.adapters.amqp.enabled }}
 #
-# Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -11,7 +11,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
-{{- $args := dict "dot" . "component" "adapter-amqp-vertx" "name" "adapter-amqp-vertx" }}
+{{- $args := dict "dot" . "component" "adapter-amqp-vertx" "name" "adapter-amqp-vertx" "componentConfig" .Values.adapters.amqp }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
-      - image: {{ include "hono.image" ( dict "dot" . "component" .Values.adapters.amqp ) }}
+      - image: {{ include "hono.image" $args }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-adapter-amqp-vertx
         ports:
@@ -59,7 +59,7 @@ spec:
               fieldPath: metadata.namespace
         {{- include "hono.jaeger.clientConf" $args | indent 8 }}
         volumeMounts:
-        {{- include "hono.container.secretVolumeMounts" ( dict "name" $args.name "conf" .Values.adapters.amqp ) | indent 8 }}
+        {{- include "hono.container.secretVolumeMounts" $args | indent 8 }}
         {{- with .Values.adapters.amqp.resources }}
         resources:
           {{- . | toYaml | nindent 10 }}
@@ -77,5 +77,5 @@ spec:
             scheme: HTTPS
           initialDelaySeconds: 10
       volumes:
-      {{- include "hono.pod.secretVolumes" ( dict "releaseName" .Release.Name "name" $args.name "conf" .Values.adapters.amqp ) | indent 6 }}
+      {{- include "hono.pod.secretVolumes" $args | indent 6 }}
 {{- end }}

--- a/charts/hono/templates/hono-adapter-coap/hono-adapter-coap-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-coap/hono-adapter-coap-vertx-deployment.yaml
@@ -45,18 +45,13 @@ spec:
         securityContext:
           privileged: false
         env:
-        - name: SPRING_CONFIG_LOCATION
-          value: file:///etc/hono/
-        - name: SPRING_PROFILES_ACTIVE
-          value: dev
-        - name: LOGGING_CONFIG
-          value: {{ default "classpath:logback-spring.xml" .Values.adapters.coap.loggingConfig | quote }}
         - name: JDK_JAVA_OPTIONS
           value: {{ .Values.adapters.coap.javaOptions | quote }}
         - name: KUBERNETES_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- include "hono.component.springEnv" $args | indent 8 }}
         {{- include "hono.jaeger.clientConf" $args | indent 8 }}
         volumeMounts:
         {{- include "hono.container.secretVolumeMounts" $args | indent 8 }}

--- a/charts/hono/templates/hono-adapter-coap/hono-adapter-coap-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-coap/hono-adapter-coap-vertx-deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.adapters.coap.enabled }}
 #
-# Copyright (c) 2019 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -11,7 +11,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
-{{- $args := dict "dot" . "component" "adapter-coap-vertx" "name" "adapter-coap-vertx" }}
+{{- $args := dict "dot" . "component" "adapter-coap-vertx" "name" "adapter-coap-vertx" "componentConfig" .Values.adapters.coap }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
-      - image: {{ include "hono.image" ( dict "dot" . "component" .Values.adapters.coap ) }}
+      - image: {{ include "hono.image" $args }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-adapter-coap-vertx
         ports:
@@ -59,7 +59,7 @@ spec:
               fieldPath: metadata.namespace
         {{- include "hono.jaeger.clientConf" $args | indent 8 }}
         volumeMounts:
-        {{- include "hono.container.secretVolumeMounts" ( dict "name" $args.name "conf" .Values.adapters.coap ) | indent 8 }}
+        {{- include "hono.container.secretVolumeMounts" $args | indent 8 }}
         {{- with .Values.adapters.coap.resources }}
         resources:
           {{- . | toYaml | nindent 10 }}
@@ -77,5 +77,5 @@ spec:
             scheme: HTTPS
           initialDelaySeconds: 10
       volumes:
-      {{- include "hono.pod.secretVolumes" ( dict "releaseName" .Release.Name "name" $args.name "conf" .Values.adapters.coap ) | indent 6 }}
+      {{- include "hono.pod.secretVolumes" $args | indent 6 }}
 {{- end }}

--- a/charts/hono/templates/hono-adapter-http/hono-adapter-http-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-http/hono-adapter-http-vertx-deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.adapters.http.enabled }}
 #
-# Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -11,7 +11,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
-{{- $args := dict "dot" . "component" "adapter-http-vertx" "name" "adapter-http-vertx" }}
+{{- $args := dict "dot" . "component" "adapter-http-vertx" "name" "adapter-http-vertx" "componentConfig" .Values.adapters.http }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
-      - image: {{ include "hono.image" ( dict "dot" . "component" .Values.adapters.http "useImageType" true) }}
+      - image: {{ include "hono.image" ( dict "dot" . "componentConfig" .Values.adapters.http "useImageType" true) }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-adapter-http-vertx
         ports:
@@ -59,7 +59,7 @@ spec:
               fieldPath: metadata.namespace
         {{- include "hono.jaeger.clientConf" $args | indent 8 }}
         volumeMounts:
-        {{- include "hono.container.secretVolumeMounts" ( dict "dot" $args.dot "name" $args.name "conf" .Values.adapters.http ) | indent 8 }}
+        {{- include "hono.container.secretVolumeMounts" $args | indent 8 }}
         {{- with .Values.adapters.http.resources }}
         resources:
           {{- . | toYaml | nindent 10 }}
@@ -77,5 +77,5 @@ spec:
             scheme: HTTPS
           initialDelaySeconds: 10
       volumes:
-      {{- include "hono.pod.secretVolumes" ( dict "dot" $args.dot "releaseName" .Release.Name "name" $args.name "conf" .Values.adapters.http ) | indent 6 }}
+      {{- include "hono.pod.secretVolumes" $args | indent 6 }}
 {{- end }}

--- a/charts/hono/templates/hono-adapter-http/hono-adapter-http-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-http/hono-adapter-http-vertx-deployment.yaml
@@ -11,7 +11,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
-{{- $args := dict "dot" . "component" "adapter-http-vertx" "name" "adapter-http-vertx" "componentConfig" .Values.adapters.http }}
+{{- $args := dict "dot" . "component" "adapter-http-vertx" "name" "adapter-http-vertx" "componentConfig" .Values.adapters.http "useImageType" true }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
-      - image: {{ include "hono.image" ( dict "dot" . "componentConfig" .Values.adapters.http "useImageType" true) }}
+      - image: {{ include "hono.image" $args }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-adapter-http-vertx
         ports:
@@ -45,18 +45,13 @@ spec:
         securityContext:
           privileged: false
         env:
-        - name: SPRING_CONFIG_LOCATION
-          value: file:///etc/hono/
-        - name: SPRING_PROFILES_ACTIVE
-          value: dev
-        - name: LOGGING_CONFIG
-          value: {{ default "classpath:logback-spring.xml" .Values.adapters.http.loggingConfig | quote }}
         - name: JDK_JAVA_OPTIONS
           value: {{ .Values.adapters.http.javaOptions | quote }}
         - name: KUBERNETES_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- include "hono.component.springEnv" $args | indent 8 }}
         {{- include "hono.jaeger.clientConf" $args | indent 8 }}
         volumeMounts:
         {{- include "hono.container.secretVolumeMounts" $args | indent 8 }}

--- a/charts/hono/templates/hono-adapter-kura/hono-adapter-kura-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-kura/hono-adapter-kura-deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.adapters.kura.enabled }}
 #
-# Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -11,7 +11,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
-{{- $args := dict "dot" . "component" "adapter-kura" "name" "adapter-kura" }}
+{{- $args := dict "dot" . "component" "adapter-kura" "name" "adapter-kura" "componentConfig" .Values.adapters.kura }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
-      - image: {{ include "hono.image" ( dict "dot" . "component" .Values.adapters.kura ) }}
+      - image: {{ include "hono.image" $args }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-adapter-kura
         ports:
@@ -59,7 +59,7 @@ spec:
               fieldPath: metadata.namespace
         {{- include "hono.jaeger.clientConf" $args | indent 8 }}
         volumeMounts:
-        {{- include "hono.container.secretVolumeMounts" ( dict "name" $args.name "conf" .Values.adapters.kura ) | indent 8 }}
+        {{- include "hono.container.secretVolumeMounts" $args | indent 8 }}
         {{- with .Values.adapters.kura.resources }}
         resources:
           {{- . | toYaml | nindent 10 }}
@@ -77,5 +77,5 @@ spec:
             scheme: HTTPS
           initialDelaySeconds: 180
       volumes:
-      {{- include "hono.pod.secretVolumes" ( dict "releaseName" .Release.Name "name" $args.name "conf" .Values.adapters.kura ) | indent 6 }}
+      {{- include "hono.pod.secretVolumes" $args | indent 6 }}
 {{ end }}

--- a/charts/hono/templates/hono-adapter-kura/hono-adapter-kura-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-kura/hono-adapter-kura-deployment.yaml
@@ -45,18 +45,13 @@ spec:
         securityContext:
           privileged: false
         env:
-        - name: SPRING_CONFIG_LOCATION
-          value: file:///etc/hono/
-        - name: SPRING_PROFILES_ACTIVE
-          value: dev
-        - name: LOGGING_CONFIG
-          value: {{ default "classpath:logback-spring.xml" .Values.adapters.kura.loggingConfig | quote }}
         - name: JDK_JAVA_OPTIONS
           value: {{ .Values.adapters.kura.javaOptions | quote }}
         - name: KUBERNETES_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- include "hono.component.springEnv" $args | indent 8 }}
         {{- include "hono.jaeger.clientConf" $args | indent 8 }}
         volumeMounts:
         {{- include "hono.container.secretVolumeMounts" $args | indent 8 }}

--- a/charts/hono/templates/hono-adapter-lora/hono-adapter-lora-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-lora/hono-adapter-lora-vertx-deployment.yaml
@@ -45,18 +45,13 @@ spec:
         securityContext:
           privileged: false
         env:
-        - name: SPRING_CONFIG_LOCATION
-          value: file:///etc/hono/
-        - name: SPRING_PROFILES_ACTIVE
-          value: dev
-        - name: LOGGING_CONFIG
-          value: {{ default "classpath:logback-spring.xml" .Values.adapters.lora.loggingConfig | quote }}
         - name: JDK_JAVA_OPTIONS
           value: {{ .Values.adapters.lora.javaOptions | quote }}
         - name: KUBERNETES_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- include "hono.component.springEnv" $args | indent 8 }}
         {{- include "hono.jaeger.clientConf" $args | indent 8 }}
         volumeMounts:
         {{- include "hono.container.secretVolumeMounts" $args | indent 8 }}

--- a/charts/hono/templates/hono-adapter-lora/hono-adapter-lora-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-lora/hono-adapter-lora-vertx-deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.adapters.lora.enabled }}
 #
-# Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -11,7 +11,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
-{{- $args := dict "dot" . "component" "adapter-lora-vertx" "name" "adapter-lora-vertx" }}
+{{- $args := dict "dot" . "component" "adapter-lora-vertx" "name" "adapter-lora-vertx" "componentConfig" .Values.adapters.lora }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
-      - image: {{ include "hono.image" ( dict "dot" . "component" .Values.adapters.lora ) }}
+      - image: {{ include "hono.image" $args }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-adapter-lora-vertx
         ports:
@@ -59,7 +59,7 @@ spec:
               fieldPath: metadata.namespace
         {{- include "hono.jaeger.clientConf" $args | indent 8 }}
         volumeMounts:
-        {{- include "hono.container.secretVolumeMounts" ( dict "name" $args.name "conf" .Values.adapters.lora ) | indent 8 }}
+        {{- include "hono.container.secretVolumeMounts" $args | indent 8 }}
         {{- with .Values.adapters.lora.resources }}
         resources:
           {{- . | toYaml | nindent 10 }}
@@ -77,5 +77,5 @@ spec:
             scheme: HTTPS
           initialDelaySeconds: 10
       volumes:
-      {{- include "hono.pod.secretVolumes" ( dict "releaseName" .Release.Name "name" $args.name "conf" .Values.adapters.lora ) | indent 6 }}
+      {{- include "hono.pod.secretVolumes" $args | indent 6 }}
 {{- end }}

--- a/charts/hono/templates/hono-adapter-mqtt/hono-adapter-mqtt-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-mqtt/hono-adapter-mqtt-vertx-deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.adapters.mqtt.enabled }}
 #
-# Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -11,7 +11,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
-{{- $args := dict "dot" . "component" "adapter-mqtt-vertx" "name" "adapter-mqtt-vertx" }}
+{{- $args := dict "dot" . "component" "adapter-mqtt-vertx" "name" "adapter-mqtt-vertx" "componentConfig" .Values.adapters.mqtt }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
-      - image: {{ include "hono.image" ( dict "dot" . "component" .Values.adapters.mqtt "useImageType" true ) }}
+      - image: {{ include "hono.image" ( dict "dot" . "componentConfig" .Values.adapters.mqtt "useImageType" true ) }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-adapter-mqtt-vertx
         ports:
@@ -59,7 +59,7 @@ spec:
               fieldPath: metadata.namespace
         {{- include "hono.jaeger.clientConf" $args | indent 8 }}
         volumeMounts:
-        {{- include "hono.container.secretVolumeMounts" ( dict "dot" $args.dot "name" $args.name "conf" .Values.adapters.mqtt ) | indent 8 }}
+        {{- include "hono.container.secretVolumeMounts" $args | indent 8 }}
         {{- with .Values.adapters.mqtt.resources }}
         resources:
           {{- . | toYaml | nindent 10 }}
@@ -77,5 +77,5 @@ spec:
             scheme: HTTPS
           initialDelaySeconds: 10
       volumes:
-      {{- include "hono.pod.secretVolumes" ( dict "dot" $args.dot "releaseName" .Release.Name "name" $args.name "conf" .Values.adapters.mqtt ) | indent 6 }}
+      {{- include "hono.pod.secretVolumes" $args | indent 6 }}
 {{- end }}

--- a/charts/hono/templates/hono-adapter-mqtt/hono-adapter-mqtt-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-mqtt/hono-adapter-mqtt-vertx-deployment.yaml
@@ -11,7 +11,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
-{{- $args := dict "dot" . "component" "adapter-mqtt-vertx" "name" "adapter-mqtt-vertx" "componentConfig" .Values.adapters.mqtt }}
+{{- $args := dict "dot" . "component" "adapter-mqtt-vertx" "name" "adapter-mqtt-vertx" "componentConfig" .Values.adapters.mqtt "useImageType" true }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
-      - image: {{ include "hono.image" ( dict "dot" . "componentConfig" .Values.adapters.mqtt "useImageType" true ) }}
+      - image: {{ include "hono.image" $args }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-adapter-mqtt-vertx
         ports:
@@ -45,18 +45,13 @@ spec:
         securityContext:
           privileged: false
         env:
-        - name: SPRING_CONFIG_LOCATION
-          value: file:///etc/hono/
-        - name: SPRING_PROFILES_ACTIVE
-          value: dev
-        - name: LOGGING_CONFIG
-          value: {{ default "classpath:logback-spring.xml" .Values.adapters.mqtt.loggingConfig | quote }}
         - name: JDK_JAVA_OPTIONS
           value: {{ .Values.adapters.mqtt.javaOptions | quote }}
         - name: KUBERNETES_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- include "hono.component.springEnv" $args | indent 8 }}
         {{- include "hono.jaeger.clientConf" $args | indent 8 }}
         volumeMounts:
         {{- include "hono.container.secretVolumeMounts" $args | indent 8 }}

--- a/charts/hono/templates/hono-service-auth/hono-service-auth-deployment.yaml
+++ b/charts/hono/templates/hono-service-auth/hono-service-auth-deployment.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -10,7 +10,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
-{{- $args := dict "dot" . "component" "service-auth" "name" "service-auth" }}
+{{- $args := dict "dot" . "component" "service-auth" "name" "service-auth" "componentConfig" .Values.authServer }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -27,7 +27,7 @@ spec:
         {{- include "hono.monitoringAnnotations" . | nindent 8 }}
     spec:
       containers:
-      - image: {{ include "hono.image" ( dict "dot" . "component" .Values.authServer ) }}
+      - image: {{ include "hono.image" $args }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-service-auth
         ports:
@@ -56,7 +56,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         volumeMounts:
-        {{- include "hono.container.secretVolumeMounts" ( dict "name" $args.name "conf" .Values.authServer ) | indent 8 }}
+        {{- include "hono.container.secretVolumeMounts" $args | indent 8 }}
         {{- with .Values.authServer.resources }}
         resources:
           {{- . | toYaml | nindent 10 }}
@@ -74,4 +74,4 @@ spec:
             scheme: HTTPS
           initialDelaySeconds: 10
       volumes:
-      {{- include "hono.pod.secretVolumes" ( dict "releaseName" .Release.Name "name" $args.name "conf" .Values.authServer ) | indent 6 }}
+      {{- include "hono.pod.secretVolumes" $args | indent 6 }}

--- a/charts/hono/templates/hono-service-auth/hono-service-auth-deployment.yaml
+++ b/charts/hono/templates/hono-service-auth/hono-service-auth-deployment.yaml
@@ -43,18 +43,13 @@ spec:
         securityContext:
           privileged: false
         env:
-        - name: SPRING_CONFIG_LOCATION
-          value: file:///etc/hono/
-        - name: SPRING_PROFILES_ACTIVE
-          value: authentication-impl,dev
-        - name: LOGGING_CONFIG
-          value: {{ default "classpath:logback-spring.xml" .Values.authServer.loggingConfig | quote }}
         - name: JDK_JAVA_OPTIONS
           value: {{ .Values.authServer.javaOptions | quote }}
         - name: KUBERNETES_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- include "hono.component.springEnv" $args | indent 8 }}
         volumeMounts:
         {{- include "hono.container.secretVolumeMounts" $args | indent 8 }}
         {{- with .Values.authServer.resources }}

--- a/charts/hono/templates/hono-service-device-connection/hono-service-device-connection-deployment.yaml
+++ b/charts/hono/templates/hono-service-device-connection/hono-service-device-connection-deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.deviceConnectionService.enabled }}
 #
-# Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -11,7 +11,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
-{{- $args := dict "dot" . "component" "service-device-connection" "name" "service-device-connection" }}
+{{- $args := dict "dot" . "component" "service-device-connection" "name" "service-device-connection" "componentConfig" .Values.deviceConnectionService }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
-      - image: {{ include "hono.image" ( dict "dot" . "component" .Values.deviceConnectionService ) }}
+      - image: {{ include "hono.image" $args }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-service-device-connection
         ports:
@@ -59,7 +59,7 @@ spec:
               fieldPath: metadata.namespace
         {{- include "hono.jaeger.clientConf" $args | indent 8 }}
         volumeMounts:
-        {{- include "hono.container.secretVolumeMounts" ( dict "name" $args.name "conf" .Values.deviceConnectionService ) | indent 8 }}
+        {{- include "hono.container.secretVolumeMounts" $args | indent 8 }}
         {{- with .Values.deviceConnectionService.resources }}
         resources:
           {{- . | toYaml | nindent 10 }}
@@ -81,5 +81,5 @@ spec:
           periodSeconds: 5
           failureThreshold: 2
       volumes:
-      {{- include "hono.pod.secretVolumes" ( dict "releaseName" .Release.Name "name" $args.name "conf" .Values.deviceConnectionService ) | indent 6 }}
+      {{- include "hono.pod.secretVolumes" $args | indent 6 }}
 {{- end }}

--- a/charts/hono/templates/hono-service-device-connection/hono-service-device-connection-deployment.yaml
+++ b/charts/hono/templates/hono-service-device-connection/hono-service-device-connection-deployment.yaml
@@ -45,18 +45,13 @@ spec:
         securityContext:
           privileged: false
         env:
-        - name: SPRING_CONFIG_LOCATION
-          value: file:///etc/hono/
-        - name: SPRING_PROFILES_ACTIVE
-          value: prod
-        - name: LOGGING_CONFIG
-          value: {{ default "classpath:logback-spring.xml" .Values.deviceConnectionService.loggingConfig | quote }}
         - name: JDK_JAVA_OPTIONS
           value: {{ .Values.deviceConnectionService.javaOptions | quote }}
         - name: KUBERNETES_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- include "hono.component.springEnv" $args | indent 8 }}
         {{- include "hono.jaeger.clientConf" $args | indent 8 }}
         volumeMounts:
         {{- include "hono.container.secretVolumeMounts" $args | indent 8 }}

--- a/charts/hono/templates/hono-service-device-registry-file/hono-service-device-registry-statefulset.yaml
+++ b/charts/hono/templates/hono-service-device-registry-file/hono-service-device-registry-statefulset.yaml
@@ -50,18 +50,13 @@ spec:
           containerPort: 5672
           protocol: TCP
         env:
-        - name: SPRING_CONFIG_LOCATION
-          value: file:///etc/hono/
-        - name: SPRING_PROFILES_ACTIVE
-          value: dev
-        - name: LOGGING_CONFIG
-          value: classpath:logback-spring.xml
         - name: JDK_JAVA_OPTIONS
           value: {{ .Values.deviceRegistryExample.javaOptions | quote }}
         - name: KUBERNETES_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- include "hono.component.springEnv" $args | indent 8 }}
         {{- include "hono.jaeger.clientConf" $args | indent 8 }}
         securityContext:
           privileged: false

--- a/charts/hono/templates/hono-service-device-registry-file/hono-service-device-registry-statefulset.yaml
+++ b/charts/hono/templates/hono-service-device-registry-file/hono-service-device-registry-statefulset.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.deviceRegistryExample.enabled ( eq .Values.deviceRegistryExample.type "file" ) }}
 #
-# Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -11,7 +11,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
-{{- $args := dict "dot" . "component" "service-device-registry" "name" "service-device-registry" }}
+{{- $args := dict "dot" . "component" "service-device-registry" "name" "service-device-registry" "componentConfig" .Values.deviceRegistryExample.fileBasedDeviceRegistry }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
-      - image: {{ include "hono.image" ( dict "dot" . "component" .Values.deviceRegistryExample.fileBasedDeviceRegistry ) }}
+      - image: {{ include "hono.image" $args }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-service-device-registry
         ports:
@@ -66,7 +66,7 @@ spec:
         securityContext:
           privileged: false
         volumeMounts:
-        {{- include "hono.container.secretVolumeMounts" ( dict "name" $args.name "conf" .Values.deviceRegistryExample ) | indent 8 }}
+        {{- include "hono.container.secretVolumeMounts" ( dict "name" $args.name "componentConfig" .Values.deviceRegistryExample ) | indent 8 }}
         - name: "registry"
           mountPath: "/var/lib/hono/device-registry"
         {{- with .Values.deviceRegistryExample.resources }}
@@ -86,7 +86,7 @@ spec:
             scheme: HTTPS
           initialDelaySeconds: 10
       volumes:
-      {{- include "hono.pod.secretVolumes" ( dict "releaseName" .Release.Name "name" $args.name "conf" .Values.deviceRegistryExample ) | indent 6 }}
+      {{- include "hono.pod.secretVolumes" ( dict "dot" $args.dot "name" $args.name "componentConfig" .Values.deviceRegistryExample ) | indent 6 }}
       - name: "registry"
         persistentVolumeClaim:
           claimName: {{ printf "%s-%s" .Release.Name $args.name | quote }}

--- a/charts/hono/templates/hono-service-device-registry-jdbc/hono-service-device-registry-deployment.yaml
+++ b/charts/hono/templates/hono-service-device-registry-jdbc/hono-service-device-registry-deployment.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.deviceRegistryExample.enabled ( eq .Values.deviceRegistryExample.type "jdbc" ) }}
 #
-# Copyright (c) 2020 Contributors to the Eclipse Foundation
+# Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -11,7 +11,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
-{{- $args := dict "dot" . "component" "service-device-registry" "name" "service-device-registry" }}
+{{- $args := dict "dot" . "component" "service-device-registry" "name" "service-device-registry" "componentConfig" .Values.deviceRegistryExample.jdbcBasedDeviceRegistry }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
-      - image: {{ include "hono.image" ( dict "dot" . "component" .Values.deviceRegistryExample.jdbcBasedDeviceRegistry ) }}
+      - image: {{ include "hono.image" $args }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-service-device-registry
         ports:
@@ -63,7 +63,7 @@ spec:
         securityContext:
           privileged: false
         volumeMounts:
-        {{- include "hono.container.secretVolumeMounts" ( dict "name" $args.name "conf" .Values.deviceRegistryExample ) | indent 8 }}
+        {{- include "hono.container.secretVolumeMounts" ( dict "name" $args.name "componentConfig" .Values.deviceRegistryExample ) | indent 8 }}
         {{- with .Values.deviceRegistryExample.resources }}
         resources:
           {{- . | toYaml | nindent 10 }}
@@ -81,5 +81,5 @@ spec:
               scheme: HTTPS
             initialDelaySeconds: 100
       volumes:
-      {{- include "hono.pod.secretVolumes" ( dict "releaseName" .Release.Name "name" $args.name "conf" .Values.deviceRegistryExample ) | indent 6 }}
+      {{- include "hono.pod.secretVolumes" ( dict "dot" $args.dot "name" $args.name "componentConfig" .Values.deviceRegistryExample ) | indent 6 }}
 {{- end }}

--- a/charts/hono/templates/hono-service-device-registry-jdbc/hono-service-device-registry-deployment.yaml
+++ b/charts/hono/templates/hono-service-device-registry-jdbc/hono-service-device-registry-deployment.yaml
@@ -47,18 +47,13 @@ spec:
             containerPort: 5672
             protocol: TCP
         env:
-        - name: SPRING_CONFIG_LOCATION
-          value: file:///etc/hono/
-        - name: SPRING_PROFILES_ACTIVE
-          value: registry-adapter,registry-management,tenant-service,dev
-        - name: LOGGING_CONFIG
-          value: {{ default "classpath:logback-spring.xml" .Values.deviceRegistryExample.loggingConfig | quote }}
         - name: JDK_JAVA_OPTIONS
           value: {{ .Values.deviceRegistryExample.javaOptions | quote }}
         - name: KUBERNETES_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- include "hono.component.springEnv" $args | indent 8 }}
         {{- include "hono.jaeger.clientConf" $args | indent 8 }}
         securityContext:
           privileged: false

--- a/charts/hono/templates/hono-service-device-registry-mongodb/hono-service-device-registry-deployment.yaml
+++ b/charts/hono/templates/hono-service-device-registry-mongodb/hono-service-device-registry-deployment.yaml
@@ -11,7 +11,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
-{{- $args := dict "dot" . "component" "service-device-registry" "name" "service-device-registry" "componentConfig" .Values.deviceRegistryExample.mongoBasedDeviceRegistry }}
+{{- $args := dict "dot" . "component" "service-device-registry" "name" "service-device-registry" "componentConfig" .Values.deviceRegistryExample.mongoDBBasedDeviceRegistry }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -47,18 +47,13 @@ spec:
             containerPort: 5672
             protocol: TCP
         env:
-        - name: SPRING_CONFIG_LOCATION
-          value: file:///etc/hono/
-        - name: SPRING_PROFILES_ACTIVE
-          value: dev
-        - name: LOGGING_CONFIG
-          value: {{ default "classpath:logback-spring.xml" .Values.deviceRegistryExample.loggingConfig | quote }}
         - name: JDK_JAVA_OPTIONS
           value: {{ .Values.deviceRegistryExample.javaOptions | quote }}
         - name: KUBERNETES_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- include "hono.component.springEnv" $args | indent 8 }}
         {{- include "hono.jaeger.clientConf" $args | indent 8 }}
         securityContext:
           privileged: false

--- a/charts/hono/templates/hono-service-device-registry-mongodb/hono-service-device-registry-deployment.yaml
+++ b/charts/hono/templates/hono-service-device-registry-mongodb/hono-service-device-registry-deployment.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.deviceRegistryExample.enabled ( eq .Values.deviceRegistryExample.type "mongodb" ) }}
 #
-# Copyright (c) 2020 Contributors to the Eclipse Foundation
+# Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -11,7 +11,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
-{{- $args := dict "dot" . "component" "service-device-registry" "name" "service-device-registry" }}
+{{- $args := dict "dot" . "component" "service-device-registry" "name" "service-device-registry" "componentConfig" .Values.deviceRegistryExample.mongoBasedDeviceRegistry }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
-      - image: {{ include "hono.image" ( dict "dot" . "component" .Values.deviceRegistryExample.mongoDBBasedDeviceRegistry ) }}
+      - image: {{ include "hono.image" $args }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-service-device-registry
         ports:
@@ -63,7 +63,7 @@ spec:
         securityContext:
           privileged: false
         volumeMounts:
-        {{- include "hono.container.secretVolumeMounts" ( dict "name" $args.name "conf" .Values.deviceRegistryExample ) | indent 8 }}
+        {{- include "hono.container.secretVolumeMounts" ( dict "name" $args.name "componentConfig" .Values.deviceRegistryExample ) | indent 8 }}
         {{- with .Values.deviceRegistryExample.resources }}
         resources:
           {{- . | toYaml | nindent 10 }}
@@ -81,5 +81,5 @@ spec:
               scheme: HTTPS
             initialDelaySeconds: 100
       volumes:
-      {{- include "hono.pod.secretVolumes" ( dict "releaseName" .Release.Name "name" $args.name "conf" .Values.deviceRegistryExample ) | indent 6 }}
+      {{- include "hono.pod.secretVolumes" ( dict "dot" $args.dot "name" $args.name "componentConfig" .Values.deviceRegistryExample ) | indent 6 }}
 {{- end }}

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -113,7 +113,7 @@ amqpMessagingNetworkExample:
       # imageName contains the name (including tag) of the container
       # image to use for the example AMQP Messaging Network Broker
       imageName: quay.io/enmasse/artemis-base:2.13.0
-      # resources contains the container's 'requests and limits for CPU and memory
+      # resources contains the container's requests and limits for CPU and memory
       # as defined by the Kubernetes API.
       # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
       # for a description of the properties' semantics.
@@ -157,7 +157,7 @@ dataGridExample:
   # imageName contains the name (including tag)
   # of the container image to use for the example data grid.
   imageName: infinispan/server:11.0.7.Final-1
-  # resources contains the container's 'requests and limits for CPU and memory
+  # resources contains the container's requests and limits for CPU and memory
   # as defined by the Kubernetes API.
   # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
   # for a description of the properties' semantics.
@@ -201,7 +201,7 @@ jaegerBackendExample:
   # allInOneImage contains the name (including tag)
   # of the container image to use for the example Jaeger back end.
   allInOneImage: jaegertracing/all-in-one:1.21
-  # resources contains the container's 'requests and limits for CPU and memory
+  # resources contains the container's requests and limits for CPU and memory
   # as defined by the Kubernetes API.
   # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
   # for a description of the properties' semantics.
@@ -253,14 +253,12 @@ healthCheckPort: 8088
 # When setting to "openshift", Route resources will also be deployed.
 platform: kubernetes
 
-# Image type indicates which image will be used for services.
-# Supported values are:
+# honoImagesType indicates which kind of container image will be used for components
+# that are available in different variants. Supported values are:
 # - spring
 # - quarkus
 # - quarkus-native
-#
-# The default value is 'spring'
-honoImagesType: spring
+honoImagesType: "spring"
 
 # useLoadBalancer indicates whether services should be deployed using the
 # "LoadBalancer" type (true) or the "NodePort" type (false).
@@ -288,6 +286,12 @@ adapters:
   # using SASL PLAIN, i.e. an adapter needs to provide a username and password which
   # can be verified by the Auth Server component.
   externalAdaptersEnabled: false
+
+  # applicationProfiles contains the Spring application profiles that should be activated
+  # in all protocol adapters.
+  # The application profiles can be overridden per adapter using the corresponding
+  # "applicationProfiles" property at the adapter level.
+  applicationProfiles: "dev"
 
   # amqpMessagingNetworkSpec contains Hono client properties used by all protocol
   # adapters for connecting to the AMQP Messaging Network to forward downstream messages to.
@@ -382,7 +386,20 @@ adapters:
     # javaOptions contains options to pass to the JVM when starting
     # up the service
     javaOptions: -XX:MinRAMPercentage=80 -XX:MaxRAMPercentage=80
-    # resources contains the container's 'requests and limits for CPU and memory
+    # springConfigLocation contains the location of the Spring application configuration file(s).
+    # See https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config-files
+    # for details.
+    springConfigLocation: "file:///etc/hono/"
+    # loggingConfig contains the location of the logback configuration file that is used
+    # by the adapter.
+    # See https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-logging
+    # for details.
+    springLoggingConfig: "classpath:logback-spring.xml"
+    # applicationProfiles contains the Spring application profiles that should be activated
+    # in the adapter.
+    # If not specified explicitly, the profile set in "adapters.applicationProfiles" is used.
+    applicationProfiles:
+    # resources contains the container's requests and limits for CPU and memory
     # as defined by the Kubernetes API.
     # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
     # for a description of the properties' semantics.
@@ -455,7 +472,20 @@ adapters:
     # javaOptions contains options to pass to the JVM when starting
     # up the service
     javaOptions: -XX:MinRAMPercentage=80 -XX:MaxRAMPercentage=80
-    # resources contains the container's 'requests and limits for CPU and memory
+    # springConfigLocation contains the location of the Spring application configuration file(s).
+    # See https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config-files
+    # for details.
+    springConfigLocation: "file:///etc/hono/"
+    # loggingConfig contains the location of the logback configuration file that is used
+    # by the adapter.
+    # See https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-logging
+    # for details.
+    springLoggingConfig: "classpath:logback-spring.xml"
+    # applicationProfiles contains the Spring application profiles that should be activated
+    # in the adapter.
+    # If not specified explicitly, the profile set in "adapters.applicationProfiles" is used.
+    applicationProfiles:
+    # resources contains the container's requests and limits for CPU and memory
     # as defined by the Kubernetes API.
     # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
     # for a description of the properties' semantics.
@@ -519,7 +549,20 @@ adapters:
     # javaOptions contains options to pass to the JVM when starting
     # up the service
     javaOptions: -XX:MinRAMPercentage=80 -XX:MaxRAMPercentage=80
-    # resources contains the container's 'requests and limits for CPU and memory
+    # springConfigLocation contains the location of the Spring application configuration file(s).
+    # See https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config-files
+    # for details.
+    springConfigLocation: "file:///etc/hono/"
+    # loggingConfig contains the location of the logback configuration file that is used
+    # by the adapter.
+    # See https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-logging
+    # for details.
+    springLoggingConfig: "classpath:logback-spring.xml"
+    # applicationProfiles contains the Spring application profiles that should be activated
+    # in the adapter.
+    # If not specified explicitly, the profile set in "adapters.applicationProfiles" is used.
+    applicationProfiles:
+    # resources contains the container's requests and limits for CPU and memory
     # as defined by the Kubernetes API.
     # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
     # for a description of the properties' semantics.
@@ -592,7 +635,20 @@ adapters:
     # javaOptions contains options to pass to the JVM when starting
     # up the service
     javaOptions: -XX:MinRAMPercentage=80 -XX:MaxRAMPercentage=80
-    # resources contains the container's 'requests and limits for CPU and memory
+    # springConfigLocation contains the location of the Spring application configuration file(s).
+    # See https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config-files
+    # for details.
+    springConfigLocation: "file:///etc/hono/"
+    # loggingConfig contains the location of the logback configuration file that is used
+    # by the adapter.
+    # See https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-logging
+    # for details.
+    springLoggingConfig: "classpath:logback-spring.xml"
+    # applicationProfiles contains the Spring application profiles that should be activated
+    # in the adapter.
+    # If not specified explicitly, the profile set in "adapters.applicationProfiles" is used.
+    applicationProfiles:
+    # resources contains the container's requests and limits for CPU and memory
     # as defined by the Kubernetes API.
     # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
     # for a description of the properties' semantics.
@@ -665,7 +721,20 @@ adapters:
     # javaOptions contains options to pass to the JVM when starting
     # up the service
     javaOptions: -XX:MinRAMPercentage=80 -XX:MaxRAMPercentage=80
-    # resources contains the container's 'requests and limits for CPU and memory
+    # springConfigLocation contains the location of the Spring application configuration file(s).
+    # See https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config-files
+    # for details.
+    springConfigLocation: "file:///etc/hono/"
+    # loggingConfig contains the location of the logback configuration file that is used
+    # by the adapter.
+    # See https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-logging
+    # for details.
+    springLoggingConfig: "classpath:logback-spring.xml"
+    # applicationProfiles contains the Spring application profiles that should be activated
+    # in the adapter.
+    # If not specified explicitly, the profile set in "adapters.applicationProfiles" is used.
+    applicationProfiles:
+    # resources contains the container's requests and limits for CPU and memory
     # as defined by the Kubernetes API.
     # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
     # for a description of the properties' semantics.
@@ -737,7 +806,20 @@ adapters:
     # javaOptions contains options to pass to the JVM when starting
     # up the service
     javaOptions: -XX:MinRAMPercentage=80 -XX:MaxRAMPercentage=80
-    # resources contains the container's 'requests and limits for CPU and memory
+    # springConfigLocation contains the location of the Spring application configuration file(s).
+    # See https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config-files
+    # for details.
+    springConfigLocation: "file:///etc/hono/"
+    # loggingConfig contains the location of the logback configuration file that is used
+    # by the adapter.
+    # See https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-logging
+    # for details.
+    springLoggingConfig: "classpath:logback-spring.xml"
+    # applicationProfiles contains the Spring application profiles that should be activated
+    # in the adapter.
+    # If not specified explicitly, the profile set in "adapters.applicationProfiles" is used.
+    applicationProfiles:
+    # resources contains the container's requests and limits for CPU and memory
     # as defined by the Kubernetes API.
     # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
     # for a description of the properties' semantics.
@@ -810,7 +892,18 @@ authServer:
   # javaOptions contains options to pass to the JVM when starting
   # up the service
   javaOptions: -XX:MinRAMPercentage=80 -XX:MaxRAMPercentage=80
-  # resources contains the container's 'requests and limits for CPU and memory
+  # springConfigLocation contains the location of the Spring application configuration file(s).
+  # See https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config-files
+  # for details.
+  springConfigLocation: "file:///etc/hono/"
+  # loggingConfig contains the location of the logback configuration file that is used by the service.
+  # See https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-logging
+  # for details.
+  springLoggingConfig: "classpath:logback-spring.xml"
+  # applicationProfiles contains the Spring application profiles that should be activated
+  # in the service.
+  applicationProfiles: "authentication-impl,dev"
+  # resources contains the container's requests and limits for CPU and memory
   # as defined by the Kubernetes API.
   # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
   # for a description of the properties' semantics.
@@ -903,7 +996,7 @@ deviceRegistryExample:
   # javaOptions contains options to pass to the JVM when starting
   # up the service
   javaOptions: -XX:MinRAMPercentage=80 -XX:MaxRAMPercentage=80
-  # resources contains the container's 'requests and limits for CPU and memory
+  # resources contains the container's requests and limits for CPU and memory
   # as defined by the Kubernetes API.
   # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
   # for a description of the properties' semantics.
@@ -987,6 +1080,9 @@ deviceRegistryExample:
     # should be used for the example registry's persistent volume claim.
     # If not set, the cluster's default storage class is used.
     storageClass:
+    # applicationProfiles contains the Spring application profiles that should be activated
+    # in the service.
+    applicationProfiles: "dev"
 
   # mongoDBBasedDeviceRegistry contains configuration properties specific to the
   # MongoDB based device registry.
@@ -1001,6 +1097,9 @@ deviceRegistryExample:
     # the image from.
     # If not specified, the value of the "honoContainerRegistry" property is used.
     # containerRegistry:
+    # applicationProfiles contains the Spring application profiles that should be activated
+    # in the service.
+    applicationProfiles: "dev"
     # mongodb contains the configuration properties to connect to the MongoDB database instance.
     # If you would like to use an already existing MongoDB database instance, then configure
     # the below section accordingly.
@@ -1029,6 +1128,9 @@ deviceRegistryExample:
     # the image from.
     # If not specified, the value of the "honoContainerRegistry" property is used.
     # containerRegistry:
+    # applicationProfiles contains the Spring application profiles that should be activated
+    # in the service.
+    applicationProfiles: "registry-adapter,registry-management,tenant-service,dev"
     # registry.jdbc contains the configuration properties for device registry
     # to connect to the database.
     registry:
@@ -1143,7 +1245,18 @@ deviceConnectionService:
   # javaOptions contains options to pass to the JVM when starting
   # up the service
   javaOptions: -XX:MinRAMPercentage=80 -XX:MaxRAMPercentage=80
-  # resources contains the container's 'requests and limits for CPU and memory
+  # springConfigLocation contains the location of the Spring application configuration file(s).
+  # See https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config-files
+  # for details.
+  springConfigLocation: "file:///etc/hono/"
+  # loggingConfig contains the location of the logback configuration file that is used by the service.
+  # See https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-logging
+  # for details.
+  springLoggingConfig: "classpath:logback-spring.xml"
+  # applicationProfiles contains the Spring application profiles that should be activated
+  # in the service.
+  applicationProfiles: "dev"
+  # resources contains the container's requests and limits for CPU and memory
   # as defined by the Kubernetes API.
   # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
   # for a description of the properties' semantics.


### PR DESCRIPTION
The application profiles that should be active for the (Spring based)
adapters and services as well as the Spring Boot and logging config file
locations can now be configured via properties of the values.yaml file.