### PR TITLE
Update Infinispan image to 11.0.13.Final

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.10.14
+version: 1.10.15
 # Version of Hono being deployed by the chart
 appVersion: 1.10.0
 keywords:

--- a/charts/hono/templates/example-data-grid/statefulset.yaml
+++ b/charts/hono/templates/example-data-grid/statefulset.yaml
@@ -44,8 +44,21 @@ spec:
           containerPort: 11222
           protocol: TCP
         volumeMounts:
-        - mountPath: /opt/infinispan/server/conf
+        - mountPath: /opt/infinispan/server/conf/hono-data-grid.xml
           name: conf
+          subPath: hono-data-grid.xml
+          readOnly: true
+        - mountPath: /opt/infinispan/server/conf/users.properties
+          name: conf
+          subPath: users.properties
+          readOnly: true
+        - mountPath: /opt/infinispan/server/conf/public-groups.properties
+          name: conf
+          subPath: public-groups.properties
+          readOnly: true
+        - mountPath: /opt/infinispan/server/conf/mgmt-groups.properties
+          name: conf
+          subPath: mgmt-groups.properties
           readOnly: true
         livenessProbe:
           httpGet:

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -188,7 +188,7 @@ dataGridExample:
   enabled: false
   # imageName contains the name (including tag)
   # of the container image to use for the example data grid.
-  imageName: infinispan/server-native:11.0.7.Final-2
+  imageName: infinispan/server:11.0.13.Final
   # livenessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
   # configuration property of the component's liveness probe.
   livenessProbeInitialDelaySeconds: 300


### PR DESCRIPTION
Update Infinispan to version with updated log4j (CVE-2021-44228). Using the non-native image since there are no native versions of the current Infinispan releases.