### PR TITLE
Use Helm 3 in Jenkinsfile

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -8,7 +8,7 @@ properties([
 ])
 
 def label = "packages-${UUID.randomUUID().toString()}"
-def HELM_VERSION = "2.16.1"
+def HELM_VERSION = "3.1.3"
 
 def needToDeploy() {
     return BRANCH_NAME == 'master' || BRANCH_NAME == 'develop'
@@ -84,16 +84,12 @@ podTemplate(
             "PROJECT_NAME=packages",
             "PROJECT_BOT_NAME=Eclipse IoT Packages Bot",
             "HELM_VERSION=${HELM_VERSION}",
-            "HELM_HOME=${env.WORKSPACE}/helm-home",
+            "XDG_CACHE_HOME=${env.WORKSPACE}/helm-cache",
+            "XDG_CONFIG_HOME=${env.WORKSPACE}/helm-config",
+            "XDG_DATA_HOME=${env.WORKSPACE}/helm-data",
         ]) {
 
             try {
-
-                stage('Helm Init') {
-                    sh '''
-                        ${WORKSPACE}/helm init --client-only --stable-repo-url https://charts.helm.sh/stable
-                       '''
-                }
 
                 stage('Helm Build') {
                     dir("build") {


### PR DESCRIPTION
Helm 3 is required now, otherwise packaging the Hono chart fails.

Corresponding manually triggered Jenkins run (via Replay) is at https://ci.eclipse.org/packages/job/Website/job/master/153/.
