### PR TITLE
allow to set qdrouterd.json location through values.yaml of Hono chart

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.4.21
+version: 1.4.22
 # Version of Hono being deployed by the chart
 appVersion: 1.5.1
 keywords:

--- a/charts/hono/templates/dispatch-router/dispatch-router-deployment.yaml
+++ b/charts/hono/templates/dispatch-router/dispatch-router-deployment.yaml
@@ -32,7 +32,7 @@ spec:
         command:
         - /sbin/qdrouterd
         - -c
-        - /etc/hono/qdrouterd.json
+        - {{ .Values.amqpMessagingNetworkExample.dispatchRouter.configPath }}
         env:
         - name: KUBERNETES_NAMESPACE
           valueFrom:

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -48,6 +48,10 @@ amqpMessagingNetworkExample:
 
   # dispatchRouter contains properties for configuring the QPid Dispatch Router
   dispatchRouter:
+    # configPath contains the path to the configuration file of the
+    # Qpid Dispatch Router configuration file
+    # See http://qpid.apache.org/releases/qpid-dispatch-1.10.0/man/qdrouterd.conf.html
+    configPath: /etc/hono/qdrouterd.json
     # imageName contains the name (including tag) of the container image
     # to use for the example AMQP Messaging Network's Dispatch Router.
     imageName: quay.io/interconnectedcloud/qdrouterd:1.14.0


### PR DESCRIPTION
As indicated in the title, this PR adds the option to set the qdrouterd.json file location from the values.yaml of the Hono chart. The default values is the previously hard-coded value from the dispatch-router-deployment.yaml file.