### PR TITLE
[Hono] Add NodePort deployment to Hono readme

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.9.0
+version: 1.9.1
 # Version of Hono being deployed by the chart
 appVersion: 1.8.0
 keywords:

--- a/charts/hono/README.md
+++ b/charts/hono/README.md
@@ -546,8 +546,11 @@ The following command provides a quickstart for Kafka based messaging (ensure `m
 helm install --dependency-update -n hono --set messagingNetworkTypes[0]=kafka --set kafkaMessagingClusterExample.enabled=true --set amqpMessagingNetworkExample.enabled=false eclipse-hono eclipse-iot/hono
 ```
 
-It enables the deployment of an example Kafka cluster, disables the deployment of the AMQP 1.0 messaging network 
-and configures adapters and services to use Kafka based messaging.
+The parameters enable the deployment of an example Kafka cluster, disable the deployment of the AMQP 1.0 messaging network 
+and configure adapters and services to use Kafka based messaging.
+
+To use the service type `NodePort` instead of `LoadBalancer`, the following parameters must be added: 
+`--set useLoadBalancer=false --set kafka.externalAccess.service.type=NodePort`.
 
 ### Using a production grade Kafka cluster
 


### PR DESCRIPTION
This adds documentation of the properties that are required to use services of type 'NodePort' instead of type 'LoadBalancer' to the readme of the Hono chart.