### PR TITLE
Update to Hono 1.7.1, fix example-tenants.sh

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,9 +15,9 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.7.1
+version: 1.7.2
 # Version of Hono being deployed by the chart
-appVersion: 1.7.0
+appVersion: 1.7.1
 keywords:
   - iot-chart
   - IoT

--- a/charts/hono/example/certs/trust-anchor.properties
+++ b/charts/hono/example/certs/trust-anchor.properties
@@ -1,5 +1,0 @@
-trusted-ca.subject-dn=CN=DEFAULT_TENANT_CA,OU=Hono,O=Eclipse IoT,L=Ottawa,C=CA
-trusted-ca.public-key=MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEQ3gE4u1z6GwtfeC2l6bPihBiZbAUdKHPJPz/YWTegzrwwIGjrvCj/uXzKUxHOeZiSmmWrYU7F9VvWicYN5IOsg==
-trusted-ca.algorithm=EC
-trusted-ca.not-before=2021-01-26T14:13:26+01:00
-trusted-ca.not-after=2022-01-26T14:13:26+01:00

--- a/charts/hono/example/create_certs.sh
+++ b/charts/hono/example/create_certs.sh
@@ -120,11 +120,13 @@ CA_SUBJECT=$(openssl x509 -in $DIR/default_tenant-cert.pem -noout -subject -name
 PK=$(openssl x509 -in $DIR/default_tenant-cert.pem -noout -pubkey | sed /^---/d | sed -z 's/\n//g')
 NOT_BEFORE=$(date --date="$(openssl x509 -in $DIR/default_tenant-cert.pem -noout -startdate -nameopt RFC2253 | sed s/^notBefore=//)" --iso-8601=seconds)
 NOT_AFTER=$(date --date="$(openssl x509 -in $DIR/default_tenant-cert.pem -noout -enddate -nameopt RFC2253 | sed s/^notAfter=//)" --iso-8601=seconds)
-echo "trusted-ca.subject-dn=$CA_SUBJECT" > $DIR/trust-anchor.properties
-echo "trusted-ca.public-key=$PK" >> $DIR/trust-anchor.properties
-echo "trusted-ca.algorithm=$KEY_ALG" >> $DIR/trust-anchor.properties
-echo "trusted-ca.not-before=$NOT_BEFORE" >> $DIR/trust-anchor.properties
-echo "trusted-ca.not-after=$NOT_AFTER" >> $DIR/trust-anchor.properties
+echo "{" > default_tenant-trusted-ca.json
+echo "  \"subject-dn\": \"$CA_SUBJECT\"," >> default_tenant-trusted-ca.json
+echo "  \"public-key\": \"$PK\"," >> default_tenant-trusted-ca.json
+echo "  \"algorithm\": \"$KEY_ALG\"," >> default_tenant-trusted-ca.json
+echo "  \"not-before\": \"$NOT_BEFORE\"," >> default_tenant-trusted-ca.json
+echo "  \"not-after\": \"$NOT_AFTER\"" >> default_tenant-trusted-ca.json
+echo "}" >> default_tenant-trusted-ca.json
 
 create_cert qdrouter
 create_cert auth-server $AUTH_SERVER_KEY_STORE $AUTH_SERVER_KEY_STORE_PWD

--- a/charts/hono/example/default_tenant-trusted-ca.json
+++ b/charts/hono/example/default_tenant-trusted-ca.json
@@ -1,0 +1,7 @@
+{
+  "subject-dn": "CN=DEFAULT_TENANT_CA,OU=Hono,O=Eclipse IoT,L=Ottawa,C=CA",
+  "public-key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEQ3gE4u1z6GwtfeC2l6bPihBiZbAUdKHPJPz/YWTegzrwwIGjrvCj/uXzKUxHOeZiSmmWrYU7F9VvWicYN5IOsg==",
+  "algorithm": "EC",
+  "not-before": "2021-01-26T14:13:26+01:00",
+  "not-after": "2022-01-26T14:13:26+01:00"
+}

--- a/charts/hono/example/example-tenants.sh
+++ b/charts/hono/example/example-tenants.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #*******************************************************************************
-# Copyright (c) 2020 Contributors to the Eclipse Foundation
+# Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -12,19 +12,15 @@
 # SPDX-License-Identifier: EPL-2.0
 #*******************************************************************************
 
+DEFAULT_TENANT_TRUSTED_CA=`cat default_tenant-trusted-ca.json`
+
 add_tenant 'DEFAULT_TENANT' \
-          '{
-              "enabled": true,
-              "trusted-ca": [
-                {
-                  "subject-dn": "CN=DEFAULT_TENANT_CA,OU=Hono,O=Eclipse IoT,L=Ottawa,C=CA",
-                  "public-key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAElkwCSPlO563eQb6ONdULAISm2XngGGSoAAz+I1s8zkS9guPUpNKoxeczLtKlObelHqBgIZtRXdrPRgXidGOnmQ==",
-                  "algorithm": "EC",
-                  "not-before": "2019-09-18T10:35:40+02:00",
-                  "not-after": "2020-09-17T10:35:40+02:00"
-                }
+          "{
+              \"enabled\": true,
+              \"trusted-ca\": [
+$DEFAULT_TENANT_TRUSTED_CA
               ]
-            }'
+            }"
 
 add_tenant 'HTTP_TENANT' \
           '{


### PR DESCRIPTION
Updates the Hono chart to Hono 1.7.1 and fixes the wrong DEFAULT_TENANT trusted-ca data in `example.tenants.sh` (see https://github.com/eclipse/hono/issues/2628).