### PR TITLE
Add messaging config for device registries

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.4.23
+version: 1.4.24
 # Version of Hono being deployed by the chart
 appVersion: 1.5.1
 keywords:

--- a/charts/hono/templates/_helpers.tpl
+++ b/charts/hono/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -161,16 +161,15 @@ healthCheck:
 
 
 {{/*
-Configuration for the service clients of protocol adapters.
+Configuration for the AMQP messaging network clients.
 The scope passed in is expected to be a dict with keys
-- "dot": the root scope (".") and
-- "component": the name of the adapter
+- (mandatory) "dot": the root scope (".") and
+- (mandatory) "component": the name of the component
 */}}
-{{- define "hono.serviceClientConfig" -}}
-{{- $adapter := default "adapter" .component -}}
+{{- define "hono.amqpMessagingNetworkClientConfig" -}}
 messaging:
 {{- if .dot.Values.amqpMessagingNetworkExample.enabled }}
-  name: Hono {{ $adapter }}
+  name: Hono {{ .component }}
   amqpHostname: hono-internal
   host: {{ .dot.Release.Name }}-dispatch-router
   port: 5673
@@ -179,8 +178,20 @@ messaging:
   trustStorePath: {{ .dot.Values.adapters.amqpMessagingNetworkSpec.trustStorePath }}
   hostnameVerificationRequired: {{ .dot.Values.adapters.amqpMessagingNetworkSpec.hostnameVerificationRequired }}
 {{- else }}
-  {{- required ".Values.adapters.amqpMessagingNetworkSpec MUST be set if example AQMP Messaging Network is disabled" .dot.Values.adapters.amqpMessagingNetworkSpec | toYaml | nindent 2 }}
+  {{- required ".Values.adapters.amqpMessagingNetworkSpec MUST be set if example AMQP Messaging Network is disabled" .dot.Values.adapters.amqpMessagingNetworkSpec | toYaml | nindent 2 }}
 {{- end }}
+{{- end }}
+
+
+{{/*
+Configuration for the service clients of protocol adapters.
+The scope passed in is expected to be a dict with keys
+- (mandatory) "dot": the root scope (".") and
+- (optional) "component": the name of the adapter
+*/}}
+{{- define "hono.serviceClientConfig" -}}
+{{- $adapter := default "adapter" .component -}}
+{{- include "hono.amqpMessagingNetworkClientConfig" ( dict "dot" .dot "component" $adapter ) }}
 command:
 {{- if .dot.Values.amqpMessagingNetworkExample.enabled }}
   name: Hono {{ $adapter }}
@@ -192,7 +203,7 @@ command:
   trustStorePath: {{ .dot.Values.adapters.commandAndControlSpec.trustStorePath }}
   hostnameVerificationRequired: {{ .dot.Values.adapters.commandAndControlSpec.hostnameVerificationRequired }}
 {{- else }}
-  {{- required ".Values.adapters.commandAndControlSpec MUST be set if example AQMP Messaging Network is disabled" .dot.Values.adapters.commandAndControlSpec | toYaml | nindent 2 }}
+  {{- required ".Values.adapters.commandAndControlSpec MUST be set if example AMQP Messaging Network is disabled" .dot.Values.adapters.commandAndControlSpec | toYaml | nindent 2 }}
 {{- end }}
 tenant:
 {{- if .dot.Values.deviceRegistryExample.enabled }}

--- a/charts/hono/templates/hono-service-device-registry-file/hono-service-device-registry-secret.yaml
+++ b/charts/hono/templates/hono-service-device-registry-file/hono-service-device-registry-secret.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.deviceRegistryExample.enabled ( eq .Values.deviceRegistryExample.type "file" ) }}
 #
-# Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -67,6 +67,7 @@ stringData:
         svc:
           filename: "/var/lib/hono/device-registry/tenants.json"
           saveToFile: true
+      {{- include "hono.amqpMessagingNetworkClientConfig" $args | nindent 6 }}
       {{- include "hono.healthServerConfig" .Values.deviceRegistryExample.hono.healthCheck | nindent 6 }}
 data:
   key.pem: {{ .Files.Get "example/certs/device-registry-key.pem" | b64enc }}

--- a/charts/hono/templates/hono-service-device-registry-jdbc/hono-service-device-registry-secret.yaml
+++ b/charts/hono/templates/hono-service-device-registry-jdbc/hono-service-device-registry-secret.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.deviceRegistryExample.enabled ( eq .Values.deviceRegistryExample.type "jdbc" ) }}
 #
-# Copyright (c) 2020 Contributors to the Eclipse Foundation
+# Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -66,6 +66,7 @@ stringData:
           {{- if .Values.deviceRegistryExample.jdbcBasedDeviceRegistry.tenant.jdbc }}
           {{- .Values.deviceRegistryExample.jdbcBasedDeviceRegistry.tenant.jdbc | toYaml | nindent 10 }}
           {{- end }}
+      {{- include "hono.amqpMessagingNetworkClientConfig" $args | nindent 6 }}
       {{- include "hono.healthServerConfig" .Values.deviceRegistryExample.hono.healthCheck | nindent 6 }}
 data:
   key.pem: {{ .Files.Get "example/certs/device-registry-key.pem" | b64enc }}

--- a/charts/hono/templates/hono-service-device-registry-mongodb/hono-service-device-registry-secret.yaml
+++ b/charts/hono/templates/hono-service-device-registry-mongodb/hono-service-device-registry-secret.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.deviceRegistryExample.enabled ( eq .Values.deviceRegistryExample.type "mongodb" ) }}
 #
-# Copyright (c) 2020 Contributors to the Eclipse Foundation
+# Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -67,6 +67,7 @@ stringData:
         username: {{ .Values.mongodb.mongodbUsername | quote }}
         password: {{ .Values.mongodb.mongodbPassword | quote }}
         {{- end }}
+      {{- include "hono.amqpMessagingNetworkClientConfig" $args | nindent 6 }}
       {{- include "hono.healthServerConfig" .Values.deviceRegistryExample.hono.healthCheck | nindent 6 }}
 data:
   key.pem: {{ .Files.Get "example/certs/device-registry-key.pem" | b64enc }}


### PR DESCRIPTION
The gateway-based auto-provisioning feature requires that the device registry connects to the AMQP messaging network. The necessary configuration is added here.

This is a preparation for Hono 1.6.