### PR TITLE
[#152] Use Mongo DB based device registry by default

### DIFF
--- a/packages/cloud2edge/Chart.yaml
+++ b/packages/cloud2edge/Chart.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Contributors to the Eclipse Foundation
+# Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -11,8 +11,8 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 apiVersion: v1
-version: 0.1.2
-appVersion: 0.1.2
+version: 0.1.3
+appVersion: 0.1.3
 name: cloud2edge
 description: |
   Eclipse IoT Cloud2Edge (C2E) is an integrated suite of services developers can use to build IoT applications

--- a/packages/cloud2edge/requirements.yaml
+++ b/packages/cloud2edge/requirements.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Contributors to the Eclipse Foundation
+# Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -12,8 +12,8 @@
 #
 dependencies:
   - name: hono
-    version: ~1.3.19
+    version: ~1.4.21
     repository: "https://eclipse.org/packages/charts/"
   - name: ditto
-    version: ~1.3.0
+    version: ~1.5.1
     repository: "https://eclipse.org/packages/charts/"

--- a/packages/cloud2edge/values.yaml
+++ b/packages/cloud2edge/values.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Contributors to the Eclipse Foundation
+# Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -23,6 +23,8 @@ honoConnection:
 # Configuration properties for Eclipse Hono.
 hono:
 
+  livenessProbeInitialDelaySeconds: 900
+  readinessProbeInitialDelaySeconds: 45
   useLoadBalancer: false
 
   prometheus:
@@ -35,11 +37,12 @@ hono:
     dispatchRouter:
       resources:
         requests:
-          cpu: 150m
+          cpu: 200m
     broker:
-      resources:
-        requests:
-          cpu: 150m
+      artemis:
+        resources:
+          requests:
+            cpu: 200m
 
   authServer:
     extraSecretMounts:
@@ -57,23 +60,29 @@ hono:
             tokenExpiration: 3600
 
   deviceRegistryExample:
+    type: mongodb
     resources:
       requests:
-        cpu: 150m
+        cpu: 200m
+    mongoDBBasedDeviceRegistry:
+      mongodb:
+        host: ditto-mongodb
+        port: 27017
+        dbName: hono
 
   adapters:
     amqp:
       resources:
         requests:
-          cpu: 150m
+          cpu: 200m
     http:
       resources:
         requests:
-          cpu: 150m
+          cpu: 200m
     mqtt:
       resources:
         requests:
-          cpu: 150m
+          cpu: 200m
 
 
 # Configuration properties for Eclipse Ditto.
@@ -82,7 +91,7 @@ ditto:
   concierge:
     resources:
       requests:
-        cpu: 150m
+        cpu: 200m
       limits:
         cpu: 1
         memory: "512Mi"
@@ -90,7 +99,7 @@ ditto:
   connectivity:
     resources:
       requests:
-        cpu: 150m
+        cpu: 200m
       limits:
         cpu: 1
         memory: "512Mi"
@@ -98,7 +107,7 @@ ditto:
   gateway:
     resources:
       requests:
-        cpu: 150m
+        cpu: 200m
       limits:
         cpu: 1
         memory: "512Mi"
@@ -116,7 +125,7 @@ ditto:
   policies:
     resources:
       requests:
-        cpu: 150m
+        cpu: 200m
       limits:
         cpu: 1
         memory: "512Mi"
@@ -132,7 +141,7 @@ ditto:
   things:
     resources:
       requests:
-        cpu: 150m
+        cpu: 200m
       limits:
         cpu: 1
         memory: "512Mi"
@@ -140,7 +149,7 @@ ditto:
   thingsSearch:
     resources:
       requests:
-        cpu: 150m
+        cpu: 200m
       limits:
         cpu: 1
         memory: "512Mi"
@@ -148,7 +157,7 @@ ditto:
   mongodb:
     resources:
       requests:
-        cpu: 150m
+        cpu: 250m
         memory: "256Mi"
       limits:
         cpu: 1


### PR DESCRIPTION
The Hono chart's registry is now configured to use Ditto's Mongo DB
instance.