### PR TITLE
Update Prometheus and Grafana chart versions

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.9.16
+version: 1.10.0
 # Version of Hono being deployed by the chart
 appVersion: 1.9.1
 keywords:

--- a/charts/hono/requirements.yaml
+++ b/charts/hono/requirements.yaml
@@ -12,11 +12,11 @@
 #
 dependencies:
   - name: prometheus
-    version: ~11.7.0
+    version: ~14.6.0
     repository: "https://prometheus-community.github.io/helm-charts"
     condition: prometheus.createInstance
   - name: grafana
-    version: ~3.8.15
+    version: ~6.16.0
     repository: "https://grafana.github.io/helm-charts"
     condition: grafana.enabled
   - name: mongodb

--- a/charts/hono/templates/grafana/grafana-datasource-secret.yaml
+++ b/charts/hono/templates/grafana/grafana-datasource-secret.yaml
@@ -35,4 +35,6 @@ stringData:
       basicAuth: false
       isDefault: true
       editable: true
+      jsonData:
+        timeInterval: '{{ default "15s" .Values.prometheus.server.global.scrape_interval }}'
 {{- end }}

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -1795,12 +1795,10 @@ grafana:
 
   # labels to be added to the Grafana Deployment
   labels:
-    app.kubernetes.io/name: eclipse-hono
     app.kubernetes.io/component: dashboard
 
   # labels to be added to the Grafana Pod(s)
   podLabels:
-    app.kubernetes.io/name: eclipse-hono
     app.kubernetes.io/component: dashboard
 
 
@@ -1814,7 +1812,6 @@ grafana:
     targetPort: 3000
     annotations: {}
     labels:
-      app.kubernetes.io/name: eclipse-hono
       app.kubernetes.io/component: dashboard
 
   ## Sidecars that collect the configmaps with specified label and stores the included files them into the respective folders


### PR DESCRIPTION
Preventing deprecation warnings regarding 'rbac.authorization.k8s.io/v1beta1' api version:
````
W0817 13:33:20.344759   86807 warnings.go:70] rbac.authorization.k8s.io/v1beta1 ClusterRole is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRole
W0817 13:33:20.347629   86807 warnings.go:70] rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRoleBinding
W0817 13:33:20.350211   86807 warnings.go:70] rbac.authorization.k8s.io/v1beta1 Role is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 Role
W0817 13:33:20.353586   86807 warnings.go:70] rbac.authorization.k8s.io/v1beta1 RoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 RoleBinding
````
and allowing '$__rate_interval' to be used in dashboard queries (Grafana 7.2).

Note that the `grafana.labels.app.kubernetes.io/name`, `grafana.podLabels.app.kubernetes.io/name` and `grafana.service.labels.app.kubernetes.io/name` entries in the `values.yaml` had to be removed because the Grafana chart now sets these values itself.
Otherwise there would be this error when installing:
```
Deployment.apps "eclipse-hono-grafana" is invalid: 
spec.template.metadata.labels: Invalid value: map[string]string{"app.kubernetes.io/component":"dashboard", "app.kubernetes.io/instance":"eclipse-hono", "app.kubernetes.io/name":"eclipse-hono"}: `selector` does not match template `labels`
```
The above change also leads to an error when running `helm upgrade` (`Deployment.apps "eclipse-hono-grafana" is invalid: [...] field is immutable.`). An upgrade of the Prometheus pod also fails (`opening storage failed: lock DB directory: resource temporarily unavailable` in the container log). This is a general issue due to only one replica being supported in the current setup (we could look into setting `prometheus.server.statefulSet.enabled=true` here by default - see https://github.com/helm/charts/pull/7116).
That's why I've increased the Hono chart minor version, not just the patch version here.
