### PR TITLE
Update Hono to 1.7.0

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,9 +15,9 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.6.0
+version: 1.7.0
 # Version of Hono being deployed by the chart
-appVersion: 1.6.1
+appVersion: 1.7.0
 keywords:
   - iot-chart
   - IoT

--- a/charts/hono/README.md
+++ b/charts/hono/README.md
@@ -353,54 +353,20 @@ In Hono a place is needed where information about the connection status of devic
 This kind of information is used for determining how [command & control](https://www.eclipse.org/hono/docs/concepts/command-and-control/) messages, 
 sent by business applications, can be routed to the protocol adapters that the target devices are connected to.
 
-### Alternative A: Using the deprecated Device Connection API (default)
-
-The [Device Connection API](https://www.eclipse.org/hono/docs/api/device-connection/) defines a service interface
-that protocol adapters can use to store, update and retrieve information about the connection status of devices dynamically during runtime.
-
-#### Example Implementation
-
-Hono's example Device Registry component contains a simple in-memory implementation of the Device Connection API.
-This example implementation is used by default when the example registry is deployed.
-
-#### Data Grid based Implementation
-
-Hono also contains a production ready, data grid based implementation of the Device Connection API which can be deployed
-and used instead of the example implementation. The component can be deployed by means of setting the
-*deviceConnectionService.enabled* property to `true`.
-
-The service requires a connection to a data grid for storing the device connection data.
-The Helm chart supports deployment of an example data grid which can be used for experimenting by means of setting the
-*dataGridExample.enabled* property to `true`:
-
-```bash
-helm install --dependency-update -n hono --set deviceConnectionService.enabled=true --set dataGridExample.enabled=true eclipse-hono eclipse-iot/hono 
-```
-
-This will deploy the data grid based Device Connection service and configure all protocol adapters to use it instead of
-the example Device Registry implementation.
-
-The Device Connection service can also be configured to connect to an already existing data grid. Use the *dataGridSpec*
-property for this.
-
-Setting the *deviceConnectionService.enabled* property to `true` and neither setting *dataGridExample.enabled* to `true`
-nor configuring an already existing data grid using the *dataGridSpec* property will result in the Device Connection
-service using an embedded cache for storage. This is a lightweight deployment option but not suitable for production purposes.
-
-### Alternative B: Using the new Command Router API
+### Alternative A: Using the Command Router API (default)
 
 Hono's protocol adapters can use the [Command Router API](https://www.eclipse.org/hono/docs/api/command-router/) to supply
 device connection information with which a Command Router service component can route command & control messages to the
 protocol adapters that the target devices are connected to.
 
-The Command Router API will replace the now deprecated Device Connection API. The Command Router service component is provided as a tech preview.
+The Command Router API will replace the now deprecated Device Connection API.
 
 #### Example with file-based storage in a persistent volume
 
-In order to use the Command Router API, the *useCommandRouter* property has to be set to `true` when deploying the Helm chart.
+The Command Router API is used by default when deploying the Helm chart.
 
 ```bash
-helm install --dependency-update -n hono --set useCommandRouter=true eclipse-hono eclipse-iot/hono 
+helm install --dependency-update -n hono eclipse-hono eclipse-iot/hono 
 ```
 
 This will let the Command Router service component use an embedded cache with file-based persistence for the device
@@ -416,13 +382,54 @@ The Helm chart supports deployment of an example data grid which can be used for
 *dataGridExample.enabled* property to `true`:
 
 ```bash
-helm install --dependency-update -n hono --set useCommandRouter=true --set dataGridExample.enabled=true eclipse-hono eclipse-iot/hono 
+helm install --dependency-update -n hono --set dataGridExample.enabled=true eclipse-hono eclipse-iot/hono 
 ```
 
 This will deploy the data grid based Command Router service component.
 
 The Command Router service component can also be configured to connect to an already existing data grid. Use the *dataGridSpec*
 property for this.
+
+### Alternative B: Using the deprecated Device Connection API
+
+The [Device Connection API](https://www.eclipse.org/hono/docs/api/device-connection/) defines a service interface
+that protocol adapters can use to store, update and retrieve information about the connection status of devices dynamically during runtime.
+
+The Device Connection API is deprecated and will be replaced by the Command Router API.
+In order to use the Device Connection API, the *useCommandRouter* property has to be set to `false` when deploying the Helm chart.
+
+```bash
+helm install --dependency-update -n hono --set useCommandRouter=false eclipse-hono eclipse-iot/hono 
+```
+
+#### Example Implementation
+
+Hono's example Device Registry component contains a simple in-memory implementation of the Device Connection API.
+This example implementation is used by default when the example registry is deployed and the *useCommandRouter* property is set to `false`.
+
+#### Data Grid based Implementation
+
+Hono also contains a production ready, data grid based implementation of the Device Connection API which can be deployed
+and used instead of the example implementation. The component can be deployed by means of setting the
+*deviceConnectionService.enabled* property to `true`.
+
+The service requires a connection to a data grid for storing the device connection data.
+The Helm chart supports deployment of an example data grid which can be used for experimenting by means of setting the
+*dataGridExample.enabled* property to `true`:
+
+```bash
+helm install --dependency-update -n hono --set useCommandRouter=false --set deviceConnectionService.enabled=true --set dataGridExample.enabled=true eclipse-hono eclipse-iot/hono 
+```
+
+This will deploy the data grid based Device Connection service and configure all protocol adapters to use it instead of
+the example Device Registry implementation.
+
+The Device Connection service can also be configured to connect to an already existing data grid. Use the *dataGridSpec*
+property for this.
+
+Setting the *deviceConnectionService.enabled* property to `true` and neither setting *dataGridExample.enabled* to `true`
+nor configuring an already existing data grid using the *dataGridSpec* property will result in the Device Connection
+service using an embedded cache for storage. This is a lightweight deployment option but not suitable for production purposes.
 
 ## Enabling or disabling Protocol Adapters
 

--- a/charts/hono/example/example-permissions.json
+++ b/charts/hono/example/example-permissions.json
@@ -56,6 +56,14 @@
     ],
     "command-router": [
       {
+        "resource": "tenant",
+        "activities": [ "READ", "WRITE" ]
+      },
+      {
+        "operation": "tenant/*:*",
+        "activities": [ "EXECUTE" ]
+      },
+      {
         "resource": "registration/*",
         "activities": [ "READ", "WRITE" ]
       },

--- a/charts/hono/templates/_helpers.tpl
+++ b/charts/hono/templates/_helpers.tpl
@@ -195,6 +195,22 @@ messaging:
 
 
 {{/*
+Configuration for the clients accessing the example Device Registry.
+The scope passed in is expected to be a dict with keys
+- (mandatory) "dot": the root scope (".") and
+- (mandatory) "component": the name of the component
+*/}}
+{{- define "hono.deviceRegistryExampleClientConfig" -}}
+name: Hono {{ .component }}
+host: {{ .dot.Release.Name }}-service-device-registry
+port: 5671
+credentialsPath: /etc/hono/adapter.credentials
+trustStorePath: /etc/hono/trusted-certs.pem
+hostnameVerificationRequired: false
+{{- end }}
+
+
+{{/*
 Configuration for the service clients of protocol adapters.
 The scope passed in is expected to be a dict with keys
 - (mandatory) "dot": the root scope (".") and
@@ -220,12 +236,7 @@ tenant:
 {{- if .dot.Values.adapters.tenantSpec }}
   {{- .dot.Values.adapters.tenantSpec | toYaml | nindent 2 }}
 {{- else if .dot.Values.deviceRegistryExample.enabled }}
-  name: Hono {{ $adapter }}
-  host: {{ .dot.Release.Name }}-service-device-registry
-  port: 5671
-  credentialsPath: /etc/hono/adapter.credentials
-  trustStorePath: /etc/hono/trusted-certs.pem
-  hostnameVerificationRequired: false
+  {{- include "hono.deviceRegistryExampleClientConfig" ( dict "dot" .dot "component" $adapter ) | nindent 2 }}
 {{- else }}
   {{- required ".Values.adapters.tenantSpec MUST be set if example Device Registry is disabled" .dot.Values.adapters.tenantSpec | toYaml | nindent 2 }}
 {{- end }}
@@ -233,12 +244,7 @@ registration:
 {{- if .dot.Values.adapters.deviceRegistrationSpec }}
   {{- .dot.Values.adapters.deviceRegistrationSpec | toYaml | nindent 2 }}
 {{- else if .dot.Values.deviceRegistryExample.enabled }}
-  name: Hono {{ $adapter }}
-  host: {{ .dot.Release.Name }}-service-device-registry
-  port: 5671
-  credentialsPath: /etc/hono/adapter.credentials
-  trustStorePath: /etc/hono/trusted-certs.pem
-  hostnameVerificationRequired: false
+  {{- include "hono.deviceRegistryExampleClientConfig" ( dict "dot" .dot "component" $adapter ) | nindent 2 }}
 {{- else }}
   {{- required ".Values.adapters.deviceRegistrationSpec MUST be set if example Device Registry is disabled" .dot.Values.adapters.deviceRegistrationSpec | toYaml | nindent 2 }}
 {{- end }}
@@ -246,12 +252,7 @@ credentials:
 {{- if .dot.Values.adapters.credentialsSpec }}
   {{- .dot.Values.adapters.credentialsSpec | toYaml | nindent 2 }}
 {{- else if .dot.Values.deviceRegistryExample.enabled }}
-  name: Hono {{ $adapter }}
-  host: {{ .dot.Release.Name }}-service-device-registry
-  port: 5671
-  credentialsPath: /etc/hono/adapter.credentials
-  trustStorePath: /etc/hono/trusted-certs.pem
-  hostnameVerificationRequired: false
+  {{- include "hono.deviceRegistryExampleClientConfig" ( dict "dot" .dot "component" $adapter ) | nindent 2 }}
 {{- else }}
   {{- required ".Values.adapters.credentialsSpec MUST be set if example Device Registry is disabled" .dot.Values.adapters.credentialsSpec | toYaml | nindent 2 }}
 {{- end }}

--- a/charts/hono/templates/_helpers.tpl
+++ b/charts/hono/templates/_helpers.tpl
@@ -403,10 +403,13 @@ Adds a Jaeger Agent container to a template spec.
   - name: agent-configs
     containerPort: 5778
     protocol: TCP
+  - name: admin-http
+    containerPort: 14271
+    protocol: TCP
   readinessProbe:
     httpGet:
       path: "/"
-      port: 14271
+      port: admin-http
     initialDelaySeconds: 5
   env:
   {{- if .Values.jaegerBackendExample.enabled }}

--- a/charts/hono/templates/hono-service-command-router/hono-service-command-router-deployment.yaml
+++ b/charts/hono/templates/hono-service-command-router/hono-service-command-router-deployment.yaml
@@ -11,7 +11,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
-{{- $args := dict "dot" . "component" "service-command-router" "name" "service-command-router" "componentConfig" .Values.commandRouterService }}
+{{- $args := dict "dot" . "component" "service-command-router" "name" "service-command-router" "componentConfig" .Values.commandRouterService "useImageType" true }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -49,7 +49,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        {{- include "hono.component.springEnv" ( merge $args ( dict "additionalProfile" ( ( or .Values.dataGridSpec .Values.dataGridExample.enabled ) | ternary "" "embedded-cache" ) ) ) | indent 8 }}
+        {{- include "hono.component.springEnv" $args | indent 8 }}
         {{- include "hono.jaeger.clientConf" $args | indent 8 }}
         volumeMounts:
         {{- include "hono.container.secretVolumeMounts" $args | indent 8 }}

--- a/charts/hono/templates/hono-service-command-router/hono-service-command-router-secret.yaml
+++ b/charts/hono/templates/hono-service-command-router/hono-service-command-router-secret.yaml
@@ -60,16 +60,16 @@ stringData:
             socketTimeout: 5000
             connectTimeout: 5000
           {{- end }}
-      registration:
       {{- if .Values.deviceRegistryExample.enabled }}
-        name: {{ printf "Hono %s" $args.component | quote }}
-        host: {{ .Release.Name }}-service-device-registry
-        port: 5671
-        credentialsPath: /etc/hono/adapter.credentials
-        trustStorePath: /etc/hono/trusted-certs.pem
-        hostnameVerificationRequired: false
+      registration:
+        {{- include "hono.deviceRegistryExampleClientConfig" $args | nindent 8 }}
+      tenant:
+        {{- include "hono.deviceRegistryExampleClientConfig" $args | nindent 8 }}
       {{- else }}
+      registration:
         {{- required ".Values.adapters.deviceRegistrationSpec MUST be set if example Device Registry is disabled" .Values.adapters.deviceRegistrationSpec | toYaml | nindent 8 }}
+      tenant:
+        {{- required ".Values.adapters.tenantSpec MUST be set if example Device Registry is disabled" .Values.adapters.tenantSpec | toYaml | nindent 8 }}
       {{- end }}
       command:
       {{- if .Values.amqpMessagingNetworkExample.enabled }}
@@ -85,6 +85,7 @@ stringData:
         {{- required ".Values.adapters.commandAndControlSpec MUST be set if example AQMP Messaging Network is disabled" .Values.adapters.commandAndControlSpec | toYaml | nindent 8 }}
       {{- end }}
       {{- include "hono.healthServerConfig" .Values.commandRouterService.hono.healthCheck | nindent 6 }}
+    {{- include "hono.quarkusConfig" $args | indent 4 }}
   {{- if and (not .Values.dataGridSpec) (not .Values.dataGridExample.enabled) }}
   cache-config.xml: |
   {{- tpl ( .Files.Get "config/command-router/embedded-cache-config.xml" ) . | nindent 4 }}

--- a/charts/hono/templates/jaeger/jaeger-deployment.yaml
+++ b/charts/hono/templates/jaeger/jaeger-deployment.yaml
@@ -32,8 +32,8 @@ spec:
       - env:
         - name: MEMORY_MAX_TRACES
           value: "100000"
-        - name: ADMIN_HTTP_PORT
-          value: {{ .Values.healthCheckPort | quote }}
+        - name: ADMIN_HTTP_HOST_PORT
+          value: ":{{ .Values.healthCheckPort }}"
         image: {{ .Values.jaegerBackendExample.allInOneImage }}
         name: jaeger
         ports:

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -186,7 +186,7 @@ dataGridExample:
   enabled: false
   # imageName contains the name (including tag)
   # of the container image to use for the example data grid.
-  imageName: infinispan/server:11.0.7.Final-1
+  imageName: infinispan/server:11.0.9.Final-1
   # livenessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
   # configuration property of the component's liveness probe.
   livenessProbeInitialDelaySeconds: 300
@@ -214,7 +214,7 @@ dataGridExample:
 # the device connection data used for routing of command messages.
 # This property should be set in order to use a storage configuration suitable for production
 # if "dataGridExample.enabled" is set to false (the default).
-# Please refer to https://docs.jboss.org/infinispan/9.4/apidocs/org/infinispan/client/hotrod/configuration/package-summary.html#package.description
+# Please refer to https://docs.jboss.org/infinispan/11.0/apidocs/org/infinispan/client/hotrod/configuration/package-summary.html#package.description
 # for a list of configuration properties.
 dataGridSpec:
   # serverList contains the hostname:port of the data grid node(s)
@@ -1457,7 +1457,7 @@ deviceConnectionService:
       # to the data grid that should be used for storing the device connection data.
       # This property MUST be set if "deviceConnectionService.enabled" is set to true
       # and "dataGridExample.enabled" is set to false (the default).
-      # Please refer to https://docs.jboss.org/infinispan/9.4/apidocs/org/infinispan/client/hotrod/configuration/package-summary.html#package.description
+      # Please refer to https://docs.jboss.org/infinispan/11.0/apidocs/org/infinispan/client/hotrod/configuration/package-summary.html#package.description
       # for a list of configuration properties.
       remote:
       #  serverList: hono-data-grid:11222

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -236,7 +236,7 @@ jaegerBackendExample:
   enabled: false
   # allInOneImage contains the name (including tag)
   # of the container image to use for the example Jaeger back end.
-  allInOneImage: jaegertracing/all-in-one:1.21
+  allInOneImage: jaegertracing/all-in-one:1.22
   # livenessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
   # configuration property of the component's liveness probe.
   livenessProbeInitialDelaySeconds: 300
@@ -261,14 +261,14 @@ jaegerBackendExample:
 # jaegerAgentImage contains the name (including tag)
 # of the container image to use for the Jaeger Agent sidecar deployed
 # with Hono's components.
-jaegerAgentImage: jaegertracing/jaeger-agent:1.21
+jaegerAgentImage: jaegertracing/jaeger-agent:1.22
 # jaegerAgentConf contains environment variables for configuring the Jaeger Agent sidecar container
 # that is deployed with each of Hono's components.
 # The Jaeger Agent sidecar container is deployed with standard properties if
 # "jaegerBackendExample.enabled" is set to true.
 # Otherwise the sidecar container is deployed using the environment variables contained
 # in this property (if not nil).
-# Please refer to https://www.jaegertracing.io/docs/1.21/cli/ for syntax and semantics
+# Please refer to https://www.jaegertracing.io/docs/1.22/cli/ for syntax and semantics
 # of environment variables.
 jaegerAgentConf:
 #  REPORTER_GRPC_HOST_PORT: my-jaeger-collector:14250

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -312,7 +312,7 @@ useLoadBalancer: true
 # messages from the AMQP messaging network to the target protocol adapters.
 # This property is provided for the transition period from the deprecated
 # Device Connection service towards the new Command Router service.
-useCommandRouter: false
+useCommandRouter: true
 
 # Configuration properties for protocol adapters.
 adapters:


### PR DESCRIPTION
- Replace deprecated `ADMIN_HTTP_PORT` Jaeger all-in-one property and update Jaeger images to 1.22
- Update Infinispan to 11.09
- Add tenant service configuration for command router component (needed in Hono 1.7.0) and update Hono to 1.7.0