### PR TITLE
Several improvements

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.11.0
+version: 1.11.1
 # Version of Hono being deployed by the chart
 appVersion: 1.11.1
 keywords:

--- a/charts/hono/ci/mongodb-based-device-registry-values.yaml
+++ b/charts/hono/ci/mongodb-based-device-registry-values.yaml
@@ -18,6 +18,8 @@
 # - without monitoring infrastructure
 # - with AMQP adapter only
 
+useLoadBalancer: false
+
 deviceRegistryExample:
   type: mongodb
 
@@ -27,12 +29,16 @@ mongodb:
     enabled: false
 
 messagingNetworkTypes:
-  - kafka
+- kafka
 
 kafkaMessagingClusterExample:
   enabled: true
 
 kafka:
+  auth:
+    clientProtocol: "sasl"
+    tls:
+      existingSecrets: []
   persistence:
     enabled: false
   externalAccess:
@@ -42,9 +48,11 @@ kafka:
       type: NodePort
       # length of the array must match replicaCount
       nodePorts:
-        - "32094"
-
-useLoadBalancer: false
+      - "32094"
+  serviceAccount:
+    create: false
+  rbac:
+    create: false
 
 adapters:
   amqp:

--- a/charts/hono/config/command-router/embedded-cache-config.xml
+++ b/charts/hono/config/command-router/embedded-cache-config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2021 Contributors to the Eclipse Foundation
+    Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
    
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -11,22 +11,15 @@
    
     SPDX-License-Identifier: EPL-2.0
  -->
-<infinispan>
+<infinispan
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="urn:infinispan:config:13.0 https://infinispan.org/schemas/infinispan-config-13.0.xsd"
+        xmlns="urn:infinispan:config:13.0">
+
   <cache-container default-cache="command-router">
-    <global-state>
-      <persistent-location path="/var/lib/hono"/>
-    </global-state>
-    <local-cache name="command-router">
-      <persistence passivation="false">
-        <file-store
-            shared="false"
-            preload="true"
-            fetch-state="false"
-            read-only="false"
-            purge="false"
-            path="command-router">
-        </file-store>
-      </persistence>
+    <local-cache name="command-router" simple-cache="true">
+      <encoding media-type="application/x-protostream" />
+      <memory max-count="200" storage="OFF_HEAP" when-full="REMOVE"></memory>
     </local-cache>
   </cache-container>
 </infinispan>

--- a/charts/hono/config/infinispan/hono-data-grid.xml
+++ b/charts/hono/config/infinispan/hono-data-grid.xml
@@ -1,3 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+    Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
+   
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+   
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0
+   
+    SPDX-License-Identifier: EPL-2.0
+ -->
 <infinispan
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="urn:infinispan:config:13.0 https://infinispan.org/schemas/infinispan-config-13.0.xsd
@@ -16,7 +29,7 @@
         </roles>
       </authorization>
     </security>
-    <distributed-cache name="{{ if .Values.useCommandRouter }}command-router{{ else }}device-connection{{ end }}">
+    <distributed-cache name='{{ ternary "command-router" "device-connection" .Values.useCommandRouter }}'>
       <encoding>
         <key media-type="text/plain" />
         <value media-type="text/plain" />

--- a/charts/hono/templates/NOTES.txt
+++ b/charts/hono/templates/NOTES.txt
@@ -23,26 +23,31 @@ NAME                                       {{ "READY   STATUS    RESTARTS   AGE"
 {{ .Release.Name }}-service-device-registry-0                 1/1     Running   0          5m51s
 
 Once all pods have status 'Running', Hono is ready to be used.
-{{- if (has "amqp" .Values.messagingNetworkTypes) }}
+{{- if ( has "amqp" .Values.messagingNetworkTypes ) }}
 
 To learn more about Hono's functionality, you should follow the Getting started guide at
 https://eclipse.org/hono/getting-started/
 {{- end }}
-{{- if (has "kafka" .Values.messagingNetworkTypes) }}
+{{- if ( has "kafka" .Values.messagingNetworkTypes ) }}
 {{ if .Values.kafkaMessagingClusterExample.enabled }}
+{{- $isKafkaTlsEnabled := ( eq .Values.kafka.auth.clientProtocol "sasl_tls" ) }}
 Hono is configured with an example Kafka cluster for messaging. To learn more about it, you
 should follow the Kafka messaging guide at https://eclipse.org/hono/getting-started-kafka/
 Clients can connect to the example Kafka cluster using the configuration properties below.
 Please refer to the guide mentioned above for details on how to determine the values for
-$KAFKA_IP and $KAFKA_TRUSTSTORE_PATH.
+$KAFKA_IP{{ if $isKafkaTlsEnabled }}and $KAFKA_TRUSTSTORE_PATH{{ end }}.
 
-  bootstrap.servers=$KAFKA_IP:{{ .Values.kafka.service.externalPort }}
-  security.protocol=SASL_SSL
+  bootstrap.servers=$KAFKA_IP:{{ .Values.kafka.externalAccess.service.port }}
   sasl.mechanism=SCRAM-SHA-512
   sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="{{ first .Values.kafka.auth.sasl.jaas.clientUsers }}" password="{{ first .Values.kafka.auth.sasl.jaas.clientPasswords }}";
+{{- if $isKafkaTlsEnabled }}
+  security.protocol=SASL_SSL
   ssl.endpoint.identification.algorithm=""
   ssl.truststore.location=$KAFKA_TRUSTSTORE_PATH
   ssl.truststore.password={{ .Values.kafka.auth.tls.password | quote }}
+{{- else }}
+  security.protocol=SASL_PLAINTEXT
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/charts/hono/templates/hono-service-command-router/hono-service-command-router-secret.yaml
+++ b/charts/hono/templates/hono-service-command-router/hono-service-command-router-secret.yaml
@@ -54,7 +54,9 @@ stringData:
           certPath: "/etc/hono/cert.pem"
           {{- end }}
         cache:
-          {{- if .Values.dataGridSpec }}
+          {{- if .Values.commandRouterService.hono.commandRouter.cache }}
+            {{- .Values.commandRouterService.hono.commandRouter.cache | toYaml | nindent 10 }}
+          {{- else if .Values.dataGridSpec }}
           remote:
             {{- .Values.dataGridSpec | toYaml | nindent 12 }}
           {{- else if .Values.dataGridExample.enabled }}
@@ -65,7 +67,7 @@ stringData:
             authUsername: {{ .Values.dataGridExample.authUsername | quote }}
             authPassword: {{ .Values.dataGridExample.authPassword | quote }}
             authRealm: "ApplicationRealm"
-            saslMechanism: "DIGEST-MD5"
+            saslMechanism: "SCRAM-SHA-512"
             socketTimeout: 5000
             connectTimeout: 5000
           {{- end }}

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -1781,6 +1781,15 @@ commandRouterService:
       #  insecurePortEnabled: true
       #  insecurePortBindAddress: "0.0.0.0"
 
+      # cache contains properties configuring the embedded or remote cache that
+      # the Command Router uses for storing routing information.
+      # If not set explicitly here, the remote cache configuration from property "dataGridSpec" will be used.
+      # If that property is empty and "dataGridExample.enabled" is "true", the example data grid is used.
+      # If "dataGridExample.enabled" is "false", an embedded cache with a default configuration will be used.
+      # Note that when using the embedded cache, the Command Router pod does NOT support scaling up to a replica
+      # count > 1
+      cache:
+
     # healthCheck contains configuration properties for the service's
     # health check server as defined by
     # https://www.eclipse.org/hono/docs/admin-guide/monitoring-tracing-config/#health-check-server-configuration
@@ -1979,5 +1988,6 @@ kafka:
         zookeeperPassword: zookeeperPassword
     tls:
       type: jks
-      existingSecret: "{{ .Release.Name }}-kafka-jks"
+      existingSecrets:
+      - "{{ .Release.Name }}-kafka-jks"
       password: honotrust

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -222,8 +222,11 @@ dataGridExample:
 # the device connection data used for routing of command messages.
 # This property should be set in order to use a storage configuration suitable for production
 # if "dataGridExample.enabled" is set to false (the default).
-# Please refer to https://docs.jboss.org/infinispan/11.0/apidocs/org/infinispan/client/hotrod/configuration/package-summary.html#package.description
+# Please refer to https://docs.jboss.org/infinispan/13.0/apidocs/org/infinispan/client/hotrod/configuration/package-summary.html#package.description
 # for a list of configuration properties.
+# DEPRECATED This property will be removed together with the "deviceConnectionService" when this chart gets updated
+# to support Hono 2.0.0. Please configure the command router's data grid connection in the
+# "commandRouterService.hono.commandRouter.cache" property instead.
 dataGridSpec:
   # serverList contains the hostname:port of the data grid node(s)
   # This property only needs to be set when using an existing data grid other than the
@@ -1558,6 +1561,8 @@ mongodb:
 # deviceConnectionService contains configuration properties for the
 # Device Connection service.
 # Note that the Device Connection service will only be used if "useCommandRouter" is false.
+# DEPRECATED This property will be removed when this chart gets updated to support Hono 2.0.0.
+# Please use the Command Router service instead.
 deviceConnectionService:
 
   # enabled indicates if the data grid based Device Connection service implementation
@@ -1660,7 +1665,7 @@ deviceConnectionService:
       # to the data grid that should be used for storing the device connection data.
       # This property MUST be set if "deviceConnectionService.enabled" is set to true
       # and "dataGridExample.enabled" is set to false (the default).
-      # Please refer to https://docs.jboss.org/infinispan/11.0/apidocs/org/infinispan/client/hotrod/configuration/package-summary.html#package.description
+      # Please refer to https://docs.jboss.org/infinispan/13.0/apidocs/org/infinispan/client/hotrod/configuration/package-summary.html#package.description
       # for a list of configuration properties.
       remote:
       #  serverList: hono-data-grid:11222
@@ -1782,7 +1787,9 @@ commandRouterService:
       #  insecurePortBindAddress: "0.0.0.0"
 
       # cache contains properties configuring the embedded or remote cache that
-      # the Command Router uses for storing routing information.
+      # the Command Router uses for storing routing information. Please refer to Hono's Command Router admin guide at
+      # https://www.eclipse.org/hono/docs/admin-guide/command-router-config/#data-grid-connection-configuration for
+      # details regarding cache configuration.
       # If not set explicitly here, the remote cache configuration from property "dataGridSpec" will be used.
       # If that property is empty and "dataGridExample.enabled" is "true", the example data grid is used.
       # If "dataGridExample.enabled" is "false", an embedded cache with a default configuration will be used.


### PR DESCRIPTION
- Updated Infinispan configuration schema to version 13
- Use in-memory data store for embedded cache in Command Router instead
of file-store based cache (which does not work with network file system
anyway)
- Added support for explicitly configuring cache usage in Command Router
- Made information output after successful deployment more specific to
the security configuration used with example Kafka cluster
