### PR TITLE
fixed nginx CORS config for Ditto chart

### DIFF
--- a/charts/ditto/Chart.yaml
+++ b/charts/ditto/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids,
   EV charging stations etc).
-version: 1.5.2
+version: 1.5.3
 appVersion: 1.5.1
 keywords:
   - iot-chart

--- a/charts/ditto/nginx-config/nginx-cors.conf
+++ b/charts/ditto/nginx-config/nginx-cors.conf
@@ -28,20 +28,22 @@ if ($request_method = 'OPTIONS') {
 }
 
 if ($cors = '1') {
-  add_header 'Access-Control-Allow-Origin' '*' always;
-  add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
+  add_header 'Access-Control-Allow-Origin' '$http_origin' always;
+  add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, PATCH, DELETE, OPTIONS' always;
   add_header 'Access-Control-Allow-Credentials' 'true' always;
-  add_header 'Access-Control-Allow-Headers' 'Accept,Authorization,Cache-Control,Content-Type,Content-Length,DNT,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Origin,User-Agent,X-Requested-With' always;
+  add_header 'Access-Control-Allow-Headers' '$http_access_control_request_headers' always;
+  add_header 'Access-Control-Expose-Headers' '*' always;
 }
 
 # OPTIONS (pre-flight) request from allowed CORS domain. return response directly
 if ($cors = '1o') {
   # Tell client that this pre-flight info is valid for 20 days
   add_header 'Access-Control-Max-Age' 1728000;
-  add_header 'Access-Control-Allow-Origin' '*' always;
-  add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
+  add_header 'Access-Control-Allow-Origin' '$http_origin' always;
+  add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, PATCH, DELETE, OPTIONS' always;
   add_header 'Access-Control-Allow-Credentials' 'true' always;
-  add_header 'Access-Control-Allow-Headers' 'Accept,Authorization,Cache-Control,Content-Type,Content-Length,DNT,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Origin,User-Agent,X-Requested-With' always;
+  add_header 'Access-Control-Allow-Headers' '$http_access_control_request_headers' always;
+  add_header 'Access-Control-Expose-Headers' '*' always;
   add_header 'Content-Type' 'text/plain charset=UTF-8';
   add_header 'Content-Length' 0;
   return 200;

--- a/charts/ditto/templates/swaggerui-deployment.yaml
+++ b/charts/ditto/templates/swaggerui-deployment.yaml
@@ -18,7 +18,6 @@ metadata:
     app.kubernetes.io/name: {{ include "ditto.name" . }}-swaggerui
 {{ include "ditto.labels" . | indent 4 }}
 spec:
-spec:
   replicas: {{ .Values.swaggerui.replicaCount }}
   strategy:
   {{- with .Values.swaggerui.updateStrategy }}


### PR DESCRIPTION
* for some browsers, usage of "*" for "Access-Control-Allow-Origin" is forbidden - fix that
* add "PATCH" verb
* white-list all HTTP headers