### PR TITLE
Update k8s versions up to 1.22, keeping the last 5 active

### DIFF
--- a/.github/kubeval.sh
+++ b/.github/kubeval.sh
@@ -19,7 +19,7 @@ set -o pipefail
 
 CHART_DIRS="$(git diff --find-renames --name-only "$(git rev-parse --abbrev-ref HEAD)" remotes/origin/master -- charts packages | grep '[cC]hart.yaml' | sed -e 's#/[Cc]hart.yaml##g')"
 KUBEVAL_VERSION="v0.16.1"
-SCHEMA_LOCATION="https://raw.githubusercontent.com/instrumenta/kubernetes-json-schema/master/"
+SCHEMA_LOCATION="https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/"
 
 # install kubeval
 curl --silent --show-error --fail --location --output /tmp/kubeval.tar.gz https://github.com/instrumenta/kubeval/releases/download/"${KUBEVAL_VERSION}"/kubeval-linux-amd64.tar.gz

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,10 +62,13 @@ jobs:
       matrix:
         # the versions supported by kubeval are the ones for
         # which a folder exists at
-        # https://github.com/instrumenta/kubernetes-json-schema
+        # https://github.com/yannh/kubernetes-json-schema/
         k8s:
-          - v1.17.4
           - v1.18.1
+          - v1.19.7
+          - v1.20.9
+          - v1.21.5
+          - v1.22.2
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -92,11 +95,11 @@ jobs:
         # the versions supported by chart-testing are the tags
         # available for the docker.io/kindest/node image
         # https://hub.docker.com/r/kindest/node/tags
-          - v1.17.17
           - v1.18.19
           - v1.19.11
           - v1.20.7
           - v1.21.1
+          - v1.22.1
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
First of all I was adding Kubernetes 1.22.x, keeping the 5 latest versions.

Second I noticed that we've been missing validation starting with version 1.19. It looks like the original repository with the schemas doesn't get updated anymore. But there is a new one, that is.