### PR TITLE
Extend Ditto logging configuration options

### DIFF
--- a/charts/ditto/Chart.yaml
+++ b/charts/ditto/Chart.yaml
@@ -15,7 +15,7 @@ description: |
   Eclipse Ditto™ is a technology in the IoT implementing a software pattern called “digital twins”.
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
-version: 2.0.1
+version: 2.0.2
 appVersion: 2.0.1
 keywords:
   - iot-chart

--- a/charts/ditto/templates/concierge-deployment.yaml
+++ b/charts/ditto/templates/concierge-deployment.yaml
@@ -50,10 +50,25 @@ spec:
       {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ template "ditto.serviceAccountName" . }}
       {{- end }}
-    {{- with .Values.global.imagePullSecrets }}
+      {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- end }}
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      {{- if .Values.global.logging.logFiles.enabled }}
+      initContainers:
+          - name: change-volume-owner
+            image: busybox
+            securityContext:
+              runAsUser: 0
+            command: [ "sh", "-c", "chown -R 1000:1000 /var/log/ditto && echo 'changed ownership of /var/log/ditto to 1000:1000'" ]
+            volumeMounts:
+              - name: ditto-log-files-directory
+                mountPath: /var/log/ditto
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}-concierge
           image: {{ printf "%s:%s" .Values.concierge.image.repository ( default .Chart.AppVersion ( default .Values.dittoTag .Values.concierge.image.tag ) ) }}
@@ -66,6 +81,12 @@ spec:
             - "-jar"
             - "/opt/ditto/starter.jar"
           env:
+            - name: DITTO_LOGGING_FILE_APPENDER
+              value: "{{ if .Values.global.logging.logFiles.enabled }}true{{ else }}false{{ end }}"
+            {{- if .Values.global.logging.logstash.enabled }}
+            - name: DITTO_LOGGING_LOGSTASH_SERVER
+              value: "{{ .Values.global.logging.logstash.endpoint }}"
+            {{- end }}
             - name: POD_LABEL_SELECTOR
               value: "app.kubernetes.io/name=%s"
             - name: POD_NAMESPACE
@@ -93,13 +114,13 @@ spec:
                 secretKeyRef:
                   name: {{ include "ditto.fullname" . }}-mongodb-secret
                   key: concierge-uri
-          {{- if .Values.global.prometheus.enabled }}
+            {{- if .Values.global.prometheus.enabled }}
             - name: PROMETHEUS_PORT
               value: "{{ .Values.global.prometheus.port }}"
-          {{- end }}
-          {{- if .Values.concierge.extraEnv }}
-            {{- toYaml .Values.concierge.extraEnv | nindent 12 }}
-          {{- end }}
+            {{- end }}
+            {{- if .Values.concierge.extraEnv }}
+              {{- toYaml .Values.concierge.extraEnv | nindent 12 }}
+            {{- end }}
           ports:
             - name: remoting
               containerPort: {{ .Values.akka.remoting.port }}
@@ -123,18 +144,30 @@ spec:
             periodSeconds: {{ .Values.concierge.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.concierge.livenessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.concierge.livenessProbe.failureThreshold }}
+          {{- if .Values.global.logging.logFiles.enabled }}
+          volumeMounts:
+            - name: ditto-log-files-directory
+              mountPath: /var/log/ditto
+          {{- end }}
           resources:
             {{- toYaml .Values.concierge.resources | nindent 12 }}
       {{- with .Values.concierge.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- with .Values.concierge.affinity }}
+      {{- with .Values.concierge.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.concierge.tolerations }}
+      {{- end }}
+      {{- with .Values.concierge.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- end }}
+      {{- if .Values.global.logging.logFiles.enabled }}
+      volumes:
+        - name: ditto-log-files-directory
+          hostPath:
+            path: /var/log/ditto
+            type: DirectoryOrCreate
+      {{- end }}
 {{- end }}

--- a/charts/ditto/templates/connectivity-deployment.yaml
+++ b/charts/ditto/templates/connectivity-deployment.yaml
@@ -50,10 +50,25 @@ spec:
       {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ template "ditto.serviceAccountName" . }}
       {{- end }}
-    {{- with .Values.global.imagePullSecrets }}
+      {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- end }}
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      {{- if .Values.global.logging.logFiles.enabled }}
+      initContainers:
+        - name: change-volume-owner
+          image: busybox
+          securityContext:
+            runAsUser: 0
+          command: [ "sh", "-c", "chown -R 1000:1000 /var/log/ditto && echo 'changed ownership of /var/log/ditto to 1000:1000'" ]
+          volumeMounts:
+            - name: ditto-log-files-directory
+              mountPath: /var/log/ditto
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}-connectivity
           image: {{ printf "%s:%s" .Values.connectivity.image.repository ( default .Chart.AppVersion ( default .Values.dittoTag .Values.connectivity.image.tag ) ) }}
@@ -66,6 +81,12 @@ spec:
             - "-jar"
             - "/opt/ditto/starter.jar"
           env:
+            - name: DITTO_LOGGING_FILE_APPENDER
+              value: "{{ if .Values.global.logging.logFiles.enabled }}true{{ else }}false{{ end }}"
+            {{- if .Values.global.logging.logstash.enabled }}
+            - name: DITTO_LOGGING_LOGSTASH_SERVER
+              value: "{{ .Values.global.logging.logstash.endpoint }}"
+            {{- end }}
             - name: POD_LABEL_SELECTOR
               value: "app.kubernetes.io/name=%s"
             - name: POD_NAMESPACE
@@ -93,13 +114,13 @@ spec:
                 secretKeyRef:
                   name: {{ include "ditto.fullname" . }}-mongodb-secret
                   key: connectivity-uri
-          {{- if .Values.global.prometheus.enabled }}
+            {{- if .Values.global.prometheus.enabled }}
             - name: PROMETHEUS_PORT
               value: "{{ .Values.global.prometheus.port }}"
-          {{- end }}
-          {{- if .Values.connectivity.extraEnv }}
-            {{- toYaml .Values.connectivity.extraEnv | nindent 12 }}
-          {{- end }}
+            {{- end }}
+            {{- if .Values.connectivity.extraEnv }}
+              {{- toYaml .Values.connectivity.extraEnv | nindent 12 }}
+            {{- end }}
           ports:
             - name: remoting
               containerPort: {{ .Values.akka.remoting.port }}
@@ -123,18 +144,30 @@ spec:
             periodSeconds: {{ .Values.connectivity.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.connectivity.livenessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.connectivity.livenessProbe.failureThreshold }}
+          {{- if .Values.global.logging.logFiles.enabled }}
+          volumeMounts:
+            - name: ditto-log-files-directory
+              mountPath: /var/log/ditto
+          {{- end }}
           resources:
             {{- toYaml .Values.connectivity.resources | nindent 12 }}
       {{- with .Values.connectivity.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- with .Values.connectivity.affinity }}
+      {{- with .Values.connectivity.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.connectivity.tolerations }}
+      {{- end }}
+      {{- with .Values.connectivity.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- end }}
+      {{- if .Values.global.logging.logFiles.enabled }}
+      volumes:
+        - name: ditto-log-files-directory
+          hostPath:
+            path: /var/log/ditto
+            type: DirectoryOrCreate
+      {{- end }}
 {{- end }}

--- a/charts/ditto/templates/gateway-deployment.yaml
+++ b/charts/ditto/templates/gateway-deployment.yaml
@@ -51,10 +51,25 @@ spec:
       {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ template "ditto.serviceAccountName" . }}
       {{- end }}
-    {{- with .Values.global.imagePullSecrets }}
+      {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- end }}
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      {{- if .Values.global.logging.logFiles.enabled }}
+      initContainers:
+        - name: change-volume-owner
+          image: busybox
+          securityContext:
+            runAsUser: 0
+          command: [ "sh", "-c", "chown -R 1000:1000 /var/log/ditto && echo 'changed ownership of /var/log/ditto to 1000:1000'" ]
+          volumeMounts:
+            - name: ditto-log-files-directory
+              mountPath: /var/log/ditto
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}-gateway
           image: {{ printf "%s:%s" .Values.gateway.image.repository ( default .Chart.AppVersion ( default .Values.dittoTag .Values.gateway.image.tag ) ) }}
@@ -67,6 +82,12 @@ spec:
             - "-jar"
             - "/opt/ditto/starter.jar"
           env:
+            - name: DITTO_LOGGING_FILE_APPENDER
+              value: "{{ if .Values.global.logging.logFiles.enabled }}true{{ else }}false{{ end }}"
+            {{- if .Values.global.logging.logstash.enabled }}
+            - name: DITTO_LOGGING_LOGSTASH_SERVER
+              value: "{{ .Values.global.logging.logstash.endpoint }}"
+            {{- end }}
             - name: POD_LABEL_SELECTOR
               value: "app.kubernetes.io/name=%s"
             - name: POD_NAMESPACE
@@ -101,13 +122,13 @@ spec:
                 secretKeyRef:
                   name: {{ include "ditto.fullname" . }}-gateway-secret
                   key: status-password
-          {{- if .Values.global.prometheus.enabled }}
+            {{- if .Values.global.prometheus.enabled }}
             - name: PROMETHEUS_PORT
               value: "{{ .Values.global.prometheus.port }}"
-          {{- end }}
-          {{- if .Values.gateway.extraEnv }}
-            {{- toYaml .Values.gateway.extraEnv | nindent 12 }}
-          {{- end }}
+            {{- end }}
+            {{- if .Values.gateway.extraEnv }}
+              {{- toYaml .Values.gateway.extraEnv | nindent 12 }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.gateway.service.port }}
@@ -134,18 +155,30 @@ spec:
             periodSeconds: {{ .Values.gateway.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.gateway.livenessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.gateway.livenessProbe.failureThreshold }}
+          {{- if .Values.global.logging.logFiles.enabled }}
+          volumeMounts:
+            - name: ditto-log-files-directory
+              mountPath: /var/log/ditto
+          {{- end }}
           resources:
             {{- toYaml .Values.gateway.resources | nindent 12 }}
       {{- with .Values.gateway.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- with .Values.gateway.affinity }}
+      {{- with .Values.gateway.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.gateway.tolerations }}
+      {{- end }}
+      {{- with .Values.gateway.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- end }}
+      {{- if .Values.global.logging.logFiles.enabled }}
+      volumes:
+        - name: ditto-log-files-directory
+          hostPath:
+            path: /var/log/ditto
+            type: DirectoryOrCreate
+      {{- end }}
 {{- end }}

--- a/charts/ditto/templates/nginx-deployment.yaml
+++ b/charts/ditto/templates/nginx-deployment.yaml
@@ -42,10 +42,22 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-    {{- with .Values.global.imagePullSecrets }}
+      {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- end }}
+      initContainers:
+        - name: wait-for-gateway
+          image: curlimages/curl:latest
+          args:
+            - /bin/sh
+            - -c
+            - >
+              set -x;
+              while [[ "$(curl -sL -w "%{http_code}\n" http://ditto-gateway:8080/health -o /dev/null)" != "200" ]]; do
+                echo '.'
+                sleep 15;
+              done
       containers:
         - name: {{ .Chart.Name }}-nginx
           image: "{{ .Values.nginx.image.repository }}:{{ .Values.nginx.image.tag }}"
@@ -118,12 +130,12 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- with .Values.nginx.affinity }}
+      {{- with .Values.nginx.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.nginx.tolerations }}
+      {{- end }}
+      {{- with .Values.nginx.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- end }}
 {{- end }}

--- a/charts/ditto/templates/nginx-deployment.yaml
+++ b/charts/ditto/templates/nginx-deployment.yaml
@@ -54,7 +54,7 @@ spec:
             - -c
             - >
               set -x;
-              while [[ "$(curl -sL -w "%{http_code}\n" http://ditto-gateway:8080/health -o /dev/null)" != "200" ]]; do
+              while [[ "$(curl -sL -w "%{http_code}\n" http://{{ include "ditto.name" . }}-gateway:8080/health -o /dev/null)" != "200" ]]; do
                 echo '.'
                 sleep 15;
               done

--- a/charts/ditto/templates/nginx-deployment.yaml
+++ b/charts/ditto/templates/nginx-deployment.yaml
@@ -54,7 +54,7 @@ spec:
             - -c
             - >
               set -x;
-              while [[ "$(curl -sL -w "%{http_code}\n" http://{{ include "ditto.name" . }}-gateway:8080/health -o /dev/null)" != "200" ]]; do
+              while [[ "$(curl -sL -w "%{http_code}\n" http://{{ include "ditto.fullname" . }}-gateway:8080/health -o /dev/null)" != "200" ]]; do
                 echo '.'
                 sleep 15;
               done

--- a/charts/ditto/templates/policies-deployment.yaml
+++ b/charts/ditto/templates/policies-deployment.yaml
@@ -50,10 +50,25 @@ spec:
       {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ template "ditto.serviceAccountName" . }}
       {{- end }}
-    {{- with .Values.global.imagePullSecrets }}
+      {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- end }}
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      {{- if .Values.global.logging.logFiles.enabled }}
+      initContainers:
+        - name: change-volume-owner
+          image: busybox
+          securityContext:
+            runAsUser: 0
+          command: [ "sh", "-c", "chown -R 1000:1000 /var/log/ditto && echo 'changed ownership of /var/log/ditto to 1000:1000'" ]
+          volumeMounts:
+            - name: ditto-log-files-directory
+              mountPath: /var/log/ditto
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}-policies
           image: {{ printf "%s:%s" .Values.policies.image.repository ( default .Chart.AppVersion ( default .Values.dittoTag .Values.policies.image.tag ) ) }}
@@ -66,6 +81,12 @@ spec:
             - "-jar"
             - "/opt/ditto/starter.jar"
           env:
+            - name: DITTO_LOGGING_FILE_APPENDER
+              value: "{{ if .Values.global.logging.logFiles.enabled }}true{{ else }}false{{ end }}"
+            {{- if .Values.global.logging.logstash.enabled }}
+            - name: DITTO_LOGGING_LOGSTASH_SERVER
+              value: "{{ .Values.global.logging.logstash.endpoint }}"
+            {{- end }}
             - name: POD_LABEL_SELECTOR
               value: "app.kubernetes.io/name=%s"
             - name: POD_NAMESPACE
@@ -93,13 +114,13 @@ spec:
                 secretKeyRef:
                   name: {{ include "ditto.fullname" . }}-mongodb-secret
                   key: policies-uri
-          {{- if .Values.global.prometheus.enabled }}
+            {{- if .Values.global.prometheus.enabled }}
             - name: PROMETHEUS_PORT
               value: "{{ .Values.global.prometheus.port }}"
-          {{- end }}
-          {{- if .Values.policies.extraEnv }}
-            {{- toYaml .Values.policies.extraEnv | nindent 12 }}
-          {{- end }}
+            {{- end }}
+            {{- if .Values.policies.extraEnv }}
+              {{- toYaml .Values.policies.extraEnv | nindent 12 }}
+            {{- end }}
           ports:
             - name: http
               containerPort: 8080
@@ -126,18 +147,30 @@ spec:
             periodSeconds: {{ .Values.policies.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.policies.livenessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.policies.livenessProbe.failureThreshold }}
+          {{- if .Values.global.logging.logFiles.enabled }}
+          volumeMounts:
+            - name: ditto-log-files-directory
+              mountPath: /var/log/ditto
+          {{- end }}
           resources:
             {{- toYaml .Values.policies.resources | nindent 12 }}
       {{- with .Values.policies.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- with .Values.policies.affinity }}
+      {{- with .Values.policies.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.policies.tolerations }}
+      {{- end }}
+      {{- with .Values.policies.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- end }}
+      {{- if .Values.global.logging.logFiles.enabled }}
+      volumes:
+        - name: ditto-log-files-directory
+          hostPath:
+            path: /var/log/ditto
+            type: DirectoryOrCreate
+      {{- end }}
 {{- end }}

--- a/charts/ditto/templates/swaggerui-deployment.yaml
+++ b/charts/ditto/templates/swaggerui-deployment.yaml
@@ -40,10 +40,10 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-    {{- with .Values.global.imagePullSecrets }}
+      {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- end }}
       initContainers:
         - name: {{ .Chart.Name }}-init
           image: "{{ .Values.swaggerui.image.repository }}:{{ .Values.swaggerui.image.tag }}"

--- a/charts/ditto/templates/things-deployment.yaml
+++ b/charts/ditto/templates/things-deployment.yaml
@@ -50,10 +50,25 @@ spec:
       {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ template "ditto.serviceAccountName" . }}
       {{- end }}
-    {{- with .Values.global.imagePullSecrets }}
+      {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- end }}
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      {{- if .Values.global.logging.logFiles.enabled }}
+      initContainers:
+        - name: change-volume-owner
+          image: busybox
+          securityContext:
+            runAsUser: 0
+          command: [ "sh", "-c", "chown -R 1000:1000 /var/log/ditto && echo 'changed ownership of /var/log/ditto to 1000:1000'" ]
+          volumeMounts:
+            - name: ditto-log-files-directory
+              mountPath: /var/log/ditto
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}-things
           image: {{ printf "%s:%s" .Values.things.image.repository ( default .Chart.AppVersion ( default .Values.dittoTag .Values.things.image.tag ) ) }}
@@ -66,6 +81,12 @@ spec:
             - "-jar"
             - "/opt/ditto/starter.jar"
           env:
+            - name: DITTO_LOGGING_FILE_APPENDER
+              value: "{{ if .Values.global.logging.logFiles.enabled }}true{{ else }}false{{ end }}"
+            {{- if .Values.global.logging.logstash.enabled }}
+            - name: DITTO_LOGGING_LOGSTASH_SERVER
+              value: "{{ .Values.global.logging.logstash.endpoint }}"
+            {{- end }}
             - name: POD_LABEL_SELECTOR
               value: "app.kubernetes.io/name=%s"
             - name: POD_NAMESPACE
@@ -93,13 +114,13 @@ spec:
                 secretKeyRef:
                   name: {{ include "ditto.fullname" . }}-mongodb-secret
                   key: things-uri
-          {{- if .Values.global.prometheus.enabled }}
+            {{- if .Values.global.prometheus.enabled }}
             - name: PROMETHEUS_PORT
               value: "{{ .Values.global.prometheus.port }}"
-          {{- end }}
-          {{- if .Values.things.extraEnv }}
-            {{- toYaml .Values.things.extraEnv | nindent 12 }}
-          {{- end }}
+            {{- end }}
+            {{- if .Values.things.extraEnv }}
+              {{- toYaml .Values.things.extraEnv | nindent 12 }}
+            {{- end }}
           ports:
             - name: remoting
               containerPort: {{ .Values.akka.remoting.port }}
@@ -123,18 +144,30 @@ spec:
             periodSeconds: {{ .Values.things.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.things.livenessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.things.livenessProbe.failureThreshold }}
+          {{- if .Values.global.logging.logFiles.enabled }}
+          volumeMounts:
+            - name: ditto-log-files-directory
+              mountPath: /var/log/ditto
+          {{- end }}
           resources:
             {{- toYaml .Values.things.resources | nindent 12 }}
       {{- with .Values.things.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- with .Values.things.affinity }}
+      {{- with .Values.things.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.things.tolerations }}
+      {{- end }}
+      {{- with .Values.things.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- end }}
+      {{- if .Values.global.logging.logFiles.enabled }}
+      volumes:
+        - name: ditto-log-files-directory
+          hostPath:
+            path: /var/log/ditto
+            type: DirectoryOrCreate
+      {{- end }}
 {{- end }}

--- a/charts/ditto/templates/thingssearch-deployment.yaml
+++ b/charts/ditto/templates/thingssearch-deployment.yaml
@@ -50,10 +50,25 @@ spec:
       {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ template "ditto.serviceAccountName" . }}
       {{- end }}
-    {{- with .Values.global.imagePullSecrets }}
+      {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- end }}
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      {{- if .Values.global.logging.logFiles.enabled }}
+      initContainers:
+        - name: change-volume-owner
+          image: busybox
+          securityContext:
+            runAsUser: 0
+          command: [ "sh", "-c", "chown -R 1000:1000 /var/log/ditto && echo 'changed ownership of /var/log/ditto to 1000:1000'" ]
+          volumeMounts:
+            - name: ditto-log-files-directory
+              mountPath: /var/log/ditto
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}-thingssearch
           image: {{ printf "%s:%s" .Values.thingsSearch.image.repository ( default .Chart.AppVersion ( default .Values.dittoTag .Values.thingsSearch.image.tag ) ) }}
@@ -66,6 +81,12 @@ spec:
             - "-jar"
             - "/opt/ditto/starter.jar"
           env:
+            - name: DITTO_LOGGING_FILE_APPENDER
+              value: "{{ if .Values.global.logging.logFiles.enabled }}true{{ else }}false{{ end }}"
+            {{- if .Values.global.logging.logstash.enabled }}
+            - name: DITTO_LOGGING_LOGSTASH_SERVER
+              value: "{{ .Values.global.logging.logstash.endpoint }}"
+            {{- end }}
             - name: POD_LABEL_SELECTOR
               value: "app.kubernetes.io/name=%s"
             - name: POD_NAMESPACE
@@ -93,13 +114,13 @@ spec:
                 secretKeyRef:
                   name: {{ include "ditto.fullname" . }}-mongodb-secret
                   key: searchDB-uri
-          {{- if .Values.global.prometheus.enabled }}
+            {{- if .Values.global.prometheus.enabled }}
             - name: PROMETHEUS_PORT
               value: "{{ .Values.global.prometheus.port }}"
-          {{- end }}
-          {{- if .Values.thingsSearch.extraEnv }}
-            {{- toYaml .Values.thingsSearch.extraEnv | nindent 12 }}
-          {{- end }}
+            {{- end }}
+            {{- if .Values.thingsSearch.extraEnv }}
+              {{- toYaml .Values.thingsSearch.extraEnv | nindent 12 }}
+            {{- end }}
           ports:
             - name: remoting
               containerPort: {{ .Values.akka.remoting.port }}
@@ -123,18 +144,30 @@ spec:
             periodSeconds: {{ .Values.thingsSearch.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.thingsSearch.livenessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.thingsSearch.livenessProbe.failureThreshold }}
+          {{- if .Values.global.logging.logFiles.enabled }}
+          volumeMounts:
+            - name: ditto-log-files-directory
+              mountPath: /var/log/ditto
+          {{- end }}
           resources:
             {{- toYaml .Values.thingsSearch.resources | nindent 12 }}
       {{- with .Values.thingsSearch.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- with .Values.thingsSearch.affinity }}
+      {{- with .Values.thingsSearch.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.thingsSearch.tolerations }}
+      {{- end }}
+      {{- with .Values.thingsSearch.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- end }}
+      {{- if .Values.global.logging.logFiles.enabled }}
+      volumes:
+        - name: ditto-log-files-directory
+          hostPath:
+            path: /var/log/ditto
+            type: DirectoryOrCreate
+      {{- end }}
 {{- end }}

--- a/charts/ditto/values.yaml
+++ b/charts/ditto/values.yaml
@@ -97,7 +97,7 @@ global:
     ## enable writing logs to log files
     ## log files can be found on the host under /var/log/ditto
     logFiles:
-      enabled: true
+      enabled: false
 ## ----------------------------------------------------------------------------
 ## akka actor configuration
 ## ref: https://doc.akka.io/docs/akka/current/typed/index.html

--- a/charts/ditto/values.yaml
+++ b/charts/ditto/values.yaml
@@ -88,7 +88,16 @@ global:
     enabled: true
     ## port where prometheus metrics will be provided
     port: 9095
-
+  ## logging configuration for ditto
+  logging:
+    ## configure if logs should be pushed to a logstash endpoint
+    logstash:
+      enabled: false
+      endpoint: ""
+    ## enable writing logs to log files
+    ## log files can be found on the host under /var/log/ditto
+    logFiles:
+      enabled: true
 ## ----------------------------------------------------------------------------
 ## akka actor configuration
 ## ref: https://doc.akka.io/docs/akka/current/typed/index.html

--- a/charts/ditto/values.yaml
+++ b/charts/ditto/values.yaml
@@ -149,7 +149,7 @@ concierge:
   ## resources for the concierge container
   resources:
     requests:
-      cpu: 200m
+      cpu: 250m
       memory: 384Mi
     # limits:
     #   ## no cpu limit to avoid CFS scheduler limits
@@ -312,7 +312,7 @@ gateway:
   ## resources for the gateway container
   resources:
     requests:
-      cpu: 150m
+      cpu: 250m
       memory: 384Mi
     # limits:
     #   ## no cpu limit to avoid CFS scheduler limits
@@ -568,7 +568,7 @@ things:
   ## resources for the things container
   resources:
     requests:
-      cpu: 150m
+      cpu: 250m
       memory: 384Mi
     # limits:
     #   ## no cpu limit to avoid CFS scheduler limits
@@ -642,7 +642,7 @@ thingsSearch:
   ## resources for the things-search container
   resources:
     requests:
-      cpu: 150m
+      cpu: 250m
       memory: 512Mi
     # limits:
     #   ## no cpu limit to avoid CFS scheduler limits

--- a/charts/ditto/values.yaml
+++ b/charts/ditto/values.yaml
@@ -113,7 +113,7 @@ akka:
 
 # Set "dittoTag" in order to specify another Ditto version to use for all Ditto services:
 # you may also use "1" (for latest Ditto 1.x.x) or "1.5" (for latest Ditto 1.5.x)
-# dittotag: 2.0.1
+# dittoTag: 2.0.1
 
 ## ----------------------------------------------------------------------------
 ## concierge configuration


### PR DESCRIPTION
With this PR it is possible to configure Ditto to log to a logstash endpoint.
It is also possible to pipe logs into log files.
Add initContainers to Ditto deployments in order to write log files in the _/var/log/dittto_ directory on the host.
Add initContainer to nginx deployment to wait until the gateway service is ready. 