### PR TITLE
Remove workaround for defining Jaeger sampling strategy

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.10.2
+version: 1.10.3
 # Version of Hono being deployed by the chart
 appVersion: 1.9.1
 keywords:

--- a/charts/hono/templates/jaeger/jaeger-deployment.yaml
+++ b/charts/hono/templates/jaeger/jaeger-deployment.yaml
@@ -40,9 +40,6 @@ spec:
         {{- end }}
         {{- end }}
         image: {{ .Values.jaegerBackendExample.allInOneImage }}
-        # the Dockerfile for the all-in-one container defines the "sampling.strategies-file" param in the CMD entry
-        # - this has to be overwritten here so that the SAMPLING_STRATEGIES_FILE env var value will be used instead (see https://github.com/jaegertracing/jaeger/issues/3022)
-        args: [""]
         name: jaeger
         ports:
         - name: collector-grpc

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -240,7 +240,7 @@ jaegerBackendExample:
   enabled: false
   # allInOneImage contains the name (including tag)
   # of the container image to use for the example Jaeger back end.
-  allInOneImage: jaegertracing/all-in-one:1.22
+  allInOneImage: jaegertracing/all-in-one:1.26
   # livenessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
   # configuration property of the component's liveness probe.
   livenessProbeInitialDelaySeconds: 300


### PR DESCRIPTION
https://github.com/jaegertracing/jaeger/issues/3022 has been fixed in
Jaeger All-in-One 1.23
