### PR TITLE
fixed device registry http route wrongly pointing to amqps endpoint

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.5.6
+version: 1.5.7
 # Version of Hono being deployed by the chart
 appVersion: 1.6.0
 keywords:

--- a/charts/hono/templates/hono-service-device-registry-base/hono-service-device-registry-http-route.yaml
+++ b/charts/hono/templates/hono-service-device-registry-base/hono-service-device-registry-http-route.yaml
@@ -18,7 +18,7 @@ metadata:
   {{- include "hono.metadata" $args | nindent 2 }}
 spec:
   port:
-    targetPort: amqps
+    targetPort: http
   to:
     kind: Service
     name: {{ .Release.Name }}-service-device-registry


### PR DESCRIPTION
The http device registry route was pointing to the `amqps` endpoint, which should point to the `http` endpoint. 
Tested on okd 4.7 with `curl`.