### PR TITLE
Use same Helm version for packaging and testing charts

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -8,7 +8,7 @@ properties([
 ])
 
 def label = "packages-${UUID.randomUUID().toString()}"
-def HELM_VERSION = "3.1.3"
+def HELM_VERSION = "3.5.4"
 
 def needToDeploy() {
     return BRANCH_NAME == 'master' || BRANCH_NAME == 'develop'


### PR DESCRIPTION
The version of Helm being used in the Jenkins build job definition has
been aligned with the version used for testing charts.
