### PR TITLE
[#339] Use deprecated property to configure TLS keys

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,9 +15,9 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.11.1
+version: 1.11.2
 # Version of Hono being deployed by the chart
-appVersion: 1.11.1
+appVersion: 1.11.2
 keywords:
   - iot-chart
   - IoT

--- a/charts/hono/ci/mongodb-based-device-registry-values.yaml
+++ b/charts/hono/ci/mongodb-based-device-registry-values.yaml
@@ -35,10 +35,6 @@ kafkaMessagingClusterExample:
   enabled: true
 
 kafka:
-  auth:
-    clientProtocol: "sasl"
-    tls:
-      existingSecrets: []
   persistence:
     enabled: false
   externalAccess:

--- a/charts/hono/templates/_helpers.tpl
+++ b/charts/hono/templates/_helpers.tpl
@@ -545,13 +545,8 @@ The scope passed in is expected to be a dict with keys
 {{- $agentHost := printf "%s-jaeger-agent" .dot.Release.Name }}
 {{/* Note that for quarkus containers, the "quarkus.jaeger.service-name" property needs to be set instead, see https://github.com/quarkusio/quarkus/issues/17400 */}}
 - name: JAEGER_SERVICE_NAME
-  value: {{ printf "%s-%s" .dot.Release.Name .component | quote }}
-{{- if and .dot.Values.jaegerBackendExample.enabled ( eq .dot.Values.honoImagesType "quarkus-native" ) }}
-- name: JAEGER_SAMPLER_TYPE
-  value: "const"
-- name: JAEGER_SAMPLER_PARAM
-  value: "1"
-{{- else if and ( not .dot.Values.jaegerBackendExample.enabled ) ( empty .dot.Values.jaegerAgentConf ) }}
+  value: {{ printf "%s-%s" .dot.Release.Name .name | quote }}
+{{- if and ( not .dot.Values.jaegerBackendExample.enabled ) ( empty .dot.Values.jaegerAgentConf ) }}
 - name: JAEGER_SAMPLER_TYPE
   value: "const"
 - name: JAEGER_SAMPLER_PARAM

--- a/charts/hono/templates/jaeger/jaeger-deployment.yaml
+++ b/charts/hono/templates/jaeger/jaeger-deployment.yaml
@@ -58,10 +58,10 @@ spec:
         - name: health
           containerPort: {{ .Values.healthCheckPort }}
           protocol: TCP
+        {{- include "hono.component.envConfigMap" $args | indent 8 }}
         volumeMounts:
         {{- include "hono.container.secretVolumeMounts" $args | indent 8 }}
         {{- with .Values.jaegerBackendExample.resources }}
-        {{- include "hono.component.envConfigMap" $args | indent 8 }}
         resources:
           {{- . | toYaml | nindent 10 }}
         {{- end }}

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -247,7 +247,7 @@ jaegerBackendExample:
   enabled: false
   # allInOneImage contains the name (including tag)
   # of the container image to use for the example Jaeger back end.
-  allInOneImage: jaegertracing/all-in-one:1.26
+  allInOneImage: jaegertracing/all-in-one:1.31
   # livenessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
   # configuration property of the component's liveness probe.
   livenessProbeInitialDelaySeconds: 300
@@ -297,7 +297,7 @@ jaegerBackendExample:
 # jaegerAgentImage contains the name (including tag)
 # of the container image to use for the Jaeger Agent sidecar deployed
 # with Hono's components.
-jaegerAgentImage: jaegertracing/jaeger-agent:1.26
+jaegerAgentImage: jaegertracing/jaeger-agent:1.31
 # jaegerAgentConf contains environment variables for configuring the Jaeger Agent sidecar container
 # that is deployed with each of Hono's components.
 # The Jaeger Agent sidecar container is deployed with standard properties if

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -1974,7 +1974,7 @@ kafka:
     service:
       # length of the array must match replicaCount
       nodePorts:
-        - 32094
+      - 32094
   serviceAccount:
     create: true
   rbac:
@@ -1988,13 +1988,12 @@ kafka:
     sasl:
       jaas:
         clientUsers:
-          - "hono"
+        - "hono"
         clientPasswords:
-          - "hono-secret"
+        - "hono-secret"
         zookeeperUser: zookeeperUser
         zookeeperPassword: zookeeperPassword
     tls:
       type: jks
-      existingSecrets:
-      - "{{ .Release.Name }}-kafka-jks"
-      password: honotrust
+      existingSecret: "{{ .Release.Name }}-kafka-jks"
+      password: "honotrust"


### PR DESCRIPTION
The "auth.tls.existingSecrets" property in the Kafka chart does not work
as documented. Falling back to the (deprecated but working)
"auth.tls.existingSecret" property.

Also updating to latest Hono service release.

Fixes #339
