### PR TITLE
Hono: Set node port for external Kafka service.

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.9.11
+version: 1.9.12
 # Version of Hono being deployed by the chart
 appVersion: 1.9.1
 keywords:

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -1817,14 +1817,16 @@ kafka:
       serverUsers: zookeeperUser
       serverPasswords: zookeeperPassword
   # Expose the Kafka service to be accessed from outside the cluster (LoadBalancer service).
-  # Alternatively use NodePort configuration, for more information refer to
+  # To use service type NodePort instead of LoadBalancer, refer to
   # https://github.com/bitnami/charts/tree/master/bitnami/kafka#accessing-kafka-brokers-from-outside-the-cluster
   externalAccess:
     enabled: true
     service:
       type: LoadBalancer
       port: 9092
-      loadBalancerIPs: []
+      # length of the array must match replicaCount
+      nodePorts:
+        - 32092
     autoDiscovery:
       enabled: true
   serviceAccount:


### PR DESCRIPTION
This defines a node port for the external service of the example Kafka broker.