### PR TITLE
[#234] Add embedded JDBC-based Device Registry

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.8.1
+version: 1.8.2
 # Version of Hono being deployed by the chart
 appVersion: 1.8.0
 keywords:

--- a/charts/hono/templates/hono-service-device-registry-embedded/headless-svc.yaml
+++ b/charts/hono/templates/hono-service-device-registry-embedded/headless-svc.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.deviceRegistryExample.enabled ( eq .Values.deviceRegistryExample.type "embedded" ) }}
+#
+# Copyright (c) 2021 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+{{- $args := dict "dot" . "component" "service-device-registry" "name" "service-device-registry" }}
+{{- include "hono.headless.service" $args }}
+{{- end }}

--- a/charts/hono/templates/hono-service-device-registry-embedded/hono-service-device-registry-pvc.yaml
+++ b/charts/hono/templates/hono-service-device-registry-embedded/hono-service-device-registry-pvc.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.deviceRegistryExample.enabled ( eq .Values.deviceRegistryExample.type "embedded" ) }}
+#
+# Copyright (c) 2021 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+{{- $args := dict "dot" . "component" "service-device-registry" "name" "service-device-registry" }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  {{- include "hono.metadata" $args | nindent 2 }}
+spec:
+  accessModes:
+  - ReadWriteOnce
+  {{- with .Values.deviceRegistryExample.embeddedJdbcDeviceRegistry.storageClass }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: 1Mi
+{{- end }}

--- a/charts/hono/templates/hono-service-device-registry-embedded/hono-service-device-registry-secret.yaml
+++ b/charts/hono/templates/hono-service-device-registry-embedded/hono-service-device-registry-secret.yaml
@@ -1,0 +1,82 @@
+{{- if and .Values.deviceRegistryExample.enabled ( eq .Values.deviceRegistryExample.type "embedded" ) }}
+#
+# Copyright (c) 2021 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+{{- $args := dict "dot" . "component" "service-device-registry" "name" "service-device-registry-conf" }}
+apiVersion: v1
+kind: Secret
+metadata:
+  {{- include "hono.metadata" $args | nindent 2 }}
+type: Opaque
+stringData:
+  application.yml: |
+    hono:
+      app:
+        maxInstances: 1
+      auth:
+        {{- if .Values.deviceRegistryExample.hono.auth }}
+        {{- .Values.deviceRegistryExample.hono.auth | toYaml | nindent 8 }}
+        {{- else }}
+        host: {{ printf "%s-service-auth" .Release.Name | quote }}
+        port: 5671
+        trustStorePath: "/etc/hono/trusted-certs.pem"
+        hostnameVerificationRequired: false
+        name: {{ printf "Hono %s" $args.component | quote }}
+        supportedSaslMechanisms: "PLAIN"
+        validation:
+          certPath: "/etc/hono/auth-server-cert.pem"
+        connectTimeout: 2000
+        {{- end }}
+      registry:
+        amqp:
+          {{- if .Values.deviceRegistryExample.hono.registry.amqp }}
+          {{- .Values.deviceRegistryExample.hono.registry.amqp | toYaml | nindent 10 }}
+          {{- else }}
+          bindAddress: "0.0.0.0"
+          keyPath: "/etc/hono/key.pem"
+          certPath: "/etc/hono/cert.pem"
+          {{- end }}
+        http:
+          {{- if .Values.deviceRegistryExample.hono.registry.http }}
+          {{- .Values.deviceRegistryExample.hono.registry.http | toYaml | nindent 10 }}
+          {{- else }}
+          authenticationRequired: false
+          bindAddress: "0.0.0.0"
+          keyPath: "/etc/hono/key.pem"
+          certPath: "/etc/hono/cert.pem"
+          insecurePortEnabled: true
+          insecurePortBindAddress: "0.0.0.0"
+          {{- end }}
+          deviceIdPattern: "^[a-zA-Z0-9-_\\.\\:]+$"
+        jdbc:
+          adapter:
+            url: "jdbc:h2:/var/lib/hono/device-registry/registry"
+            driverClass: "org.h2.Driver"
+          management:
+            url: "jdbc:h2:/var/lib/hono/device-registry/registry"
+            driverClass: "org.h2.Driver"
+      tenant:
+        jdbc:
+          adapter:
+            url: "jdbc:h2:/var/lib/hono/device-registry/registry"
+            driverClass: "org.h2.Driver"
+          management:
+            url: "jdbc:h2:/var/lib/hono/device-registry/registry"
+            driverClass: "org.h2.Driver"
+      {{- include "hono.amqpMessagingNetworkClientConfig" $args | nindent 6 }}
+      {{- include "hono.healthServerConfig" .Values.deviceRegistryExample.hono.healthCheck | nindent 6 }}
+data:
+  key.pem: {{ .Files.Get "example/certs/device-registry-key.pem" | b64enc }}
+  cert.pem: {{ .Files.Get "example/certs/device-registry-cert.pem" | b64enc }}
+  trusted-certs.pem: {{ .Files.Get "example/certs/trusted-certs.pem" | b64enc }}
+  auth-server-cert.pem: {{ .Files.Get "example/certs/auth-server-cert.pem" | b64enc }}
+{{- end }}

--- a/charts/hono/templates/hono-service-device-registry-embedded/hono-service-device-registry-statefulset.yaml
+++ b/charts/hono/templates/hono-service-device-registry-embedded/hono-service-device-registry-statefulset.yaml
@@ -1,0 +1,75 @@
+{{- if and .Values.deviceRegistryExample.enabled ( eq .Values.deviceRegistryExample.type "embedded" ) }}
+#
+# Copyright (c) 2021 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+{{- $args := dict "dot" . "component" "service-device-registry" "name" "service-device-registry" "componentConfig" .Values.deviceRegistryExample.embeddedJdbcDeviceRegistry }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  {{- include "hono.metadata" $args | nindent 2 }}
+spec:
+  serviceName: {{ printf "%s-headless" $args.name }}
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "hono.matchLabels" $args | nindent 6 }}
+  template:
+    metadata:
+      {{- include "hono.metadata" $args | nindent 6 }}
+      annotations:
+        {{- include "hono.monitoringAnnotations" . | nindent 8 }}
+    spec:
+      containers:
+      {{- include "hono.jaeger.agent" . | indent 6 }}
+      {{- include "hono.container" $args | indent 6 }}
+        ports:
+          - name: health
+            containerPort: {{ .Values.healthCheckPort }}
+            protocol: TCP
+          - name: http
+            containerPort: 8080
+            protocol: TCP
+          - name: https
+            containerPort: 8443
+            protocol: TCP
+          - name: amqps
+            containerPort: 5671
+            protocol: TCP
+          - name: amqp
+            containerPort: 5672
+            protocol: TCP
+        env:
+        - name: JDK_JAVA_OPTIONS
+          value: {{ .Values.deviceRegistryExample.javaOptions | quote }}
+        - name: KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        {{- include "hono.component.springEnv" $args | indent 8 }}
+        {{- include "hono.jaeger.clientConf" $args | indent 8 }}
+        securityContext:
+          privileged: false
+        volumeMounts:
+        {{- include "hono.container.secretVolumeMounts" ( dict "name" $args.name "componentConfig" .Values.deviceRegistryExample ) | indent 8 }}
+        - name: "registry"
+          mountPath: "/var/lib/hono/device-registry"
+        {{- with .Values.deviceRegistryExample.resources }}
+        resources:
+          {{- . | toYaml | nindent 10 }}
+        {{- end }}
+        {{- include "hono.component.healthChecks" $args | indent 8 }}
+      volumes:
+      {{- include "hono.pod.secretVolumes" ( dict "dot" $args.dot "name" $args.name "componentConfig" .Values.deviceRegistryExample ) | indent 6 }}
+      - name: "registry"
+        persistentVolumeClaim:
+          claimName: {{ printf "%s-%s" .Release.Name $args.name | quote }}
+{{- end }}

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -1119,6 +1119,8 @@ deviceRegistryExample:
   # Sets the type of the device registry to be deployed. The following types are defined:
   # - file: File based device registry. Also refer to the section "fileBasedDeviceRegistry"
   # for additional configuration.
+  # - embedded: Embedded JDBC based device registry. Also refer to the section "embeddedJdbcDeviceRegistry"
+  # for additional configuration.
   # - mongodb: MongoDB based device registry. Also refer to the section "mongoDBBasedDeviceRegistry"
   # for additional configuration.
   # - jdbc: JDBC based device registry. Also refer to the section "jdbcBasedDeviceRegistry"
@@ -1218,6 +1220,35 @@ deviceRegistryExample:
     # applicationProfiles contains the Spring application profiles that should be activated
     # in the service.
     applicationProfiles: "dev"
+    # livenessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
+    # configuration property of the component's liveness probe.
+    # The value of the top level "livenessProbeInitialDelaySeconds" property will be used if not set.
+    livenessProbeInitialDelaySeconds:
+    # readinessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
+    # configuration property of the component's readiness probe.
+    # The value of the top level "readinessProbeInitialDelaySeconds" property will be used if not set.
+    readinessProbeInitialDelaySeconds:
+
+  # embeddedJdbcDeviceRegistry contains configuration properties specific to the
+  # embedded JDBC device registry.
+  embeddedJdbcDeviceRegistry:
+    # imageName contains the name (excluding registry)
+    # of the container image for the example embedded jdbc device registry.
+    imageName: eclipse/hono-service-device-registry-jdbc
+    # imageTag contains the tag of the container image to deploy.
+    # If not specified, the value of the honoImagesTag property is used.
+    # imageTag:
+    # containerRegistry contains the name of the container registry to pull
+    # the image from.
+    # If not specified, the value of the "honoContainerRegistry" property is used.
+    # containerRegistry:
+    # storageClass indicates the name of the kubernetes StorageClass that
+    # should be used for the example registry's persistent volume claim.
+    # If not set, the cluster's default storage class is used.
+    storageClass:
+    # applicationProfiles contains the Spring application profiles that should be activated
+    # in the service.
+    applicationProfiles: "registry-adapter,registry-management,tenant-service,create-schema,dev"
     # livenessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
     # configuration property of the component's liveness probe.
     # The value of the top level "livenessProbeInitialDelaySeconds" property will be used if not set.


### PR DESCRIPTION
This resolves #234. It should not be merged before Hono 1.8.0 is released because it depends on [a feature](https://github.com/eclipse/hono/issues/2587) that will be available from this version on.

This PR adds `embedded` as a new type of example device registry. The embedded device registry uses the existing JDBC device registry implementation and activates the application profile `create-schema` on it. The device registration database, as well as the tenant database, are H2 databases stored on a persisted volume.
