### PR TITLE
add 'subPath' support for secretVolumeMounts in Hono chart

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.4.22
+version: 1.4.23
 # Version of Hono being deployed by the chart
 appVersion: 1.5.1
 keywords:

--- a/charts/hono/templates/_helpers.tpl
+++ b/charts/hono/templates/_helpers.tpl
@@ -442,6 +442,9 @@ The scope passed in is expected to be a dict with keys
 {{- range $name,$spec := . }}
 - name: {{ $name | quote }}
   mountPath: {{ $spec.mountPath | quote }}
+{{- if $spec.subPath }}
+  subPath: {{ $spec.subPath | quote }}
+{{- end }}
   readOnly: true
 {{- end }}
 {{- end }}


### PR DESCRIPTION
This PR extends the 'defineSecretVolumeMounts' in the _helpers.tpl used within the Hono chart to also consider the 'subPath' property.

Note, since the previous PR #187 increases the version field to 1.4.22, this PR already sets the version to 1.4.23. Therefore, I propose to merge the other PR (#187) before this PR. 