### PR TITLE
Add RBAC role for Hono command router to list/watch pods

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.10.8
+version: 1.10.9
 # Version of Hono being deployed by the chart
 appVersion: 1.10.0
 keywords:

--- a/charts/hono/templates/hono-service-command-router/hono-service-command-router-deployment.yaml
+++ b/charts/hono/templates/hono-service-command-router/hono-service-command-router-deployment.yaml
@@ -70,4 +70,5 @@ spec:
         persistentVolumeClaim:
           claimName: {{ printf "%s-%s" .Release.Name $args.name | quote }}
       {{- end }}
+      serviceAccountName: {{ printf "%s-%s" .Release.Name $args.name | quote }}
 {{- end }}

--- a/charts/hono/templates/hono-service-command-router/hono-service-command-router-role.yaml
+++ b/charts/hono/templates/hono-service-command-router/hono-service-command-router-role.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.useCommandRouter .Values.commandRouterService.enabled }}
+{{- $args := dict "dot" . "name" "service-command-router" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  {{- include "hono.metadata" $args | nindent 2 }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["list", "watch"]
+{{- end }}

--- a/charts/hono/templates/hono-service-command-router/hono-service-command-router-rolebinding.yaml
+++ b/charts/hono/templates/hono-service-command-router/hono-service-command-router-rolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.useCommandRouter .Values.commandRouterService.enabled }}
+{{- $args := dict "dot" . "name" "service-command-router" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  {{- include "hono.metadata" $args | nindent 2 }}
+roleRef:
+  kind: Role
+  name: {{ printf "%s-%s" .Release.Name $args.name | quote }}
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: {{ printf "%s-%s" .Release.Name $args.name | quote }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/hono/templates/hono-service-command-router/hono-service-command-router-sa.yaml
+++ b/charts/hono/templates/hono-service-command-router/hono-service-command-router-sa.yaml
@@ -1,0 +1,7 @@
+{{- if and .Values.useCommandRouter .Values.commandRouterService.enabled }}
+{{- $args := dict "dot" . "name" "service-command-router" }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  {{- include "hono.metadata" $args | nindent 2 }}
+{{- end }}


### PR DESCRIPTION
This adds the RBAC role needed for the Hono Command Router `AdapterInstancesLivenessService` introduced in Hono 1.10.0 (see https://github.com/eclipse/hono/issues/2028).