### PR TITLE
Fix usage of springLoggingConfig

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.10.13
+version: 1.10.14
 # Version of Hono being deployed by the chart
 appVersion: 1.10.0
 keywords:

--- a/charts/hono/templates/_helpers.tpl
+++ b/charts/hono/templates/_helpers.tpl
@@ -417,7 +417,7 @@ The scope passed in is expected to be a dict with keys
 - name: SPRING_CONFIG_LOCATION
   value: {{ default "file:///etc/hono/" .componentConfig.springConfigLocation | quote }}
 - name: LOGGING_CONFIG
-  value: {{ default "classpath:logback-spring.xml" .componentConfig.loggingConfig | quote }}
+  value: {{ default "classpath:logback-spring.xml" .componentConfig.springLoggingConfig | quote }}
 - name: SPRING_PROFILES_ACTIVE
   value: {{ print $applicationProfiles ( ( empty .additionalProfile ) | ternary "" "," ) ( default "" .additionalProfile ) | quote }}
 {{- end }}

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -505,7 +505,7 @@ adapters:
     # See https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config-files
     # for details.
     springConfigLocation: "file:///etc/hono/"
-    # loggingConfig contains the location of the logback configuration file that is used
+    # springLoggingConfig contains the location of the logback configuration file that is used
     # by the adapter.
     # See https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-logging
     # for details.
@@ -602,7 +602,7 @@ adapters:
     # See https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config-files
     # for details.
     springConfigLocation: "file:///etc/hono/"
-    # loggingConfig contains the location of the logback configuration file that is used
+    # springLoggingConfig contains the location of the logback configuration file that is used
     # by the adapter.
     # See https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-logging
     # for details.
@@ -690,7 +690,7 @@ adapters:
     # See https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config-files
     # for details.
     springConfigLocation: "file:///etc/hono/"
-    # loggingConfig contains the location of the logback configuration file that is used
+    # springLoggingConfig contains the location of the logback configuration file that is used
     # by the adapter.
     # See https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-logging
     # for details.
@@ -787,7 +787,7 @@ adapters:
     # See https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config-files
     # for details.
     springConfigLocation: "file:///etc/hono/"
-    # loggingConfig contains the location of the logback configuration file that is used
+    # springLoggingConfig contains the location of the logback configuration file that is used
     # by the adapter.
     # See https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-logging
     # for details.
@@ -884,7 +884,7 @@ adapters:
     # See https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config-files
     # for details.
     springConfigLocation: "file:///etc/hono/"
-    # loggingConfig contains the location of the logback configuration file that is used
+    # springLoggingConfig contains the location of the logback configuration file that is used
     # by the adapter.
     # See https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-logging
     # for details.
@@ -980,7 +980,7 @@ adapters:
     # See https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config-files
     # for details.
     springConfigLocation: "file:///etc/hono/"
-    # loggingConfig contains the location of the logback configuration file that is used
+    # springLoggingConfig contains the location of the logback configuration file that is used
     # by the adapter.
     # See https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-logging
     # for details.
@@ -1077,7 +1077,7 @@ authServer:
   # See https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config-files
   # for details.
   springConfigLocation: "file:///etc/hono/"
-  # loggingConfig contains the location of the logback configuration file that is used by the service.
+  # springLoggingConfig contains the location of the logback configuration file that is used by the service.
   # See https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-logging
   # for details.
   springLoggingConfig: "classpath:logback-spring.xml"
@@ -1541,7 +1541,7 @@ deviceConnectionService:
   # See https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config-files
   # for details.
   springConfigLocation: "file:///etc/hono/"
-  # loggingConfig contains the location of the logback configuration file that is used by the service.
+  # springLoggingConfig contains the location of the logback configuration file that is used by the service.
   # See https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-logging
   # for details.
   springLoggingConfig: "classpath:logback-spring.xml"
@@ -1658,7 +1658,7 @@ commandRouterService:
   # See https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config-files
   # for details.
   springConfigLocation: "file:///etc/hono/"
-  # loggingConfig contains the location of the logback configuration file that is used by the service.
+  # springLoggingConfig contains the location of the logback configuration file that is used by the service.
   # See https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-logging
   # for details.
   springLoggingConfig: "classpath:logback-spring.xml"


### PR DESCRIPTION
Wrong property name was used in `_helpers.tpl` and in the documentation.