### PR TITLE
Request more memory for embedded device registry type

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.8.2
+version: 1.8.3
 # Version of Hono being deployed by the chart
 appVersion: 1.8.0
 keywords:

--- a/charts/hono/templates/hono-service-device-registry-embedded/hono-service-device-registry-statefulset.yaml
+++ b/charts/hono/templates/hono-service-device-registry-embedded/hono-service-device-registry-statefulset.yaml
@@ -62,7 +62,7 @@ spec:
         {{- include "hono.container.secretVolumeMounts" ( dict "name" $args.name "componentConfig" .Values.deviceRegistryExample ) | indent 8 }}
         - name: "registry"
           mountPath: "/var/lib/hono/device-registry"
-        {{- with .Values.deviceRegistryExample.resources }}
+        {{- with ( default .Values.deviceRegistryExample.resources $args.componentConfig.resources ) }}
         resources:
           {{- . | toYaml | nindent 10 }}
         {{- end }}

--- a/charts/hono/templates/hono-service-device-registry-file/hono-service-device-registry-statefulset.yaml
+++ b/charts/hono/templates/hono-service-device-registry-file/hono-service-device-registry-statefulset.yaml
@@ -62,7 +62,7 @@ spec:
         {{- include "hono.container.secretVolumeMounts" ( dict "name" $args.name "componentConfig" .Values.deviceRegistryExample ) | indent 8 }}
         - name: "registry"
           mountPath: "/var/lib/hono/device-registry"
-        {{- with .Values.deviceRegistryExample.resources }}
+        {{- with ( default .Values.deviceRegistryExample.resources $args.componentConfig.resources ) }}
         resources:
           {{- . | toYaml | nindent 10 }}
         {{- end }}

--- a/charts/hono/templates/hono-service-device-registry-jdbc/hono-service-device-registry-deployment.yaml
+++ b/charts/hono/templates/hono-service-device-registry-jdbc/hono-service-device-registry-deployment.yaml
@@ -57,7 +57,7 @@ spec:
           privileged: false
         volumeMounts:
         {{- include "hono.container.secretVolumeMounts" ( dict "name" $args.name "componentConfig" .Values.deviceRegistryExample ) | indent 8 }}
-        {{- with .Values.deviceRegistryExample.resources }}
+        {{- with ( default .Values.deviceRegistryExample.resources $args.componentConfig.resources ) }}
         resources:
           {{- . | toYaml | nindent 10 }}
         {{- end }}

--- a/charts/hono/templates/hono-service-device-registry-mongodb/hono-service-device-registry-deployment.yaml
+++ b/charts/hono/templates/hono-service-device-registry-mongodb/hono-service-device-registry-deployment.yaml
@@ -57,7 +57,7 @@ spec:
           privileged: false
         volumeMounts:
         {{- include "hono.container.secretVolumeMounts" ( dict "name" $args.name "componentConfig" .Values.deviceRegistryExample ) | indent 8 }}
-        {{- with .Values.deviceRegistryExample.resources }}
+        {{- with ( default .Values.deviceRegistryExample.resources $args.componentConfig.resources ) }}
         resources:
           {{- . | toYaml | nindent 10 }}
         {{- end }}

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -1228,6 +1228,10 @@ deviceRegistryExample:
     # configuration property of the component's readiness probe.
     # The value of the top level "readinessProbeInitialDelaySeconds" property will be used if not set.
     readinessProbeInitialDelaySeconds:
+    # If not specified here, then the values from "deviceRegistryExample.resources" are used.
+    # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+    # for a description of the properties' semantics.
+    resources:
 
   # embeddedJdbcDeviceRegistry contains configuration properties specific to the
   # embedded JDBC device registry.
@@ -1257,6 +1261,18 @@ deviceRegistryExample:
     # configuration property of the component's readiness probe.
     # The value of the top level "readinessProbeInitialDelaySeconds" property will be used if not set.
     readinessProbeInitialDelaySeconds:
+    # resources contains the container's requests and limits for CPU and memory
+    # as defined by the Kubernetes API.
+    # If not specified here, then the values from "deviceRegistryExample.resources" are used.
+    # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+    # for a description of the properties' semantics.
+    resources:
+      requests:
+        cpu: "200m"
+        memory: "400Mi"
+      limits:
+        cpu: "1"
+        memory: "500Mi"
 
   # mongoDBBasedDeviceRegistry contains configuration properties specific to the
   # MongoDB based device registry.
@@ -1282,6 +1298,10 @@ deviceRegistryExample:
     # configuration property of the component's readiness probe.
     # The value of the top level "readinessProbeInitialDelaySeconds" property will be used if not set.
     readinessProbeInitialDelaySeconds:
+    # If not specified here, then the values from "deviceRegistryExample.resources" are used.
+    # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+    # for a description of the properties' semantics.
+    resources:
     # mongodb contains the configuration properties to connect to the MongoDB database instance.
     # If you would like to use an already existing MongoDB database instance, then configure
     # the below section accordingly.
@@ -1321,6 +1341,10 @@ deviceRegistryExample:
     # configuration property of the component's readiness probe.
     # The value of the top level "readinessProbeInitialDelaySeconds" property will be used if not set.
     readinessProbeInitialDelaySeconds:
+    # If not specified here, then the values from "deviceRegistryExample.resources" are used.
+    # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+    # for a description of the properties' semantics.
+    resources:
     # registry.jdbc contains the configuration properties for device registry
     # to connect to the database.
     registry:


### PR DESCRIPTION
This improves #235

The JDBC based registry, when used with an embedded H2 DB, will require
more memory to accommodate the additional H2 DB functionality.

The resource requests and limits of the device registry can now also be
set at the particular registry type level, falling back to the default
values specified at the registry example level.