### PR TITLE
[Hono] Enable deletion of Kafka topics

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.10.11
+version: 1.10.12
 # Version of Hono being deployed by the chart
 appVersion: 1.10.0
 keywords:

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -334,7 +334,7 @@ honoImagesType: "quarkus"
 useLoadBalancer: true
 
 # serviceType indicates which service type services should have.
-# Possible serivceTypes are described on
+# Possible serviceTypes are described on
 # https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
 serviceType:
 
@@ -415,7 +415,7 @@ adapters:
     hostnameVerificationRequired: false
 
   # kafkaMessagingSpec contains the configuration used by all protocol
-  # adapters for connecting to the Kafka cluster to be uses for messaging.
+  # adapters for connecting to the Kafka cluster to be used for messaging.
   # This property MUST be set if "messagingNetworkTypes" contains "kafka" and
   # "kafkaMessagingClusterExample.enabled" is set to false.
   # Please refer to https://www.eclipse.org/hono/docs/admin-guide/hono-kafka-client-configuration/
@@ -1857,6 +1857,7 @@ kafka:
   replicaCount: 1
   # Set to false for productive setups. Topic management then needs to be provided externally.
   autoCreateTopicsEnable: true
+  deleteTopicEnable: true
   # The data is stored in Persistent Volumes. For more information regarding persistence and
   # potential problems with permissions refer to: https://github.com/bitnami/charts/tree/master/bitnami/kafka#persistence
   persistence:


### PR DESCRIPTION
The default Kafka broker configuration is adapted here to allow deletion of topics.
This is relevant for the `hono.command_internal.[adapterInstanceId]` topics, created by Hono for the lifetime of a protocol adapter instance after which they shall get deleted.

Relates to https://github.com/eclipse/hono/issues/2901.