### PR TITLE
Use back end to centrally manage Jaeger sampling strategy

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.7.5
+version: 1.7.6
 # Version of Hono being deployed by the chart
 appVersion: 1.7.3
 keywords:

--- a/charts/hono/README.md
+++ b/charts/hono/README.md
@@ -505,8 +505,8 @@ from the Jaeger back end's *Collector* service. The service loads the strategies
 `SAMPLING_STRATEGIES_FILE` environment variable points to. The example Jaeger back end server's environment variables
 can be set via the chart's *jaegerBackendExample.env* property.
 
-By default, the `SAMPLING_STRATEGIES_FILE` variable points to file which configures all components to sample every span.
-A custom file can be used by creating a Kubernetes secret containing the custom file and then configure the chart's
+By default, the `SAMPLING_STRATEGIES_FILE` variable points to a file which configures all components to sample every span.
+A custom file can be used by creating a Kubernetes secret containing the custom file and then configuring the chart's
 *jaegerBackendExample.extraSecretMounts* property to mount the secret's files into the Jaeger container where it then
 can be used by setting the `SAMPLING_STRATEGIES_FILE` variable accordingly.
 

--- a/charts/hono/README.md
+++ b/charts/hono/README.md
@@ -500,6 +500,19 @@ If no example Jaeger back end should be deployed but instead an existing Jaeger 
 the chart's *jaegerAgentConf* property can be set to environment variables which are passed in to
 the Jaeger Agent that is deployed with each of Hono's components.
 
+By default, the Jaeger Agent deployed with each of Hono's components is configured to retrieve its sampling strategy
+from the Jaeger back end's *Collector* service. The service loads the strategies from the file that the
+`SAMPLING_STRATEGIES_FILE` environment variable points to. The example Jaeger back end server's environment variables
+can be set via the chart's *jaegerBackendExample.env* property.
+
+By default, the `SAMPLING_STRATEGIES_FILE` variable points to file which configures all components to sample every span.
+A custom file can be used by creating a Kubernetes secret containing the custom file and then configure the chart's
+*jaegerBackendExample.extraSecretMounts* property to mount the secret's files into the Jaeger container where it then
+can be used by setting the `SAMPLING_STRATEGIES_FILE` variable accordingly.
+
+Please refer to the [Jaeger documentation](https://www.jaegertracing.io/docs/sampling/#collector-sampling-configuration)
+for details regarding the configuration of the sampling strategies.
+
 ## Using Quarkus based services
 
 The Helm chart can be configured to use Quarkus based images for services that support it. In order to do that, you need

--- a/charts/hono/example/jaeger/default-sampling-strategies.json
+++ b/charts/hono/example/jaeger/default-sampling-strategies.json
@@ -1,0 +1,64 @@
+{
+  "service_strategies": [
+    {
+      "service": {{ printf "%s-service-device-registry" .Release.Name | quote }},
+      "type": "probabilistic",
+      "param": 1.0,
+      "operation_strategies": [
+      ]
+    },
+    {
+      "service": {{ printf "%s-service-command-router" .Release.Name | quote }},
+      "type": "probabilistic",
+      "param": 1.0,
+      "operation_strategies": [
+      ]
+    },
+    {
+      "service": {{ printf "%s-adapter-amqp-vertx" .Release.Name | quote }},
+      "type": "probabilistic",
+      "param": 1.0,
+      "operation_strategies": [
+      ]
+    },
+    {
+      "service": {{ printf "%s-adapter-coap-vertx" .Release.Name | quote }},
+      "type": "probabilistic",
+      "param": 1.0,
+      "operation_strategies": [
+      ]
+    },
+    {
+      "service": {{ printf "%s-adapter-http-vertx" .Release.Name | quote }},
+      "type": "probabilistic",
+      "param": 1.0,
+      "operation_strategies": [
+      ]
+    },
+    {
+      "service": {{ printf "%s-adapter-kura" .Release.Name | quote }},
+      "type": "probabilistic",
+      "param": 1.0,
+      "operation_strategies": [
+      ]
+    },
+    {
+      "service": {{ printf "%s-adapter-lora-vertx" .Release.Name | quote }},
+      "type": "probabilistic",
+      "param": 1.0,
+      "operation_strategies": [
+      ]
+    },
+    {
+      "service": {{ printf "%s-adapter-mqtt-vertx" .Release.Name | quote }},
+      "type": "probabilistic",
+      "param": 1.0,
+      "operation_strategies": [
+      ]
+    }
+  ],
+  "default_strategy": {
+    "type": "probabilistic",
+    "param": 1.0
+  }
+}

--- a/charts/hono/templates/_helpers.tpl
+++ b/charts/hono/templates/_helpers.tpl
@@ -437,12 +437,7 @@ The scope passed in is expected to be a dict with keys
 {{- $agentHost := printf "%s-jaeger-agent" .dot.Release.Name }}
 - name: JAEGER_SERVICE_NAME
   value: {{ printf "%s-%s" .dot.Release.Name .name | quote }}
-{{- if .dot.Values.jaegerBackendExample.enabled }}
-- name: JAEGER_SAMPLER_TYPE
-  value: "const"
-- name: JAEGER_SAMPLER_PARAM
-  value: "1"
-{{- else if empty .dot.Values.jaegerAgentConf }}
+{{- if and ( not .dot.Values.jaegerBackendExample.enabled ) ( empty .dot.Values.jaegerAgentConf ) }}
 - name: JAEGER_SAMPLER_TYPE
   value: "const"
 - name: JAEGER_SAMPLER_PARAM

--- a/charts/hono/templates/jaeger/jaeger-deployment.yaml
+++ b/charts/hono/templates/jaeger/jaeger-deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.jaegerBackendExample.enabled }}
 #
-# Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -14,7 +14,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  {{- $args := dict "dot" . "component" "tracing" "name" "jaeger-all-in-one" }}
+  {{- $args := dict "dot" . "component" "tracing" "name" "jaeger-all-in-one" "componentConfig" .Values.jaegerBackendExample }}
   {{- include "hono.metadata" $args | nindent 2 }}
 spec:
   replicas: 1
@@ -30,10 +30,14 @@ spec:
     spec:
       containers:
       - env:
-        - name: MEMORY_MAX_TRACES
-          value: "100000"
         - name: ADMIN_HTTP_HOST_PORT
           value: ":{{ .Values.healthCheckPort }}"
+        {{- with .Values.jaegerBackendExample.env }}
+        {{- range $name,$value := . }}
+        - name: {{ .name }}
+          value: {{ .value | quote }}
+        {{- end }}
+        {{- end }}
         image: {{ .Values.jaegerBackendExample.allInOneImage }}
         name: jaeger
         ports:
@@ -49,6 +53,8 @@ spec:
         - name: health
           containerPort: {{ .Values.healthCheckPort }}
           protocol: TCP
+        volumeMounts:
+        {{- include "hono.container.secretVolumeMounts" $args | indent 8 }}
         {{- with .Values.jaegerBackendExample.resources }}
         resources:
           {{- . | toYaml | nindent 10 }}
@@ -63,4 +69,6 @@ spec:
             path: "/"
             port: health
           initialDelaySeconds: {{ .Values.jaegerBackendExample.readinessProbeInitialDelaySeconds }}
+      volumes:
+      {{- include "hono.pod.secretVolumes" $args | indent 6 }}
 {{- end }}

--- a/charts/hono/templates/jaeger/jaeger-secret.yaml
+++ b/charts/hono/templates/jaeger/jaeger-secret.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.jaegerBackendExample.enabled }}
+#
+# Copyright (c) 2021 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+{{- $args := dict "dot" . "component" "tracing" "name" "jaeger-all-in-one-conf" "componentConfig" .Values.jaegerBackendExample }}
+apiVersion: v1
+kind: Secret
+metadata:
+  {{- include "hono.metadata" $args | nindent 2 }}
+type: Opaque
+stringData:
+  default-sampling-strategies.json: |
+    {{- tpl ( .Files.Get "example/jaeger/default-sampling-strategies.json" ) . | nindent 4 }}
+{{- end }}

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -258,6 +258,28 @@ jaegerBackendExample:
     annotations: {}
     loadBalancerIP:
 
+  # env contains environment variables to set for the Jaeger all-in-one container.
+  # The default variables configure the container to keep up to 100000 traces in memory
+  # and load the default sampling strategies file that comes with the chart.
+  env:
+  - name: MEMORY_MAX_TRACES
+    value: "100000"
+  - name: SAMPLING_STRATEGIES_FILE
+    value: "/etc/hono/default-sampling-strategies.json"
+
+  # extraSecretMounts describes additional secrets that should be mounted into the
+  # container's filesystem. The files from the secret(s) can
+  # then be used in environment variables referring to configuration files etc.
+  # The secrets are expected to exist in the same Kubernetes namespace
+  # as the one that the Jaeger back end has been deployed to.
+  extraSecretMounts: {}
+  #  passwords:
+  #    secretName: "my-passwords"
+  #    mountPath: "/etc/pwd"
+  #  other:
+  #    secretName: "other-stuff"
+  #    mountPath: "/etc/other"
+
 # jaegerAgentImage contains the name (including tag)
 # of the container image to use for the Jaeger Agent sidecar deployed
 # with Hono's components.


### PR DESCRIPTION
The Jaeger Collector can serve sampling strategies for individual
services to Agents from a central configuration file.

The chart now uses this approach to define a default "sample everything"
strategy and distribute it to all Hono components' side car Agent
containers.

The sampling strategies can be configured in a custom file as well which
can be mounted as an extra secret into the Jaeger all-in-one container.