### PR TITLE
[#200] Fix Artemis startup in OpenShift

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.5.3
+version: 1.5.4
 # Version of Hono being deployed by the chart
 appVersion: 1.6.0
 keywords:

--- a/charts/hono/config/artemis/broker.xml
+++ b/charts/hono/config/artemis/broker.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 
 <!--
-    Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
+    Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
    
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -96,7 +96,7 @@
          <!--<acceptor name="amqp">tcp://0.0.0.0:5672?protocols=AMQP</acceptor>-->
          <acceptor name="amqps">
              tcp://0.0.0.0:5671?protocols=AMQP;sslEnabled=true;
-             keyStorePath=file:/var/run/artemis/custom/etc/artemisKeyStore.p12;keyStorePassword=artemiskeys;
+             keyStorePath=file:/run/artemis/split-1/custom/etc/artemisKeyStore.p12;keyStorePassword=artemiskeys;
          </acceptor>
 
       </acceptors>

--- a/charts/hono/templates/artemis/artemis-deployment.yaml
+++ b/charts/hono/templates/artemis/artemis-deployment.yaml
@@ -35,7 +35,7 @@ spec:
         - name: AMQ_NAME
           value: custom
         - name: HOME
-          value: /var/run/artemis/
+          value: /run/artemis/split-1/
         - name: JAVA_INITIAL_MEM_RATIO
           value: "30"
         - name: JAVA_MAX_MEM_RATIO

--- a/charts/hono/templates/dispatch-router/dispatch-router-route.yaml
+++ b/charts/hono/templates/dispatch-router/dispatch-router-route.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.amqpMessagingNetworkExample.enabled (eq .Values.platform "openshift") }}
 #
-# Copyright (c) 2019 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -11,7 +11,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
-apiVersion: v1
+apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   {{- $args := dict "dot" . "component" "amqp-messaging-network-router" "name" "dispatch-router" }}


### PR DESCRIPTION
This fixes #200:
Using the HOME env variable value used in the Artemis image to prevent errors creating the /var/run/artemis/custom
directory as a non-root user in OpenShift.
Also fixing the Qdrouter Route definition.
