### PR TITLE
[#202] Enable Hono Device Connection service

### DIFF
--- a/packages/cloud2edge/Chart.yaml
+++ b/packages/cloud2edge/Chart.yaml
@@ -11,8 +11,8 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 apiVersion: v1
-version: 0.1.3
-appVersion: 0.1.3
+version: 0.1.4
+appVersion: 0.1.4
 name: cloud2edge
 description: |
   Eclipse IoT Cloud2Edge (C2E) is an integrated suite of services developers can use to build IoT applications

--- a/packages/cloud2edge/requirements.yaml
+++ b/packages/cloud2edge/requirements.yaml
@@ -12,7 +12,7 @@
 #
 dependencies:
   - name: hono
-    version: ~1.4.21
+    version: ~1.5.4
     repository: "https://eclipse.org/packages/charts/"
   - name: ditto
     version: ~1.5.1

--- a/packages/cloud2edge/values.yaml
+++ b/packages/cloud2edge/values.yaml
@@ -70,6 +70,9 @@ hono:
         port: 27017
         dbName: hono
 
+  deviceConnectionService:
+    enabled: true
+
   adapters:
     amqp:
       resources:


### PR DESCRIPTION
This fixes #202:
With the switch to the Hono MongoDB-based device registry (not containing a device connection service implementation like the file-based one does) in the cloud2edge chart (#152), there is no device connection service implementation getting deployed anymore, leading to Hono command & control errors. 

Therefore the "deviceConnectionService.enabled" option is set here to deploy the device connection service component, using an embedded cache (newer Hono chart version needed for that).