### PR TITLE
Update hono and ditto requirements to latest versions

### DIFF
--- a/packages/cloud2edge/Chart.yaml
+++ b/packages/cloud2edge/Chart.yaml
@@ -11,8 +11,8 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 apiVersion: v1
-version: 0.2.1
-appVersion: 0.2.1
+version: 0.3.0
+appVersion: 0.3.0
 name: cloud2edge
 description: |
   Eclipse IoT Cloud2Edge (C2E) is an integrated suite of services developers can use to build IoT applications

--- a/packages/cloud2edge/requirements.yaml
+++ b/packages/cloud2edge/requirements.yaml
@@ -12,8 +12,8 @@
 #
 dependencies:
   - name: hono
-    version: ~1.8.0
+    version: ~1.10.19
     repository: "https://eclipse.org/packages/charts/"
   - name: ditto
-    version: ~2.0.1
+    version: ~2.3.0
     repository: "https://eclipse.org/packages/charts/"


### PR DESCRIPTION
As of 27.01.22, deployments of cloud2edge fail due to expired TLS certificates. The certificates have been updated inside hono and ditto charts, but cloud2edge-requirements have not been updated accordingly.