### PR TITLE
[Hono] Do not expose Command Router and Device Connection Service.

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.9.3
+version: 1.9.4
 # Version of Hono being deployed by the chart
 appVersion: 1.8.0
 keywords:

--- a/charts/hono/templates/hono-service-auth/hono-service-auth-secret.yaml
+++ b/charts/hono/templates/hono-service-auth/hono-service-auth-secret.yaml
@@ -37,7 +37,7 @@ stringData:
           {{- with .Values.authServer.hono.auth.svc }}
           {{- . | toYaml | nindent 10 }}
           {{- end }}
-      {{- include "hono.healthServerConfig" .Values.authServer.hono.healthServer | nindent 6 }}
+      {{- include "hono.healthServerConfig" .Values.authServer.hono.healthCheck | nindent 6 }}
     {{- include "hono.quarkusConfig" $args | indent 4 }}
 data:
   key.pem: {{ .Files.Get "example/certs/auth-server-key.pem" | b64enc }}

--- a/charts/hono/templates/hono-service-command-router/hono-service-command-router-svc.yaml
+++ b/charts/hono/templates/hono-service-command-router/hono-service-command-router-svc.yaml
@@ -28,8 +28,4 @@ spec:
     targetPort: amqps
   selector:
     {{- include "hono.matchLabels" $args | nindent 4 }}
-  {{- include "hono.serviceType" . }}
-{{- with .Values.commandRouterService.svc.loadBalancerIP }}
-  loadBalancerIP: {{ . | quote }}
-{{- end }}
 {{- end }}

--- a/charts/hono/templates/hono-service-device-connection/hono-service-device-connection-svc.yaml
+++ b/charts/hono/templates/hono-service-device-connection/hono-service-device-connection-svc.yaml
@@ -28,8 +28,4 @@ spec:
     targetPort: amqps
   selector:
     {{- include "hono.matchLabels" $args | nindent 4 }}
-  {{- include "hono.serviceType" . }}
-{{- with .Values.deviceConnectionService.svc.loadBalancerIP }}
-  loadBalancerIP: {{ . | quote }}
-{{- end }}
 {{- end }}


### PR DESCRIPTION
The "Command Router" and "Device Connection Service" components are no longer exposed to the outside of the Kubernetes cluster.

PS: I just saw that I pushed by accident a very small fix for the Auth service config. I'll leave it here because it's really small and obvious :)