### PR TITLE
Hono: Enable parallel usage of AMQP and Kafka messaging

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.8.4
+version: 1.9.0
 # Version of Hono being deployed by the chart
 appVersion: 1.8.0
 keywords:

--- a/charts/hono/README.md
+++ b/charts/hono/README.md
@@ -534,12 +534,16 @@ of Quarkus based services images.
 ## Using Kafka based Messaging
 
 The chart can be configured to use Kafka as the messaging network instead of an AMQP 1.0 messaging network.
-The property `messagingNetworkType` is used to select the type of the messaging network.
+The configuration `messagingNetworkTypes[0]=kafka` deploys Hono configured to use Kafka for messaging.
+It is possible to enable AMQP _and_ Kafka based messaging at the same time (command line parameters of the deployment 
+would be `--set messagingNetworkTypes[0]=amqp --set messagingNetworkTypes[1]=kafka`). Each tenant in Hono can then be 
+[configured](https://www.eclipse.org/hono/docs/admin-guide/hono-kafka-client-configuration/#configure-for-kafka-based-messaging)
+to use Kafka _or_ AMQP for messaging.
 
 The following command provides a quickstart for Kafka based messaging (ensure `minikube tunnel` is running when using Minikube):
 
 ```bash
-helm install --dependency-update -n hono --set messagingNetworkType=kafka --set kafkaMessagingClusterExample.enabled=true --set amqpMessagingNetworkExample.enabled=false  eclipse-hono eclipse-iot/hono
+helm install --dependency-update -n hono --set messagingNetworkTypes[0]=kafka --set kafkaMessagingClusterExample.enabled=true --set amqpMessagingNetworkExample.enabled=false eclipse-hono eclipse-iot/hono
 ```
 
 It enables the deployment of an example Kafka cluster, disables the deployment of the AMQP 1.0 messaging network 
@@ -547,7 +551,7 @@ and configures adapters and services to use Kafka based messaging.
 
 ### Using a production grade Kafka cluster
 
-If Kafka based messaging is enabled by setting `messagingNetworkType` to `kafka`, the Kafka clients need to
+If Kafka based messaging is enabled by adding `kafka` to `messagingNetworkTypes`, the Kafka clients need to
 be configured with connection information for a Kafka cluster. The Helm chart can deploy an example Kafka cluster. 
 This is enabled by setting `kafkaMessagingClusterExample.enabled` to `true`. With this setting the chart
 deploys a Kafka cluster consisting of a single broker and a single Zookeeper instance and configures the 
@@ -564,7 +568,8 @@ The easiest way to set these properties is by means of putting them into a YAML 
 
 ```yaml
 # configure protocol adapters for Kafka messaging
-messagingNetworkType: kafka
+messagingNetworkTypes: 
+  - kafka
 
 # do not deploy example AMQP Messaging Network
 amqpMessagingNetworkExample:

--- a/charts/hono/profileKafkaMessaging.yaml
+++ b/charts/hono/profileKafkaMessaging.yaml
@@ -10,7 +10,8 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
-messagingNetworkType: kafka
+messagingNetworkTypes:
+  - kafka
 
 kafkaMessagingClusterExample:
   enabled: true

--- a/charts/hono/templates/hono-service-command-router/hono-service-command-router-secret.yaml
+++ b/charts/hono/templates/hono-service-command-router/hono-service-command-router-secret.yaml
@@ -71,7 +71,7 @@ stringData:
       tenant:
         {{- required ".Values.adapters.tenantSpec MUST be set if example Device Registry is disabled" .Values.adapters.tenantSpec | toYaml | nindent 8 }}
       {{- end }}
-      {{- if eq .Values.messagingNetworkType "amqp" }}
+      {{- if has "amqp" .Values.messagingNetworkTypes }}
       command:
       {{- if .Values.amqpMessagingNetworkExample.enabled }}
         name: {{ printf "Hono %s" $args.component | quote }}
@@ -85,10 +85,12 @@ stringData:
       {{- else }}
         {{- required ".Values.adapters.commandAndControlSpec MUST be set if example AMQP Messaging Network is disabled" .Values.adapters.commandAndControlSpec | toYaml | nindent 8 }}
       {{- end }}
-      {{- else if eq .Values.messagingNetworkType "kafka" }}
-        {{- include "hono.kafkaMessagingConfig" $args | nindent 6 }}
-      {{- else }}
-        {{- required "Values.messagingNetworkType MUST be either 'amqp' or 'kafka'" nil }}
+      {{- end }}
+      {{- if has "kafka" .Values.messagingNetworkTypes }}
+        {{- include "hono.kafkaMessagingConfig" $args | indent 6 }}
+      {{- end -}}
+      {{- if and (not (has "amqp" .Values.messagingNetworkTypes)) (not (has "kafka" .Values.messagingNetworkTypes)) -}}
+        {{- required "Property messagingNetworkTypes MUST contain 'amqp' and/or 'kafka'" nil }}
       {{- end }}
       {{- include "hono.healthServerConfig" .Values.commandRouterService.hono.healthCheck | nindent 6 }}
     {{- include "hono.quarkusConfig" $args | indent 4 }}

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -40,7 +40,7 @@ livenessProbeInitialDelaySeconds: 300
 readinessProbeInitialDelaySeconds: 20
 
 # amqpMessagingNetworkExample contains properties for configuring an example AMQP network
-# to be used for messaging if "messagingNetworkType" is set to "amqp"
+# to be used for messaging if "messagingNetworkTypes" contains "amqp"
 amqpMessagingNetworkExample:
   # enabled indicates whether the example AMQP Messaging Network
   # consisting of a single Dispatch Router and Broker should be
@@ -338,13 +338,14 @@ useLoadBalancer: true
 # Device Connection service towards the new Command Router service.
 useCommandRouter: true
 
-# messagingNetworkType indicates which type of messaging should be used.
+# messagingNetworkTypes indicates the type(s) of messaging to be used.
 # The following types are defined:
 # - amqp: AMQP 1.0 based messaging. Also refer to the
 #     sections "amqpMessagingNetworkExample" and "adapters.amqpMessagingNetworkSpec".
 # - kafka: Apache Kafka based messaging. Also refer to the
 #     sections "kafkaMessagingClusterExample" and "adapters.kafkaMessagingSpec"
-messagingNetworkType: amqp
+messagingNetworkTypes:
+  - amqp
 
 # Configuration properties for protocol adapters.
 adapters:
@@ -376,7 +377,7 @@ adapters:
 
   # amqpMessagingNetworkSpec contains Hono client properties used by all protocol
   # adapters for connecting to the AMQP Messaging Network to forward downstream messages to.
-  # This property MUST be set if "messagingNetworkType" is "amqp" and
+  # This property MUST be set if "messagingNetworkTypes" contains "amqp" and
   # "amqpMessagingNetworkExample.enabled" is set to false.
   # Please refer to https://www.eclipse.org/hono/docs/admin-guide/hono-client-configuration/
   # for a description of supported properties.
@@ -394,7 +395,7 @@ adapters:
   # commandAndControlSpec contains Hono client properties used by all protocol
   # adapters for connecting to the AMQP Messaging Network which is used by applications
   # to send commands to devices.
-  # This property MUST be set if "messagingNetworkType" is "amqp" and
+  # This property MUST be set if "messagingNetworkTypes" contains "amqp" and
   # "amqpMessagingNetworkExample.enabled" is set to false.
   # Please refer to https://www.eclipse.org/hono/docs/admin-guide/hono-client-configuration/
   # for a description of supported properties.
@@ -408,7 +409,7 @@ adapters:
 
   # kafkaMessagingSpec contains the configuration used by all protocol
   # adapters for connecting to the Kafka cluster to be uses for messaging.
-  # This property MUST be set if "messagingNetworkType" is "kafka" and
+  # This property MUST be set if "messagingNetworkTypes" contains "kafka" and
   # "kafkaMessagingClusterExample.enabled" is set to false.
   # Please refer to https://www.eclipse.org/hono/docs/admin-guide/hono-kafka-client-configuration/
   # for a description of supported properties.
@@ -1787,7 +1788,7 @@ grafana:
     namespaced: true
 
 # kafkaMessagingClusterExample contains properties for configuring an example Kafka cluster
-# to be used for messaging if "messagingNetworkType" is set to "kafka"
+# to be used for messaging if "messagingNetworkTypes" contains "kafka"
 kafkaMessagingClusterExample:
   # enabled indicates whether the example Kafka cluster consisting of a single broker
   # and one Zookeeper instance should be deployed. This minimal deployment is not suitable


### PR DESCRIPTION
Instead of selecting one messaging type with the property `messagingNetworkType`, the messaging configuration is now selected with the property `messagingNetworkTypes` that allows setting more than one value. This is intended to be used for the deployment of Hono's sandbox, where both messaging networks should be enabled simultaneously.