### PR TITLE
Hono: Allow to disable TLS on example Kafka deployment

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.9.2
+version: 1.9.3
 # Version of Hono being deployed by the chart
 appVersion: 1.8.0
 keywords:


### PR DESCRIPTION
Adds client configuration for cases in which the example Kafka broker is configured to allow unencrypted connections from clients. This is intended to be used in the Hono Sandbox.