### PR TITLE
Use Quarkus based images by default

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.9.12
+version: 1.9.13
 # Version of Hono being deployed by the chart
 appVersion: 1.9.1
 keywords:

--- a/charts/hono/ci/device-connection-service-values.yaml
+++ b/charts/hono/ci/device-connection-service-values.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Contributors to the Eclipse Foundation
+# Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -15,6 +15,7 @@
 # - without monitoring infrastructure
 # - with example Infinispan data grid
 # - with Device Connection service
+# - using Spring Boot based images
 
 useLoadBalancer: false
 
@@ -29,3 +30,5 @@ dataGridExample:
 
 deviceConnectionService:
   enabled: true
+
+honoImagesType: "spring"

--- a/charts/hono/ci/quarkus-native-images-values.yaml
+++ b/charts/hono/ci/quarkus-native-images-values.yaml
@@ -13,6 +13,7 @@
 
 # profile for installing Hono
 # - without monitoring infrastructure
+# - with example Infinispan data grid
 # - using Quarkus based native images
 
 useLoadBalancer: false
@@ -22,5 +23,8 @@ prometheus:
 
 grafana:
   enabled: false
+
+dataGridExample:
+  enabled: true
 
 honoImagesType: quarkus-native

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -326,7 +326,7 @@ platform: kubernetes
 # - spring
 # - quarkus
 # - quarkus-native
-honoImagesType: "spring"
+honoImagesType: "quarkus"
 
 # useLoadBalancer indicates whether services should be deployed using the
 # "LoadBalancer" type (true) or the "NodePort" type (false).


### PR DESCRIPTION
The Deviec Connection CI profile has been adapted to use the Spring Boot
based images.