### PR TITLE
Update to latest kubernetes version(s)

### DIFF
--- a/.github/kind-config.yaml
+++ b/.github/kind-config.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -10,7 +10,7 @@
 # SPDX-License-Identifier: EPL-2.0
 
 kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha3
+apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 # the control plane node config
 - role: control-plane

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,8 +51,6 @@ jobs:
         # which a folder exists at
         # https://github.com/instrumenta/kubernetes-json-schema
         k8s:
-          - v1.13.11
-          - v1.14.9
           - v1.15.7
           - v1.16.4
           - v1.17.4
@@ -79,19 +77,19 @@ jobs:
         # the versions supported by chart-testing are the tags
         # available for the docker.io/kindest/node image
         # https://hub.docker.com/r/kindest/node/tags
-          - v1.13.12
-          - v1.14.10
-          - v1.15.11
-          - v1.16.9
-          - v1.17.5
-          - v1.18.4
+          - v1.15.12
+          - v1.16.15
+          - v1.17.11
+          - v1.18.8
+          - v1.19.4
+          - v1.20.0
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Fetch history for chart testing
         run: git fetch --prune --unshallow
       - name: Create kind ${{ matrix.k8s }} cluster
-        uses: helm/kind-action@v1.0.0-alpha.3
+        uses: helm/kind-action@v1.1.0
         with:
           config: .github/kind-config.yaml
           node_image: kindest/node:${{ matrix.k8s }}


### PR DESCRIPTION
The chart linter and kind deploy confiugrations have been updated to the
latest kubernetes versions.
The helm/kind-action has been upgraded to the latest minor version
(1.1.0).
