### PR TITLE
Use Infinispan server native image

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.9.7
+version: 1.9.8
 # Version of Hono being deployed by the chart
 appVersion: 1.9.0
 keywords:

--- a/charts/hono/config/infinispan/hono-data-grid.xml
+++ b/charts/hono/config/infinispan/hono-data-grid.xml
@@ -19,7 +19,7 @@
         <key media-type="text/plain" />
         <value media-type="text/plain" />
       </encoding>
-      <memory storage="OFF_HEAP" max-size="30 MB" when-full="REMOVE"/>
+      <memory storage="OFF_HEAP" max-size="{{ .Values.dataGridExample.dataMaxSize }}" when-full="REMOVE"/>
       <security>
         <authorization enabled="true" />
       </security>
@@ -29,43 +29,35 @@
   <server xmlns="urn:infinispan:server:11.0">
     <interfaces>
       <interface name="public">
-        <non-loopback />
+        <inet-address value="${infinispan.bind.address:0.0.0.0}" />
       </interface>
-      <interface name="admin">
+      <interface name="local">
         <loopback />
       </interface>
     </interfaces>
 
-    <socket-bindings default-interface="public" port-offset="${infinispan.socket.binding.port-offset:0}">
-      <socket-binding name="default" port="${infinispan.bind.port:11222}"/>
-      <socket-binding name="admin" port="9990" interface="admin"/>
+    <socket-bindings default-interface="local" port-offset="${infinispan.socket.binding.port-offset:0}">
+      <socket-binding name="default" port="${infinispan.bind.port:11222}" interface="public"/>
+      <socket-binding name="admin" port="9990"/>
     </socket-bindings>
 
     <security>
       <security-realms>
         <security-realm name="ManagementRealm">
           <properties-realm groups-attribute="Roles">
-            <user-properties path="hono/users.properties"
+            <user-properties path="users.properties"
                              relative-to="infinispan.server.config.path"
                              plain-text="true" />
-            <group-properties path="hono/mgmt-groups.properties"
+            <group-properties path="mgmt-groups.properties"
                              relative-to="infinispan.server.config.path"/>
           </properties-realm>
         </security-realm>
         <security-realm name="ApplicationRealm">
-          <server-identities>
-            <ssl>
-              <keystore path="application.keystore" relative-to="infinispan.server.config.path"
-                             keystore-password="password" alias="server" key-password="password"
-                             generate-self-signed-certificate-host="localhost"/>
-              <engine enabled-protocols="TLSv1.2"/>
-            </ssl>
-          </server-identities>
           <properties-realm groups-attribute="Roles">
-            <user-properties path="hono/users.properties"
+            <user-properties path="users.properties"
                              relative-to="infinispan.server.config.path"
                              plain-text="true" />
-            <group-properties path="hono/public-groups.properties"
+            <group-properties path="public-groups.properties"
                              relative-to="infinispan.server.config.path" />
           </properties-realm>
         </security-realm>

--- a/charts/hono/templates/_helpers.tpl
+++ b/charts/hono/templates/_helpers.tpl
@@ -438,6 +438,7 @@ quarkus:
   log:
     console:
       color: true
+    min-level: TRACE
     level: INFO
     category:
       "org.eclipse.hono":
@@ -448,6 +449,8 @@ quarkus:
         level: INFO
   vertx:
     prefer-native-transport: true
+    resolver:
+      cache-max-time-to-live: 0
 {{- end }}
 {{- end }}
 

--- a/charts/hono/templates/example-data-grid/statefulset.yaml
+++ b/charts/hono/templates/example-data-grid/statefulset.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.dataGridExample.enabled }}
 #
-# Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -33,7 +33,7 @@ spec:
         command:
         - /opt/infinispan/bin/server.sh
         - -c
-        - /opt/infinispan/server/conf/hono/hono-data-grid.xml
+        - hono-data-grid.xml
         env:
         - name: JDK_JAVA_OPTIONS
           value: "-XX:MinRAMPercentage=85 -XX:MaxRAMPercentage=85"
@@ -44,7 +44,7 @@ spec:
           containerPort: 11222
           protocol: TCP
         volumeMounts:
-        - mountPath: /opt/infinispan/server/conf/hono
+        - mountPath: /opt/infinispan/server/conf
           name: conf
           readOnly: true
         livenessProbe:

--- a/charts/hono/templates/hono-service-command-router/hono-service-command-router-secret.yaml
+++ b/charts/hono/templates/hono-service-command-router/hono-service-command-router-secret.yaml
@@ -18,6 +18,8 @@ metadata:
   {{- include "hono.metadata" $args | nindent 2 }}
 type: Opaque
 stringData:
+  dns-cache-config.properties: |
+    networkaddress.cache.negative.ttl=0
   application.yml: |
     hono:
       app:

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -188,7 +188,7 @@ dataGridExample:
   enabled: false
   # imageName contains the name (including tag)
   # of the container image to use for the example data grid.
-  imageName: infinispan/server:11.0.9.Final-1
+  imageName: infinispan/server-native:11.0.7.Final-2
   # livenessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
   # configuration property of the component's liveness probe.
   livenessProbeInitialDelaySeconds: 300
@@ -201,15 +201,17 @@ dataGridExample:
   # for a description of the properties' semantics.
   resources:
     requests:
-      cpu: "200m"
-      memory: "300Mi"
+      cpu: "150m"
+      memory: "100Mi"
     limits:
       cpu: "1"
-      memory: "512Mi"
+      memory: "200Mi"
   # authUsername contains the name of the user that is authorized to connect to the example data grid.
   authUsername: "hono"
   # authPassword contains the secret of the user that is authorized to connect to the example data grid
   authPassword: "hono-secret"
+  # dataMaxSize contains the maximum size of off-heap memory used for storing data per Infinispan node
+  dataMaxSize: "30 MB"
 
 # dataGridSpec contains properties for configuring the Infinispan Hotrod connection
 # to the existing data grid (i.e. not the example grid) that should be used for storing
@@ -1605,7 +1607,7 @@ commandRouterService:
   # containerRegistry:
   # javaOptions contains options to pass to the JVM when starting
   # up the service
-  javaOptions: -XX:MinRAMPercentage=80 -XX:MaxRAMPercentage=80
+  javaOptions: -XX:MinRAMPercentage=80 -XX:MaxRAMPercentage=80 -Djava.security.properties=/etc/hono/dns-cache-config.properties
   # springConfigLocation contains the location of the Spring application configuration file(s).
   # See https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config-files
   # for details.


### PR DESCRIPTION
The example data grid currently uses the standard infinispan/server
image which uses a lot of memory. The infinispan/server-native image is
based on a Quarkus native binary which uses fewer memory and starts up
much quicker. It can therefore help to reduce the overall memory
footprint and improve start up time of the overall Hono instance.

Fixes #271