### PR TITLE
Fix usage of jaeger sampling strategies, fix metrics scraping

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.7.8
+version: 1.7.9
 # Version of Hono being deployed by the chart
 appVersion: 1.7.3
 keywords:

--- a/charts/hono/README.md
+++ b/charts/hono/README.md
@@ -507,6 +507,9 @@ can be used by setting the `SAMPLING_STRATEGIES_FILE` variable accordingly.
 Please refer to the [Jaeger documentation](https://www.jaegertracing.io/docs/sampling/#collector-sampling-configuration)
 for details regarding the configuration of the sampling strategies.
 
+Note that usage of the sampling strategy of the Collector service is currently not supported when using the quarkus-native
+Hono images. In that case the Jaeger Agent deployed with each of Hono's components is configured to sample all traces.
+
 ## Using Quarkus based services
 
 The Helm chart can be configured to use Quarkus based images for services that support it. In order to do that, you need

--- a/charts/hono/templates/_helpers.tpl
+++ b/charts/hono/templates/_helpers.tpl
@@ -351,6 +351,8 @@ The scope passed in is expected to be a dict with keys
 {{- define "hono.quarkusConfig" -}}
 {{- if ( contains "quarkus" .dot.Values.honoImagesType ) }}
 quarkus:
+  jaeger:
+    service-name: {{ printf "%s-%s" .dot.Release.Name .component | quote }}
   log:
     console:
       color: true
@@ -435,8 +437,9 @@ The scope passed in is expected to be a dict with keys
 */}}
 {{- define "hono.jaeger.clientConf" }}
 {{- $agentHost := printf "%s-jaeger-agent" .dot.Release.Name }}
+{{/* Note that for quarkus containers, the "quarkus.jaeger.service-name" property needs to be set instead, see https://github.com/quarkusio/quarkus/issues/17400 */}}
 - name: JAEGER_SERVICE_NAME
-  value: {{ printf "%s-%s" .dot.Release.Name .name | quote }}
+  value: {{ printf "%s-%s" .dot.Release.Name .component | quote }}
 {{- if and ( not .dot.Values.jaegerBackendExample.enabled ) ( empty .dot.Values.jaegerAgentConf ) }}
 - name: JAEGER_SAMPLER_TYPE
   value: "const"

--- a/charts/hono/templates/_helpers.tpl
+++ b/charts/hono/templates/_helpers.tpl
@@ -440,7 +440,12 @@ The scope passed in is expected to be a dict with keys
 {{/* Note that for quarkus containers, the "quarkus.jaeger.service-name" property needs to be set instead, see https://github.com/quarkusio/quarkus/issues/17400 */}}
 - name: JAEGER_SERVICE_NAME
   value: {{ printf "%s-%s" .dot.Release.Name .component | quote }}
-{{- if and ( not .dot.Values.jaegerBackendExample.enabled ) ( empty .dot.Values.jaegerAgentConf ) }}
+{{- if and .dot.Values.jaegerBackendExample.enabled ( eq .dot.Values.honoImagesType "quarkus-native" ) }}
+- name: JAEGER_SAMPLER_TYPE
+  value: "const"
+- name: JAEGER_SAMPLER_PARAM
+  value: "1"
+{{- else if and ( not .dot.Values.jaegerBackendExample.enabled ) ( empty .dot.Values.jaegerAgentConf ) }}
 - name: JAEGER_SAMPLER_TYPE
   value: "const"
 - name: JAEGER_SAMPLER_PARAM

--- a/charts/hono/templates/jaeger/jaeger-deployment.yaml
+++ b/charts/hono/templates/jaeger/jaeger-deployment.yaml
@@ -27,6 +27,7 @@ spec:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ .Values.healthCheckPort | quote }}
+        prometheus.io/scheme: "http"
     spec:
       containers:
       - env:
@@ -39,6 +40,9 @@ spec:
         {{- end }}
         {{- end }}
         image: {{ .Values.jaegerBackendExample.allInOneImage }}
+        # the Dockerfile for the all-in-one container defines the "sampling.strategies-file" param in the CMD entry
+        # - this has to be overwritten here so that the SAMPLING_STRATEGIES_FILE env var value will be used instead (see https://github.com/jaegertracing/jaeger/issues/3022)
+        args: [""]
         name: jaeger
         ports:
         - name: collector-grpc

--- a/charts/hono/templates/prometheus/prometheus-config.yaml
+++ b/charts/hono/templates/prometheus/prometheus-config.yaml
@@ -37,6 +37,7 @@ data:
         # * `prometheus.io/scrape`: Only scrape pods that have a value of `true`
         # * `prometheus.io/path`: If the metrics path is not `/metrics` override this.
         # * `prometheus.io/port`: Scrape the pod on the indicated port instead of the default of `9102`.
+        # * `prometheus.io/scheme`: Scrape the pod using the indicated scheme instead of the default of `https`.
       - job_name: 'hono-pods'
         scheme: https
         tls_config:
@@ -64,6 +65,10 @@ data:
             regex: ([^:]+)(?::\d+)?;(\d+)
             replacement: $1:$2
             target_label: __address__
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scheme]
+            action: replace
+            target_label: __scheme__
+            regex: (.+)
           - action: labelmap
             regex: __meta_kubernetes_pod_label_(.+)
           - source_labels: [__meta_kubernetes_namespace]


### PR DESCRIPTION
(Relates to https://github.com/eclipse/packages/pull/236.)
Fixes these 4 issues:
1. chart jaeger sampling strategies file isn't getting used
2. quarkus service names in strategies file don't match
3. tracing for quarkus-native images doesn't work
4. jaeger metrics are not getting scraped 


## Chart jaeger sampling strategies file isn't getting used
Adding
````
        - name: LOG_LEVEL
          value: debug
        - name: SAMPLING_STRATEGIES_RELOAD_INTERVAL
          value: 3s
````
env vars to the Jaeger all-in-one deployment reveals that the configured sampling strategies file isn't actually used:
````
{"level":"info","ts":1621436711.2852476,"caller":"static/strategy_store.go:181","msg":"Updated sampling strategies:{\n  \"default_strategy\": {\n    \"type\": \"probabilistic\",\n    \"param\": 1\n  }\n}\n"}

{"level":"debug","ts":1621436732.8051255,"caller":"static/strategy_store.go:89","msg":"sampling strategy not found, using default","service":"eclipse-hono-adapter-mqtt-vertx"}
{"level":"debug","ts":1621436752.630337,"caller":"static/strategy_store.go:89","msg":"sampling strategy not found, using default","service":"eclipse-hono-adapter-amqp-vertx"}
{"level":"debug","ts":1621436762.9257107,"caller":"static/strategy_store.go:89","msg":"sampling strategy not found, using default","service":"eclipse-hono-service-command-router"}
{"level":"debug","ts":1621436763.5102658,"caller":"static/strategy_store.go:89","msg":"sampling strategy not found, using default","service":"eclipse-hono-service-device-registry"}
````
The first line above shows the content of the default `/etc/jaeger/sampling_strategies.json` file.
This is caused by the jaeger all-in-one image not using the `SAMPLING_STRATEGIES_FILE` env var (without overwriting the container args) - see https://github.com/jaegertracing/jaeger/issues/3022.

Therefore the `args: [""]` line has been added to the container spec (see explanation in https://github.com/jaegertracing/jaeger/issues/3022).


 ## Quarkus service names in strategies file don't match

When using quarkus-based images, there is this debug log output in the jaeger container
````
{"level":"debug","ts":1621456817.084745,"caller":"static/strategy_store.go:89","msg":"sampling strategy not found, using default","service":"hono-adapter-mqtt-vertx-quarkus"}
{"level":"debug","ts":1621456817.6625888,"caller":"static/strategy_store.go:89","msg":"sampling strategy not found, using default","service":"hono-adapter-http-vertx-quarkus"}
{"level":"debug","ts":1621456821.1413589,"caller":"static/strategy_store.go:89","msg":"sampling strategy not found, using default","service":"hono-service-command-router-quarkus"}
````
Note the added `-quarkus` suffix in the services names - that is something not contained in the `JAEGER_SERVICE_NAME` env var values getting set in the chart.
Because of 
https://github.com/quarkusio/quarkus/blob/7b08f357e534cabdacd178ac5a4ac1ec91f55596/extensions/jaeger/runtime/src/main/java/io/quarkus/jaeger/runtime/JaegerDeploymentRecorder.java#L42-L46
the `JAEGER_SERVICE_NAME` env var actually isn't getting used, but instead the app configuration name (set at build time as it seems), containing the `-quarkus` suffix. This doesn't match the name in the sampling strategies file.
That means that for the quarkus case, the `quarkus.jaeger.service-name` has to be set. This PR does this.

I've created https://github.com/quarkusio/quarkus/issues/17400 here, so that `JAEGER_SERVICE_NAME` can be used again to set the service name.

## Tracing for quarkus-native images doesn't work

For quarkus-native images, the usage of the sampling strategies file and the RemoteControlledSampler doesn't work at this point.
A symptom of this is this log output in the quarkus Hono components:
````
2021-05-20 18:58:01,147 ERROR [io.jae.int.sam.RemoteControlledSampler] (Timer-1) No strategy present in response. Not updating sampler.
````
See https://github.com/quarkusio/quarkus/issues/10402 on this.

A solution/workaround for this is to adapt the reflection config for the Hono components - see https://github.com/quarkusio/quarkus/issues/10402#issuecomment-845717069.

Of course this doesn't work with the current Hono 1.7/1.8 images. 
Therefore with this PR the usage of the sampling strategies when using quarkus-native images gets disabled for now, defining the sampling (of all traces) in the agent containers instead, as it was before #236.

## Jaeger metrics are not getting scraped 
`http` scheme has to be used here.