### PR TITLE
Fix CI build

### DIFF
--- a/.github/kubeval.sh
+++ b/.github/kubeval.sh
@@ -3,7 +3,7 @@
 # use kubeval to validate helm generated kubernetes manifest
 #
 
-# Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -18,14 +18,8 @@ set -o errexit
 set -o pipefail
 
 CHART_DIRS="$(git diff --find-renames --name-only "$(git rev-parse --abbrev-ref HEAD)" remotes/origin/master -- charts packages | grep '[cC]hart.yaml' | sed -e 's#/[Cc]hart.yaml##g')"
-HELM_VERSION="v3.1.2"
-KUBEVAL_VERSION="0.15.0"
+KUBEVAL_VERSION="v0.16.1"
 SCHEMA_LOCATION="https://raw.githubusercontent.com/instrumenta/kubernetes-json-schema/master/"
-
-# install helm
-curl --silent --show-error --fail --location --output get_helm.sh https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get
-chmod 700 get_helm.sh
-./get_helm.sh --version "${HELM_VERSION}"
 
 # install kubeval
 curl --silent --show-error --fail --location --output /tmp/kubeval.tar.gz https://github.com/instrumenta/kubeval/releases/download/"${KUBEVAL_VERSION}"/kubeval-linux-amd64.tar.gz
@@ -46,3 +40,4 @@ for CHART_DIR in ${CHART_DIRS};do
   echo "kubeval(idating) ${CHART_DIR##charts/} chart..."
   helm template "${CHART_DIR}" | kubeval --strict --ignore-missing-schemas --kubernetes-version "${KUBERNETES_VERSION#v}" --schema-location "${SCHEMA_LOCATION}"
 done
+

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,8 +51,6 @@ jobs:
         # which a folder exists at
         # https://github.com/instrumenta/kubernetes-json-schema
         k8s:
-          - v1.15.7
-          - v1.16.4
           - v1.17.4
           - v1.18.1
     steps:
@@ -63,7 +61,7 @@ jobs:
       - name: Run kubeval
         env:
           KUBERNETES_VERSION: ${{ matrix.k8s }}
-        run: .github/kubeval.sh 
+        run: .github/kubeval.sh
 
   install-chart:
     name: install-chart
@@ -77,12 +75,11 @@ jobs:
         # the versions supported by chart-testing are the tags
         # available for the docker.io/kindest/node image
         # https://hub.docker.com/r/kindest/node/tags
-          - v1.15.12
-          - v1.16.15
-          - v1.17.11
-          - v1.18.8
-          - v1.19.4
-          - v1.20.0
+          - v1.17.17
+          - v1.18.19
+          - v1.19.11
+          - v1.20.7
+          - v1.21.1
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,11 @@
 
 name: ci
 
+env:
+  CONFIG_OPTION_CHART_TESTING: "--config .github/ct.yaml"
+  VERSION_CHART_TESTING: "v3.3.1"
+  VERSION_HELM: "v3.1.3"
+  VERSION_PYTHON: "3.7"
 on:
   pull_request:
     paths:
@@ -36,11 +41,19 @@ jobs:
         uses: actions/checkout@v2
       - name: Fetch history for chart testing
         run: git fetch --prune --unshallow
-      - name: Run chart-testing (lint)
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: ${{ env.VERSION_HELM }}
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ env.VERSION_PYTHON }}
+      - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.0.1
         with:
-          command: lint
-          config: .github/ct.yaml
+          version: ${{ env.VERSION_CHART_TESTING }}
+      - name: Run chart-testing (lint)
+        run: ct lint ${{ env.CONFIG_OPTION_CHART_TESTING }}
 
   kubeval-chart:
     runs-on: ubuntu-latest
@@ -85,14 +98,30 @@ jobs:
         uses: actions/checkout@v2
       - name: Fetch history for chart testing
         run: git fetch --prune --unshallow
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: ${{ env.VERSION_HELM }}
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ env.VERSION_PYTHON }}
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.0.1
+        with:
+          version: ${{ env.VERSION_CHART_TESTING }}
+      - name: Check for changed charts
+        id: list-changed
+        run: |
+          changed=$(ct list-changed ${{ env.CONFIG_OPTION_CHART_TESTING }})
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
       - name: Create kind ${{ matrix.k8s }} cluster
         uses: helm/kind-action@v1.1.0
         with:
+          version: v0.11.0
           config: .github/kind-config.yaml
           node_image: kindest/node:${{ matrix.k8s }}
+        if: steps.list-changed.outputs.changed == 'true'
       - name: Run chart-testing (install)
-        uses: helm/chart-testing-action@v2.0.1
-        with:
-          version: v3.3.1
-          command: install
-          config: .github/ct.yaml
+        run: ct install ${{ env.CONFIG_OPTION_CHART_TESTING }}

--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.7.7
+version: 1.7.8
 # Version of Hono being deployed by the chart
 appVersion: 1.7.3
 keywords:

--- a/homepage/prereqs.md
+++ b/homepage/prereqs.md
@@ -37,7 +37,7 @@ expectations of what was tested at some point.
 <div class="row">
 
 <div class="col-12 col-sm-6 col-md-5 col-lg-4 mx-md-auto mb-3">
-{% include cluster-req.html reqs="Kubernetes=1.15.x;CPUs=2;Memory=1024 MiB;Disk=40 GiB" additional="Additional requirements."%}
+{% include cluster-req.html reqs="Kubernetes=1.17.x;CPUs=2;Memory=1024 MiB;Disk=40 GiB" additional="Additional requirements."%}
 </div>
 
 </div>
@@ -272,7 +272,7 @@ The amount of RAM allocated to the virtual machine. This is the amount in MiB (e
 
 <dt class="col-sm-2">version</dt>
 <dd class="col-sm-10">
-The Kubernetes version deployed into the virtual machine (e.g. <code>--kubernetes-version v1.15.4</code>). 
+The Kubernetes version deployed into the virtual machine (e.g. <code>--kubernetes-version v1.20.2</code>). 
 </dd>
 
 </dl>


### PR DESCRIPTION
The chart-testing-action version 2 has introduced some breaking changes.
in particular, it now installs the chart testing tool instead of
wrapping it. Thus invocation of the `ct` command line tool needs to be
adapted.

Also changed the `kubeval.sh` script to no longer install helm as this is now
done by the `ci.yml` workflow.

Also removed outdated k8s versions from the install-chart job.