### PR TITLE
[#198] Fix 'command-router' cache not being defined

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.5.2
+version: 1.5.3
 # Version of Hono being deployed by the chart
 appVersion: 1.6.0
 keywords:

--- a/charts/hono/config/infinispan/hono-data-grid.xml
+++ b/charts/hono/config/infinispan/hono-data-grid.xml
@@ -14,7 +14,7 @@
         <role name="adapter" permissions="READ WRITE" />
       </authorization>
     </security>
-    <distributed-cache name="device-connection">
+    <distributed-cache name="{{ if .Values.useCommandRouter }}command-router{{ else }}device-connection{{ end }}">
       <encoding>
         <key media-type="text/plain" />
         <value media-type="text/plain" />


### PR DESCRIPTION
This fixes #198.