### PR TITLE
Cloud2Edge: Update Hono and Ditto dependencies

### DIFF
--- a/.github/ct.yaml
+++ b/.github/ct.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -24,3 +24,4 @@ chart-repos:
   - grafana=https://grafana.github.io/helm-charts
 excluded-charts:
   - telemetry-e2e
+  - cloud2edge

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -128,10 +128,6 @@ jobs:
           config: .github/kind-config.yaml
           node_image: kindest/node:${{ matrix.k8s }}
         if: ${{ steps.list-changed.outputs.changed == 'true' }}
-      - name: Describe nodes
-        if: ${{ steps.list-changed.outputs.changed == 'true' }}
-        run: |
-          kubectl describe nodes
       - name: Deploy ingress controller
         if: ${{ steps.list-changed.outputs.changed == 'true' }}
         run: |
@@ -153,6 +149,9 @@ jobs:
       - if: ${{ failure() }}
         run: |
           kubectl -n ingress-nginx describe pods
+      - name: Describe nodes
+        if: ${{ steps.list-changed.outputs.changed == 'true' }}
+        run: |
           kubectl describe nodes
       - name: Run CI chart customization
         if: ${{ steps.list-changed.outputs.changed == 'true' }}

--- a/homepage/_packages/cloud2edge/tour.md
+++ b/homepage/_packages/cloud2edge/tour.md
@@ -459,7 +459,7 @@ Furthermore, we add a reference to the in the previous step created *policy id* 
 information of the twin: 
 
 {% clipboard %}
-curl -X PUT -u ditto:ditto -H 'Content-Type: application/json' --data '{
+curl -i -X PUT -u ditto:ditto -H 'Content-Type: application/json' --data '{
   "policyId": "org.acme:my-policy",
   "attributes": {
     "location": "Germany"

--- a/packages/cloud2edge/Chart.yaml
+++ b/packages/cloud2edge/Chart.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+# Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -11,8 +11,8 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 apiVersion: v1
-version: 0.2.1
-appVersion: 0.2.1
+version: 0.2.2
+appVersion: 0.2.2
 name: cloud2edge
 description: |
   Eclipse IoT Cloud2Edge (C2E) is an integrated suite of services developers can use to build IoT applications

--- a/packages/cloud2edge/README.md
+++ b/packages/cloud2edge/README.md
@@ -11,4 +11,4 @@ The package currently consists of
 The package is supposed to provide an easy way for developers to start using Eclipse Hono and Ditto in their
 IoT application.
 
-For installation and examples please visit [Cloud2Edge home page] (https://www.eclipse.org/packages/packages/cloud2edge)
+For installation and examples please visit [Cloud2Edge home page](https://www.eclipse.org/packages/packages/cloud2edge)

--- a/packages/cloud2edge/example-permissions.json
+++ b/packages/cloud2edge/example-permissions.json
@@ -92,10 +92,6 @@
         "activities": [ "READ" ]
       },
       {
-        "resource": "control/*",
-        "activities": [ "READ", "WRITE" ]
-      },
-      {
         "resource": "command/*",
         "activities": [ "WRITE" ]
       },

--- a/packages/cloud2edge/post-install/thing-definition.json
+++ b/packages/cloud2edge/post-install/thing-definition.json
@@ -25,7 +25,7 @@
             "HONO": {
                 "subjects": {
                     "pre-authenticated:hono-connection": {
-                        "type": "Connetion to Eclipse Hono"
+                        "type": "Connection to Eclipse Hono"
                     }
                 },
                 "resources": {

--- a/packages/cloud2edge/requirements.yaml
+++ b/packages/cloud2edge/requirements.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+# Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -12,8 +12,8 @@
 #
 dependencies:
   - name: hono
-    version: ~1.8.0
+    version: ^1.10.18
     repository: "https://eclipse.org/packages/charts/"
   - name: ditto
-    version: ~2.0.1
+    version: ~2.3.0
     repository: "https://eclipse.org/packages/charts/"

--- a/packages/cloud2edge/templates/NOTES.txt
+++ b/packages/cloud2edge/templates/NOTES.txt
@@ -12,23 +12,24 @@ You can check the current status by issuing the following command:
 
 Once all services are up and running, the output should look similar to this:
 
-NAME                                   {{ "READY   STATUS    RESTARTS   AGE" | indent ( len .Release.Name ) }}
-ditto-mongodb-8ff6bb7cf-r7hh5          {{ "1/1     Running   0          3m15s" | indent ( len .Release.Name ) }}
-{{ .Release.Name }}-adapter-amqp-vertx-65cfb4d675-g5wn4   1/1     Running   0          3m15s
-{{ .Release.Name }}-adapter-http-vertx-66bd6bb89c-mng5t   1/1     Running   0          3m15s
-{{ .Release.Name }}-adapter-mqtt-vertx-765fcd578b-5rl7n   1/1     Running   0          3m15s
-{{ .Release.Name }}-artemis-f8f7dc7f4-864cj               1/1     Running   0          3m15s
-{{ .Release.Name }}-dispatch-router-6c77dc78bd-hjn4l      1/1     Running   0          3m15s
-{{ .Release.Name }}-ditto-concierge-5949cb449d-46vp5      1/1     Running   0          3m15s
-{{ .Release.Name }}-ditto-connectivity-779fc6f574-gd5gq   1/1     Running   0          3m15s
-{{ .Release.Name }}-ditto-gateway-5cfdc9f9fc-kl6mh        1/1     Running   0          3m15s
-{{ .Release.Name }}-ditto-nginx-864cffd948-mvcdg          1/1     Running   0          3m15s
-{{ .Release.Name }}-ditto-policies-86748888d6-g2xs7       1/1     Running   0          3m15s
-{{ .Release.Name }}-ditto-swaggerui-75677db684-h5ngx      1/1     Running   0          3m15s
-{{ .Release.Name }}-ditto-things-67b86569fb-z4w7b         1/1     Running   0          3m15s
-{{ .Release.Name }}-ditto-thingssearch-55fb58cd96-52zg8   1/1     Running   0          3m15s
-{{ .Release.Name }}-service-auth-84d9695cfc-5wlfh         1/1     Running   0          3m15s
-{{ .Release.Name }}-service-device-registry-0             1/1     Running   0          3m15s
+NAME                                       {{ "READY   STATUS    RESTARTS   AGE" | indent ( len .Release.Name ) }}
+{{ .Release.Name }}-adapter-amqp-vertx-65cfb4d675-g5wn4       1/1     Running   0          3m15s
+{{ .Release.Name }}-adapter-http-vertx-66bd6bb89c-mng5t       1/1     Running   0          3m15s
+{{ .Release.Name }}-adapter-mqtt-vertx-765fcd578b-5rl7n       1/1     Running   0          3m15s
+{{ .Release.Name }}-artemis-f8f7dc7f4-864cj                   1/1     Running   0          3m15s
+{{ .Release.Name }}-dispatch-router-6c77dc78bd-hjn4l          1/1     Running   0          3m15s
+{{ .Release.Name }}-ditto-concierge-5949cb449d-46vp5          1/1     Running   0          3m15s
+{{ .Release.Name }}-ditto-connectivity-779fc6f574-gd5gq       1/1     Running   0          3m15s
+{{ .Release.Name }}-ditto-gateway-5cfdc9f9fc-kl6mh            1/1     Running   0          3m15s
+{{ .Release.Name }}-ditto-nginx-864cffd948-mvcdg              1/1     Running   0          3m15s
+{{ .Release.Name }}-ditto-policies-86748888d6-g2xs7           1/1     Running   0          3m15s
+{{ .Release.Name }}-ditto-swaggerui-75677db684-h5ngx          1/1     Running   0          3m15s
+{{ .Release.Name }}-ditto-things-67b86569fb-z4w7b             1/1     Running   0          3m15s
+{{ .Release.Name }}-ditto-thingssearch-55fb58cd96-52zg8       1/1     Running   0          3m15s
+{{ .Release.Name }}-service-auth-84d9695cfc-5wlfh             1/1     Running   0          3m15s
+{{ .Release.Name }}-service-command-router-8d6bcc664-5xfz8    1/1     Running   0          3m15s
+{{ .Release.Name }}-service-device-registry-975dfcdb7-d6d6h   1/1     Running   0          3m15s
+ditto-mongodb-8ff6bb7cf-r7hh5              {{ "1/1     Running   0          3m15s" | indent ( len .Release.Name ) }}
 
 Once all pods have status 'Running', the Cloud2Edge package is ready to be used.
 

--- a/packages/cloud2edge/values.yaml
+++ b/packages/cloud2edge/values.yaml
@@ -68,10 +68,10 @@ hono:
 
   deviceRegistryExample:
     type: mongodb
-    resources:
-      requests:
-        cpu: 200m
     mongoDBBasedDeviceRegistry:
+      resources:
+        requests:
+          cpu: 200m
       mongodb:
         host: ditto-mongodb
         port: 27017


### PR DESCRIPTION
Use current Hono and Ditto versions (including updated Hono example certificates).
Also apply some minor corrections.