### PR TITLE
[#224] Fix info in README on mounting AMQP network secret

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.7.2
+version: 1.7.3
 # Version of Hono being deployed by the chart
 appVersion: 1.7.1
 keywords:

--- a/charts/hono/README.md
+++ b/charts/hono/README.md
@@ -253,14 +253,30 @@ The easiest way to set these properties is by means of putting them into a YAML 
 amqpMessagingNetworkExample:
   enabled: false
 
-adapters:
-
-  # mount (existing) Kubernetes secret which contains
-  # credentials for connecting to AMQP network
+# mount (existing) Kubernetes secret which contains
+# credentials for connecting to AMQP network
+# into Command Router and protocol adapter containers 
+commandRouterService:
   extraSecretMounts:
-  - amqpNetwork:
+    amqpNetwork:
       secretName: "my-secret"
       mountPath: "/etc/custom"
+adapters:
+  http:
+    extraSecretMounts:
+      amqpNetwork:
+        secretName: "my-secret"
+        mountPath: "/etc/custom"
+  mqtt:
+    extraSecretMounts:
+      amqpNetwork:
+        secretName: "my-secret"
+        mountPath: "/etc/custom"
+  amqp:
+    extraSecretMounts:
+      amqpNetwork:
+        secretName: "my-secret"
+        mountPath: "/etc/custom"
 
   # provide connection params
   # assuming that "my-secret" contains an "amqp-credentials.properties" file


### PR DESCRIPTION
This fixes #224.

Also adds info on mounting the secret for the Command Router service.
(Note that even with the Command Router service being used, the `commandAndControlSpec` is still expected to be below `adapters` - for compatibility with the configuration using the old device connection service (`useCommandRouter: false`). This shall get changed in a later chart update.) 