### PR TITLE
[Hono] Replace usage of pem truststore by JKS

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.8.4
+version: 1.8.5
 # Version of Hono being deployed by the chart
 appVersion: 1.8.0
 keywords:

--- a/charts/hono/templates/_helpers.tpl
+++ b/charts/hono/templates/_helpers.tpl
@@ -206,6 +206,7 @@ messaging:
   keyPath: {{ .dot.Values.adapters.amqpMessagingNetworkSpec.keyPath }}
   certPath: {{ .dot.Values.adapters.amqpMessagingNetworkSpec.certPath }}
   trustStorePath: {{ .dot.Values.adapters.amqpMessagingNetworkSpec.trustStorePath }}
+  trustStorePassword: {{ .dot.Values.adapters.amqpMessagingNetworkSpec.trustStorePassword }}
   hostnameVerificationRequired: {{ .dot.Values.adapters.amqpMessagingNetworkSpec.hostnameVerificationRequired }}
 {{- else }}
   {{- required ".Values.adapters.amqpMessagingNetworkSpec MUST be set if example AMQP Messaging Network is disabled" .dot.Values.adapters.amqpMessagingNetworkSpec | toYaml | nindent 2 }}
@@ -221,7 +222,7 @@ The scope passed in is expected to be a dict with keys
 - (mandatory) "component": the name of the component
 */}}
 {{- define "hono.kafkaMessagingConfig" -}}
-{{- include "hono.kafkaConfigCheck" (dict "dot" .dot) }}
+{{- include "hono.kafkaConfigCheck" (dict "dot" .dot) -}}
 kafka:
   defaultClientIdPrefix: {{ .component }}
 {{- if .dot.Values.kafkaMessagingClusterExample.enabled }}
@@ -274,7 +275,8 @@ name: Hono {{ .component }}
 host: {{ .dot.Release.Name }}-service-device-registry
 port: 5671
 credentialsPath: /etc/hono/adapter.credentials
-trustStorePath: /etc/hono/trusted-certs.pem
+trustStorePath: /etc/hono/truststore.jks
+trustStorePassword: honotrust
 hostnameVerificationRequired: false
 {{- end }}
 
@@ -298,6 +300,7 @@ command:
   keyPath: {{ .dot.Values.adapters.commandAndControlSpec.keyPath }}
   certPath: {{ .dot.Values.adapters.commandAndControlSpec.certPath }}
   trustStorePath: {{ .dot.Values.adapters.commandAndControlSpec.trustStorePath }}
+  trustStorePassword: {{ .dot.Values.adapters.commandAndControlSpec.trustStorePassword }}
   hostnameVerificationRequired: {{ .dot.Values.adapters.commandAndControlSpec.hostnameVerificationRequired }}
 {{- else }}
   {{- required ".Values.adapters.commandAndControlSpec MUST be set if example AMQP Messaging Network is disabled" .dot.Values.adapters.commandAndControlSpec | toYaml | nindent 2 }}
@@ -338,7 +341,8 @@ commandRouter:
   host: {{ .dot.Release.Name }}-service-command-router
   port: 5671
   credentialsPath: /etc/hono/adapter.credentials
-  trustStorePath: /etc/hono/trusted-certs.pem
+  trustStorePath: /etc/hono/truststore.jks
+  trustStorePassword: honotrust
   hostnameVerificationRequired: false
 {{- else }}
   {{- required "Either .Values.adapters.commandRouterSpec MUST be set or .Values.commandRouterService.enabled MUST be 'true' if useCommandRouter is 'true'" nil }}
@@ -374,7 +378,8 @@ deviceConnection:
   {{- end }}
   port: 5671
   credentialsPath: /etc/hono/adapter.credentials
-  trustStorePath: /etc/hono/trusted-certs.pem
+  trustStorePath: /etc/hono/truststore.jks
+  trustStorePassword: honotrust
   hostnameVerificationRequired: false
 {{- end }}
 {{- end }}

--- a/charts/hono/templates/hono-adapter-amqp/hono-adapter-amqp-vertx-secret.yaml
+++ b/charts/hono/templates/hono-adapter-amqp/hono-adapter-amqp-vertx-secret.yaml
@@ -39,7 +39,6 @@ stringData:
 data:
   key.pem: {{ .Files.Get "example/certs/amqp-adapter-key.pem" | b64enc }}
   cert.pem: {{ .Files.Get "example/certs/amqp-adapter-cert.pem" | b64enc }}
-  trusted-certs.pem: {{ .Files.Get "example/certs/trusted-certs.pem" | b64enc }}
-  adapter.credentials: {{ .Files.Get "example/amqp-adapter.credentials" | b64enc }}
   truststore.jks: {{ .Files.Get "example/certs/trustStore.jks" | b64enc }}
+  adapter.credentials: {{ .Files.Get "example/amqp-adapter.credentials" | b64enc }}
 {{- end }}

--- a/charts/hono/templates/hono-adapter-coap/hono-adapter-coap-vertx-secret.yaml
+++ b/charts/hono/templates/hono-adapter-coap/hono-adapter-coap-vertx-secret.yaml
@@ -38,7 +38,6 @@ stringData:
 data:
   key.pem: {{ .Files.Get "example/certs/coap-adapter-key.pem" | b64enc }}
   cert.pem: {{ .Files.Get "example/certs/coap-adapter-cert.pem" | b64enc }}
-  trusted-certs.pem: {{ .Files.Get "example/certs/trusted-certs.pem" | b64enc }}
-  adapter.credentials: {{ .Files.Get "example/coap-adapter.credentials" | b64enc }}
   truststore.jks: {{ .Files.Get "example/certs/trustStore.jks" | b64enc }}
+  adapter.credentials: {{ .Files.Get "example/coap-adapter.credentials" | b64enc }}
 {{- end }}

--- a/charts/hono/templates/hono-adapter-http/hono-adapter-http-vertx-secret.yaml
+++ b/charts/hono/templates/hono-adapter-http/hono-adapter-http-vertx-secret.yaml
@@ -39,7 +39,6 @@ stringData:
 data:
   key.pem: {{ .Files.Get "example/certs/http-adapter-key.pem" | b64enc }}
   cert.pem: {{ .Files.Get "example/certs/http-adapter-cert.pem" | b64enc }}
-  trusted-certs.pem: {{ .Files.Get "example/certs/trusted-certs.pem" | b64enc }}
-  adapter.credentials: {{ .Files.Get "example/http-adapter.credentials" | b64enc }}
   truststore.jks: {{ .Files.Get "example/certs/trustStore.jks" | b64enc }}
+  adapter.credentials: {{ .Files.Get "example/http-adapter.credentials" | b64enc }}
 {{- end }}

--- a/charts/hono/templates/hono-adapter-kura/hono-adapter-kura-secret.yaml
+++ b/charts/hono/templates/hono-adapter-kura/hono-adapter-kura-secret.yaml
@@ -38,7 +38,6 @@ stringData:
 data:
   key.pem: {{ .Files.Get "example/certs/kura-adapter-key.pem" | b64enc }}
   cert.pem: {{ .Files.Get "example/certs/kura-adapter-cert.pem" | b64enc }}
-  trusted-certs.pem: {{ .Files.Get "example/certs/trusted-certs.pem" | b64enc }}
-  adapter.credentials: {{ .Files.Get "example/kura-adapter.credentials" | b64enc }}
   truststore.jks: {{ .Files.Get "example/certs/trustStore.jks" | b64enc }}
+  adapter.credentials: {{ .Files.Get "example/kura-adapter.credentials" | b64enc }}
 {{- end }}

--- a/charts/hono/templates/hono-adapter-lora/hono-adapter-lora-vertx-secret.yaml
+++ b/charts/hono/templates/hono-adapter-lora/hono-adapter-lora-vertx-secret.yaml
@@ -38,7 +38,6 @@ stringData:
 data:
   key.pem: {{ .Files.Get "example/certs/lora-adapter-key.pem" | b64enc }}
   cert.pem: {{ .Files.Get "example/certs/lora-adapter-cert.pem" | b64enc }}
-  trusted-certs.pem: {{ .Files.Get "example/certs/trusted-certs.pem" | b64enc }}
-  adapter.credentials: {{ .Files.Get "example/lora-adapter.credentials" | b64enc }}
   truststore.jks: {{ .Files.Get "example/certs/trustStore.jks" | b64enc }}
+  adapter.credentials: {{ .Files.Get "example/lora-adapter.credentials" | b64enc }}
 {{- end }}

--- a/charts/hono/templates/hono-adapter-mqtt/hono-adapter-mqtt-vertx-secret.yaml
+++ b/charts/hono/templates/hono-adapter-mqtt/hono-adapter-mqtt-vertx-secret.yaml
@@ -43,7 +43,6 @@ stringData:
 data:
   key.pem: {{ .Files.Get "example/certs/mqtt-adapter-key.pem" | b64enc }}
   cert.pem: {{ .Files.Get "example/certs/mqtt-adapter-cert.pem" | b64enc }}
-  trusted-certs.pem: {{ .Files.Get "example/certs/trusted-certs.pem" | b64enc }}
-  adapter.credentials: {{ .Files.Get "example/mqtt-adapter.credentials" | b64enc }}
   truststore.jks: {{ .Files.Get "example/certs/trustStore.jks" | b64enc }}
+  adapter.credentials: {{ .Files.Get "example/mqtt-adapter.credentials" | b64enc }}
 {{- end }}

--- a/charts/hono/templates/hono-service-auth/hono-service-auth-secret.yaml
+++ b/charts/hono/templates/hono-service-auth/hono-service-auth-secret.yaml
@@ -29,7 +29,8 @@ stringData:
           bindAddress: "0.0.0.0"
           keyPath: "/etc/hono/key.pem"
           certPath: "/etc/hono/cert.pem"
-          trustStorePath: "/etc/hono/trusted-certs.pem"
+          trustStorePath: "/etc/hono/truststore.jks"
+          trustStorePassword: honotrust
           insecurePortBindAddress: "0.0.0.0"
           insecurePortEnabled: true
           {{- end }}
@@ -42,5 +43,5 @@ stringData:
 data:
   key.pem: {{ .Files.Get "example/certs/auth-server-key.pem" | b64enc }}
   cert.pem: {{ .Files.Get "example/certs/auth-server-cert.pem" | b64enc }}
-  trusted-certs.pem: {{ .Files.Get "example/certs/trusted-certs.pem" | b64enc }}
+  truststore.jks: {{ .Files.Get "example/certs/trustStore.jks" | b64enc }}
   permissions.json: {{ .Files.Get "example/example-permissions.json" | b64enc }}

--- a/charts/hono/templates/hono-service-command-router/hono-service-command-router-secret.yaml
+++ b/charts/hono/templates/hono-service-command-router/hono-service-command-router-secret.yaml
@@ -29,7 +29,8 @@ stringData:
         {{- else }}
         host: {{ printf "%s-service-auth" .Release.Name | quote }}
         port: 5671
-        trustStorePath: "/etc/hono/trusted-certs.pem"
+        trustStorePath: "/etc/hono/truststore.jks"
+        trustStorePassword: honotrust
         hostnameVerificationRequired: false
         name: {{ printf "Hono %s" $args.component | quote }}
         validation:
@@ -81,6 +82,7 @@ stringData:
         keyPath: {{ .Values.adapters.commandAndControlSpec.keyPath }}
         certPath: {{ .Values.adapters.commandAndControlSpec.certPath }}
         trustStorePath: {{ .Values.adapters.commandAndControlSpec.trustStorePath }}
+        trustStorePassword: {{ .Values.adapters.commandAndControlSpec.trustStorePassword }}
         hostnameVerificationRequired: {{ .Values.adapters.commandAndControlSpec.hostnameVerificationRequired }}
       {{- else }}
         {{- required ".Values.adapters.commandAndControlSpec MUST be set if example AMQP Messaging Network is disabled" .Values.adapters.commandAndControlSpec | toYaml | nindent 8 }}
@@ -99,8 +101,7 @@ stringData:
 data:
   key.pem: {{ .Files.Get "example/certs/command-router-key.pem" | b64enc }}
   cert.pem: {{ .Files.Get "example/certs/command-router-cert.pem" | b64enc }}
-  trusted-certs.pem: {{ .Files.Get "example/certs/trusted-certs.pem" | b64enc }}
+  truststore.jks: {{ .Files.Get "example/certs/trustStore.jks" | b64enc }}
   auth-server-cert.pem: {{ .Files.Get "example/certs/auth-server-cert.pem" | b64enc }}
   adapter.credentials: {{ .Files.Get "example/command-router.credentials" | b64enc }}
-  truststore.jks: {{ .Files.Get "example/certs/trustStore.jks" | b64enc }}
 {{- end }}

--- a/charts/hono/templates/hono-service-device-connection/hono-service-device-connection-secret.yaml
+++ b/charts/hono/templates/hono-service-device-connection/hono-service-device-connection-secret.yaml
@@ -29,7 +29,8 @@ stringData:
         {{- else }}
         host: {{ printf "%s-service-auth" .Release.Name | quote }}
         port: 5671
-        trustStorePath: "/etc/hono/trusted-certs.pem"
+        trustStorePath: "/etc/hono/truststore.jks"
+        trustStorePassword: honotrust
         hostnameVerificationRequired: false
         name: {{ printf "Hono %s" $args.component | quote }}
         validation:
@@ -66,6 +67,6 @@ stringData:
 data:
   key.pem: {{ .Files.Get "example/certs/device-connection-key.pem" | b64enc }}
   cert.pem: {{ .Files.Get "example/certs/device-connection-cert.pem" | b64enc }}
-  trusted-certs.pem: {{ .Files.Get "example/certs/trusted-certs.pem" | b64enc }}
+  truststore.jks: {{ .Files.Get "example/certs/trustStore.jks" | b64enc }}
   auth-server-cert.pem: {{ .Files.Get "example/certs/auth-server-cert.pem" | b64enc }}
 {{- end }}

--- a/charts/hono/templates/hono-service-device-registry-embedded/hono-service-device-registry-secret.yaml
+++ b/charts/hono/templates/hono-service-device-registry-embedded/hono-service-device-registry-secret.yaml
@@ -28,7 +28,8 @@ stringData:
         {{- else }}
         host: {{ printf "%s-service-auth" .Release.Name | quote }}
         port: 5671
-        trustStorePath: "/etc/hono/trusted-certs.pem"
+        trustStorePath: "/etc/hono/truststore.jks"
+        trustStorePassword: honotrust
         hostnameVerificationRequired: false
         name: {{ printf "Hono %s" $args.component | quote }}
         supportedSaslMechanisms: "PLAIN"
@@ -77,6 +78,6 @@ stringData:
 data:
   key.pem: {{ .Files.Get "example/certs/device-registry-key.pem" | b64enc }}
   cert.pem: {{ .Files.Get "example/certs/device-registry-cert.pem" | b64enc }}
-  trusted-certs.pem: {{ .Files.Get "example/certs/trusted-certs.pem" | b64enc }}
+  truststore.jks: {{ .Files.Get "example/certs/trustStore.jks" | b64enc }}
   auth-server-cert.pem: {{ .Files.Get "example/certs/auth-server-cert.pem" | b64enc }}
 {{- end }}

--- a/charts/hono/templates/hono-service-device-registry-file/hono-service-device-registry-secret.yaml
+++ b/charts/hono/templates/hono-service-device-registry-file/hono-service-device-registry-secret.yaml
@@ -28,7 +28,8 @@ stringData:
         {{- else }}
         host: {{ printf "%s-service-auth" .Release.Name | quote }}
         port: 5671
-        trustStorePath: "/etc/hono/trusted-certs.pem"
+        trustStorePath: "/etc/hono/truststore.jks"
+        trustStorePassword: honotrust
         hostnameVerificationRequired: false
         name: {{ printf "Hono %s" $args.component | quote }}
         supportedSaslMechanisms: "PLAIN"
@@ -72,7 +73,6 @@ stringData:
 data:
   key.pem: {{ .Files.Get "example/certs/device-registry-key.pem" | b64enc }}
   cert.pem: {{ .Files.Get "example/certs/device-registry-cert.pem" | b64enc }}
-  trusted-certs.pem: {{ .Files.Get "example/certs/trusted-certs.pem" | b64enc }}
-  auth-server-cert.pem: {{ .Files.Get "example/certs/auth-server-cert.pem" | b64enc }}
   truststore.jks: {{ .Files.Get "example/certs/trustStore.jks" | b64enc }}
+  auth-server-cert.pem: {{ .Files.Get "example/certs/auth-server-cert.pem" | b64enc }}
 {{- end }}

--- a/charts/hono/templates/hono-service-device-registry-jdbc/hono-service-device-registry-secret.yaml
+++ b/charts/hono/templates/hono-service-device-registry-jdbc/hono-service-device-registry-secret.yaml
@@ -28,7 +28,8 @@ stringData:
         {{- else }}
         host: {{ printf "%s-service-auth" .Release.Name | quote }}
         port: 5671
-        trustStorePath: "/etc/hono/trusted-certs.pem"
+        trustStorePath: "/etc/hono/truststore.jks"
+        trustStorePassword: honotrust
         hostnameVerificationRequired: false
         name: {{ printf "Hono %s" $args.component | quote }}
         supportedSaslMechanisms: "PLAIN"
@@ -71,7 +72,6 @@ stringData:
 data:
   key.pem: {{ .Files.Get "example/certs/device-registry-key.pem" | b64enc }}
   cert.pem: {{ .Files.Get "example/certs/device-registry-cert.pem" | b64enc }}
-  trusted-certs.pem: {{ .Files.Get "example/certs/trusted-certs.pem" | b64enc }}
-  auth-server-cert.pem: {{ .Files.Get "example/certs/auth-server-cert.pem" | b64enc }}
   truststore.jks: {{ .Files.Get "example/certs/trustStore.jks" | b64enc }}
+  auth-server-cert.pem: {{ .Files.Get "example/certs/auth-server-cert.pem" | b64enc }}
 {{- end }}

--- a/charts/hono/templates/hono-service-device-registry-mongodb/hono-service-device-registry-secret.yaml
+++ b/charts/hono/templates/hono-service-device-registry-mongodb/hono-service-device-registry-secret.yaml
@@ -28,7 +28,8 @@ stringData:
         {{- else }}
         host: {{ printf "%s-service-auth" .Release.Name | quote }}
         port: 5671
-        trustStorePath: "/etc/hono/trusted-certs.pem"
+        trustStorePath: "/etc/hono/truststore.jks"
+        trustStorePassword: honotrust
         hostnameVerificationRequired: false
         name: {{ printf "Hono %s" $args.component | quote }}
         supportedSaslMechanisms: "PLAIN"
@@ -72,7 +73,6 @@ stringData:
 data:
   key.pem: {{ .Files.Get "example/certs/device-registry-key.pem" | b64enc }}
   cert.pem: {{ .Files.Get "example/certs/device-registry-cert.pem" | b64enc }}
-  trusted-certs.pem: {{ .Files.Get "example/certs/trusted-certs.pem" | b64enc }}
-  auth-server-cert.pem: {{ .Files.Get "example/certs/auth-server-cert.pem" | b64enc }}
   truststore.jks: {{ .Files.Get "example/certs/trustStore.jks" | b64enc }}
+  auth-server-cert.pem: {{ .Files.Get "example/certs/auth-server-cert.pem" | b64enc }}
 {{- end }}

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -385,7 +385,8 @@ adapters:
   amqpMessagingNetworkSpec:
     keyPath: /etc/hono/key.pem
     certPath: /etc/hono/cert.pem
-    trustStorePath: /etc/hono/trusted-certs.pem
+    trustStorePath: /etc/hono/truststore.jks
+    trustStorePassword: honotrust
     hostnameVerificationRequired: false
   #  host: my-amqp-host
   #  port: 5671
@@ -403,7 +404,8 @@ adapters:
   commandAndControlSpec:
     keyPath: /etc/hono/key.pem
     certPath: /etc/hono/cert.pem
-    trustStorePath: /etc/hono/trusted-certs.pem
+    trustStorePath: /etc/hono/truststore.jks
+    trustStorePassword: honotrust
     hostnameVerificationRequired: false
 
   # kafkaMessagingSpec contains the configuration used by all protocol


### PR DESCRIPTION
As discussed in https://github.com/eclipse/packages/pull/237#discussion_r646366566:
Kafka (in the version currently used by Hono) does not support PEM files. Instead of providing the same certificates in PEM as well as in JKS format to Hono's components, this replaces the usage of the file `trusted-certs.pem` with the file `trustStore.jks`. The JKS file requires a password which is added to the configuration as well.