### PR TITLE
Added imagePullSecrets to hono chart for pulling from private registries

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.10.20
+version: 1.10.21
 # Version of Hono being deployed by the chart
 appVersion: 1.10.1
 keywords:

--- a/charts/hono/templates/artemis/artemis-deployment.yaml
+++ b/charts/hono/templates/artemis/artemis-deployment.yaml
@@ -25,6 +25,10 @@ spec:
     metadata:
       {{- include "hono.metadata" $args | nindent 6 }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: apache-activemq-artemis
         image: {{ .Values.amqpMessagingNetworkExample.broker.artemis.imageName | quote }}

--- a/charts/hono/templates/dispatch-router/dispatch-router-deployment.yaml
+++ b/charts/hono/templates/dispatch-router/dispatch-router-deployment.yaml
@@ -25,6 +25,10 @@ spec:
     metadata:
       {{- include "hono.metadata" $args | nindent 6 }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: apache-qpid-dispatch-router
         image: {{ .Values.amqpMessagingNetworkExample.dispatchRouter.imageName | quote }}

--- a/charts/hono/templates/example-data-grid/statefulset.yaml
+++ b/charts/hono/templates/example-data-grid/statefulset.yaml
@@ -26,6 +26,10 @@ spec:
     metadata:
       {{- include "hono.metadata" $args | nindent 6 }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - image: {{ .Values.dataGridExample.imageName | quote }}
         imagePullPolicy: IfNotPresent

--- a/charts/hono/templates/hono-adapter-amqp/hono-adapter-amqp-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-amqp/hono-adapter-amqp-vertx-deployment.yaml
@@ -27,6 +27,10 @@ spec:
       annotations:
         {{- include "hono.monitoringAnnotations" . | nindent 8 }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
       {{- include "hono.container" $args | indent 6 }}

--- a/charts/hono/templates/hono-adapter-coap/hono-adapter-coap-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-coap/hono-adapter-coap-vertx-deployment.yaml
@@ -27,6 +27,10 @@ spec:
       annotations:
         {{- include "hono.monitoringAnnotations" . | nindent 8 }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
       {{- include "hono.container" $args | indent 6 }}

--- a/charts/hono/templates/hono-adapter-http/hono-adapter-http-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-http/hono-adapter-http-vertx-deployment.yaml
@@ -27,6 +27,10 @@ spec:
       annotations:
         {{- include "hono.monitoringAnnotations" . | nindent 8 }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
       {{- include "hono.container" $args | indent 6 }}

--- a/charts/hono/templates/hono-adapter-kura/hono-adapter-kura-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-kura/hono-adapter-kura-deployment.yaml
@@ -27,6 +27,10 @@ spec:
       annotations:
         {{- include "hono.monitoringAnnotations" . | nindent 8 }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
       {{- include "hono.container" $args | indent 6 }}

--- a/charts/hono/templates/hono-adapter-lora/hono-adapter-lora-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-lora/hono-adapter-lora-vertx-deployment.yaml
@@ -27,6 +27,10 @@ spec:
       annotations:
         {{- include "hono.monitoringAnnotations" . | nindent 8 }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
       {{- include "hono.container" $args | indent 6 }}

--- a/charts/hono/templates/hono-adapter-mqtt/hono-adapter-mqtt-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-mqtt/hono-adapter-mqtt-vertx-deployment.yaml
@@ -27,6 +27,10 @@ spec:
       annotations:
         {{- include "hono.monitoringAnnotations" . | nindent 8 }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
       {{- include "hono.container" $args | indent 6 }}

--- a/charts/hono/templates/hono-service-auth/hono-service-auth-deployment.yaml
+++ b/charts/hono/templates/hono-service-auth/hono-service-auth-deployment.yaml
@@ -26,6 +26,10 @@ spec:
       annotations:
         {{- include "hono.monitoringAnnotations" . | nindent 8 }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       {{- include "hono.container" $args | indent 6 }}
         ports:

--- a/charts/hono/templates/hono-service-command-router/hono-service-command-router-deployment.yaml
+++ b/charts/hono/templates/hono-service-command-router/hono-service-command-router-deployment.yaml
@@ -27,6 +27,10 @@ spec:
       annotations:
         {{- include "hono.monitoringAnnotations" . | nindent 8 }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
       {{- include "hono.container" $args | indent 6 }}

--- a/charts/hono/templates/hono-service-device-connection/hono-service-device-connection-deployment.yaml
+++ b/charts/hono/templates/hono-service-device-connection/hono-service-device-connection-deployment.yaml
@@ -27,6 +27,10 @@ spec:
       annotations:
         {{- include "hono.monitoringAnnotations" . | nindent 8 }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
       {{- include "hono.container" $args | indent 6 }}

--- a/charts/hono/templates/hono-service-device-registry-base/hono-service-device-registry-post-install-job.yaml
+++ b/charts/hono/templates/hono-service-device-registry-base/hono-service-device-registry-post-install-job.yaml
@@ -27,6 +27,10 @@ spec:
     metadata:
       name: {{ printf "%s-%s" .Release.Name "post-install" | quote }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       restartPolicy: Never
       containers:
         - name: "post-install"

--- a/charts/hono/templates/hono-service-device-registry-embedded/hono-service-device-registry-statefulset.yaml
+++ b/charts/hono/templates/hono-service-device-registry-embedded/hono-service-device-registry-statefulset.yaml
@@ -28,6 +28,10 @@ spec:
       annotations:
         {{- include "hono.monitoringAnnotations" . | nindent 8 }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
       {{- include "hono.container" $args | indent 6 }}

--- a/charts/hono/templates/hono-service-device-registry-file/hono-service-device-registry-statefulset.yaml
+++ b/charts/hono/templates/hono-service-device-registry-file/hono-service-device-registry-statefulset.yaml
@@ -28,6 +28,10 @@ spec:
       annotations:
         {{- include "hono.monitoringAnnotations" . | nindent 8 }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
       {{- include "hono.container" $args | indent 6 }}

--- a/charts/hono/templates/hono-service-device-registry-jdbc/hono-service-device-registry-deployment.yaml
+++ b/charts/hono/templates/hono-service-device-registry-jdbc/hono-service-device-registry-deployment.yaml
@@ -25,6 +25,10 @@ spec:
     metadata:
       {{- include "hono.metadata" $args | nindent 6 }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
       {{- include "hono.container" $args | indent 6 }}

--- a/charts/hono/templates/hono-service-device-registry-mongodb/hono-service-device-registry-deployment.yaml
+++ b/charts/hono/templates/hono-service-device-registry-mongodb/hono-service-device-registry-deployment.yaml
@@ -25,6 +25,10 @@ spec:
     metadata:
       {{- include "hono.metadata" $args | nindent 6 }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
       {{- include "hono.container" $args | indent 6 }}

--- a/charts/hono/templates/jaeger/jaeger-deployment.yaml
+++ b/charts/hono/templates/jaeger/jaeger-deployment.yaml
@@ -29,6 +29,10 @@ spec:
         prometheus.io/port: {{ .Values.healthCheckPort | quote }}
         prometheus.io/scheme: "http"
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - env:
         - name: ADMIN_HTTP_HOST_PORT

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -26,6 +26,10 @@
 # the value specified here.
 honoContainerRegistry: index.docker.io
 
+# imagePullSecrets for pulling docker images from private registry. It will
+# be added to every deployment and statefulset.
+imagePullSecrets: []
+
 # livenessProbeInitialDelaySeconds contains the default value to use
 # for the "initialDelaySeconds" configuration property of a Hono
 # component's liveness probe.


### PR DESCRIPTION
This pull request allows to pull images in Hono chart from private registry (e.g. using a proxy registry in enterprise infrastructure). Other charts already provide this option. I've used the approach from default helm template. But it is a valid discussion how to unify it across other charts. I intentionally din't use "global" value from Ditto chart since it conflicts with bitnami dependencies which use the same value with different yaml format.