### PR TITLE
Upgrade Kafka chart

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.10.18
+version: 1.10.19
 # Version of Hono being deployed by the chart
 appVersion: 1.10.1
 keywords:

--- a/charts/hono/ci/device-connection-service-values.yaml
+++ b/charts/hono/ci/device-connection-service-values.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+# Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -23,6 +23,7 @@ useLoadBalancer: false
 dataGridExample:
   enabled: true
 
+useCommandRouter: false
 deviceConnectionService:
   enabled: true
 

--- a/charts/hono/requirements.yaml
+++ b/charts/hono/requirements.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -25,5 +25,5 @@ dependencies:
     condition: mongodb.createInstance
   - name: kafka
     repository: "https://charts.bitnami.com/bitnami"
-    version: ~12.17.6
+    version: ^14.x
     condition: kafkaMessagingClusterExample.enabled

--- a/charts/hono/templates/NOTES.txt
+++ b/charts/hono/templates/NOTES.txt
@@ -36,7 +36,7 @@ https://eclipse.org/hono/getting-started-kafka/
 Clients can connect to the Kafka cluster with the configuration properties below
 (see the above guide on how to set $KAFKA_IP and $KAFKA_TRUSTSTORE_PATH).
 
-  bootstrap.servers=$KAFKA_IP:9092
+  bootstrap.servers=$KAFKA_IP:{{ .Values.kafka.service.externalPort }}
   ssl.truststore.location=$KAFKA_TRUSTSTORE_PATH
   security.protocol=SASL_SSL
   sasl.mechanism=SCRAM-SHA-512

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -1876,14 +1876,12 @@ kafka:
   # https://github.com/bitnami/charts/tree/master/bitnami/kafka#accessing-kafka-brokers-from-outside-the-cluster
   externalAccess:
     enabled: true
-    service:
-      type: LoadBalancer
-      port: 9092
-      # length of the array must match replicaCount
-      nodePorts:
-        - 32092
     autoDiscovery:
       enabled: true
+    service:
+      # length of the array must match replicaCount
+      nodePorts:
+        - 32094
   serviceAccount:
     create: true
   rbac:
@@ -1892,8 +1890,6 @@ kafka:
     create: true
   # the name of the template (maintains the release name)
   nameOverride: kafka
-  service:
-    port: 9094
   auth:
     clientProtocol: sasl_tls
     sasl:


### PR DESCRIPTION
The dependency on the Kafka chart has been changed to version 14.
The default internal and external ports defined in the Kafka chart are
now being used unaltered.
