### PR TITLE
[#260] Hono: Support Kafka based messaging in embedded Device Registry

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.9.1
+version: 1.9.2
 # Version of Hono being deployed by the chart
 appVersion: 1.8.0
 keywords:

--- a/charts/hono/templates/hono-service-device-registry-embedded/hono-service-device-registry-secret.yaml
+++ b/charts/hono/templates/hono-service-device-registry-embedded/hono-service-device-registry-secret.yaml
@@ -72,11 +72,12 @@ stringData:
           management:
             url: "jdbc:h2:/var/lib/hono/device-registry/registry"
             driverClass: "org.h2.Driver"
-      {{- include "hono.amqpMessagingNetworkClientConfig" $args | nindent 6 }}
+      {{- include "hono.messagingNetworkClientConfig" $args | nindent 6 }}
       {{- include "hono.healthServerConfig" .Values.deviceRegistryExample.hono.healthCheck | nindent 6 }}
 data:
   key.pem: {{ .Files.Get "example/certs/device-registry-key.pem" | b64enc }}
   cert.pem: {{ .Files.Get "example/certs/device-registry-cert.pem" | b64enc }}
   trusted-certs.pem: {{ .Files.Get "example/certs/trusted-certs.pem" | b64enc }}
   auth-server-cert.pem: {{ .Files.Get "example/certs/auth-server-cert.pem" | b64enc }}
+  truststore.jks: {{ .Files.Get "example/certs/trustStore.jks" | b64enc }}
 {{- end }}


### PR DESCRIPTION
This fixes #260. It adds support for Kafka-based messaging to the device registry with an embedded database.