### PR TITLE
[#267] Hono: Use standard Kafka port for external access.

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.9.5
+version: 1.9.6
 # Version of Hono being deployed by the chart
 appVersion: 1.8.0
 keywords:

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -1821,7 +1821,7 @@ kafka:
     enabled: true
     service:
       type: LoadBalancer
-      port: 9094
+      port: 9092
       loadBalancerIPs: []
     autoDiscovery:
       enabled: true
@@ -1834,7 +1834,7 @@ kafka:
   # the name of the template (maintains the release name)
   nameOverride: kafka
   service:
-    port: 9092
+    port: 9094
   auth:
     clientProtocol: sasl_tls
     sasl:


### PR DESCRIPTION
This fixes #267. 
It configures the example Kafka cluster that can be deployed with Hono to expose the standard Kafka port 9092 for external access. Before the port 9094 was used as an external port and 9092 was used only internally in the Kubernetes cluster. This commit changes both ports.