### PR TITLE
Update c2e package to use latest Hono and Ditto releases

### DIFF
--- a/homepage/_packages/cloud2edge/installation.md
+++ b/homepage/_packages/cloud2edge/installation.md
@@ -48,7 +48,7 @@ out of the box. Instead, services are exposed via *NodePorts*.
 
 {% clipboard %}
 RELEASE=c2e
-helm install -n $NS --wait --timeout 10m $RELEASE eclipse-iot/cloud2edge
+helm install -n $NS --wait --timeout 15m $RELEASE eclipse-iot/cloud2edge
 {% endclipboard %}
 {% endvariant %}
 
@@ -58,7 +58,7 @@ IP addresses. To install the Cloud2Edge package using load balancers, run the fo
 
 {% clipboard %}
 RELEASE=c2e
-helm install -n $NS --wait --timeout 10m --set hono.useLoadBalancer=true --set ditto.nginx.service.type=LoadBalancer $RELEASE eclipse-iot/cloud2edge
+helm install -n $NS --wait --timeout 15m --set hono.useLoadBalancer=true --set ditto.nginx.service.type=LoadBalancer $RELEASE eclipse-iot/cloud2edge
 {% endclipboard %}
 {% endvariant %}
 
@@ -72,7 +72,7 @@ The easiest way of getting to know the Cloud2Edge package is by [taking a little
 {% endcapture %}
 
 {% capture aside %}
-{% include cluster-req.html reqs="Kubernetes=1.15.x;CPUs=4;Memory=8192 MiB;Disk=40 GiB" additional="Will require cluster admin privileges."%}
+{% include cluster-req.html reqs="Kubernetes=1.17.x;CPUs=4;Memory=8192 MiB;Disk=40 GiB" additional="Will require cluster admin privileges."%}
 {% endcapture %}
 
 {% include side-page.html main=main aside=aside %}

--- a/packages/cloud2edge/Chart.yaml
+++ b/packages/cloud2edge/Chart.yaml
@@ -11,8 +11,8 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 apiVersion: v1
-version: 0.1.4
-appVersion: 0.1.4
+version: 0.2.0
+appVersion: 0.2.0
 name: cloud2edge
 description: |
   Eclipse IoT Cloud2Edge (C2E) is an integrated suite of services developers can use to build IoT applications

--- a/packages/cloud2edge/example-permissions.json
+++ b/packages/cloud2edge/example-permissions.json
@@ -38,11 +38,37 @@
         "activities": [ "EXECUTE" ]
       },
       {
+        "resource": "cmd_router/*",
+        "activities": [ "READ", "WRITE" ]
+      },
+      {
+        "operation": "cmd_router/*:*",
+        "activities": [ "EXECUTE" ]
+      },
+      {
         "resource": "device_con/*",
         "activities": [ "READ", "WRITE" ]
       },
       {
         "operation": "device_con/*:*",
+        "activities": [ "EXECUTE" ]
+      }
+    ],
+    "command-router": [
+      {
+        "resource": "tenant",
+        "activities": [ "READ", "WRITE" ]
+      },
+      {
+        "operation": "tenant/*:*",
+        "activities": [ "EXECUTE" ]
+      },
+      {
+        "resource": "registration/*",
+        "activities": [ "READ", "WRITE" ]
+      },
+      {
+        "operation": "registration/*:*",
         "activities": [ "EXECUTE" ]
       }
     ],
@@ -127,6 +153,11 @@
       "mechanism": "PLAIN",
       "password": "kura-secret",
       "authorities": [ "hono-component", "protocol-adapter" ]
+    },
+    "command-router@HONO": {
+      "mechanism": "PLAIN",
+      "password": "cmd-router-secret",
+      "authorities": [ "hono-component", "command-router" ]
     },
     "hono-client@HONO": {
       "mechanism": "PLAIN",

--- a/packages/cloud2edge/requirements.yaml
+++ b/packages/cloud2edge/requirements.yaml
@@ -12,8 +12,8 @@
 #
 dependencies:
   - name: hono
-    version: ~1.5.4
+    version: ~1.7.7
     repository: "https://eclipse.org/packages/charts/"
   - name: ditto
-    version: ~1.5.1
+    version: ~2.0.0
     repository: "https://eclipse.org/packages/charts/"

--- a/packages/cloud2edge/values.yaml
+++ b/packages/cloud2edge/values.yaml
@@ -45,6 +45,13 @@ hono:
             cpu: 200m
 
   authServer:
+    resources:
+      requests:
+        cpu: "200m"
+        memory: "196Mi"
+      limits:
+        cpu: "1"
+        memory: "256Mi"
     extraSecretMounts:
       permissions:
         secretName: "permissions"
@@ -52,7 +59,7 @@ hono:
     hono:
       auth:
         svc:
-          permissionsPath: "file:///var/run/hono/auth/permissions.json"
+          permissionsPath: "/var/run/hono/auth/permissions.json"
           supportedSaslMechanisms: "PLAIN"
           signing:
             # tokenExpiration contains the number of seconds after which tokens issued
@@ -69,9 +76,6 @@ hono:
         host: ditto-mongodb
         port: 27017
         dbName: hono
-
-  deviceConnectionService:
-    enabled: true
 
   adapters:
     amqp:


### PR DESCRIPTION
Changed Hono configuration to use Command Router instead of (deprecated) Device Connection service.