### PR TITLE
[Hono] Remove obsolete configuration property

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.10.10
+version: 1.10.11
 # Version of Hono being deployed by the chart
 appVersion: 1.10.0
 keywords:

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -303,10 +303,6 @@ jaegerAgentConf:
 #  REPORTER_GRPC_HOST_PORT: my-jaeger-collector:14250
 #  REPORTER_GRPC_DISCOVERY_MIN_PEERS: 1
 
-# defaultJavaOptions contains options to pass to the JVM when starting
-# up Hono's containers
-defaultJavaOptions: -XX:MinRAMPercentage=80 -XX:MaxRAMPercentage=80
-
 # the port that the Hono components' Prometheus scraping endpoint is exposed on
 monitoring:
   prometheus:


### PR DESCRIPTION
The "defaultJavaOptions" property had never been used in any of the
templates. Instead, the JDK_JAVA_OPTIONS environment variable set on the
containers had been created with the value of component specific
properties.
