### PR TITLE
Hono: Adapt setting of 'Always' pull policy

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.5.9
+version: 1.5.10
 # Version of Hono being deployed by the chart
 appVersion: 1.6.0
 keywords:

--- a/charts/hono/templates/_helpers.tpl
+++ b/charts/hono/templates/_helpers.tpl
@@ -44,10 +44,12 @@ Create chart name and version as used by the chart label.
   {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
+
 {{/*
 Adds an element to a Container array.
 Sets "name" and "image" values and adds an "Always" "imagePullPolicy"
-if the image tag contains "SNAPSHOT".
+if the image tag contains "SNAPSHOT" and a custom image name
+(not starting with "index.docker.io/eclipse/") is used.
 
 The scope passed in is expected to be a dict with keys
 - (mandatory) "dot": the root (".") scope
@@ -67,7 +69,7 @@ The scope passed in is expected to be a dict with keys
 {{- end }}
 - name: {{ .name | quote }}
   image: {{ $image | quote }}
-{{- if contains "SNAPSHOT" $tag }}
+{{- if and ( contains "SNAPSHOT" $tag ) ( not ( hasPrefix "index.docker.io/eclipse/" $image ) ) }}
   imagePullPolicy: "Always"
 {{- end }}
 {{- end }}
@@ -83,6 +85,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/version: {{ .Chart.AppVersion }}
 {{- end }}
+
 
 {{/*
 Add standard labels and name for resources as recommended by Helm best practices.


### PR DESCRIPTION
An "Always" "imagePullPolicy" will only be used on SNAPSHOT images if the image name doesn't
start with "index.docker.io/eclipse/". 
This simplifies usage of self-built images with standard names in minikube. And the "index.docker.io" registry doesn't contain "eclipse/*" SNAPSHOT images anyway.