### PR TITLE
[#303] Support setting log level in Quarkus based images

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.12.0
+version: 1.12.1
 # Version of Hono being deployed by the chart
 appVersion: 1.12.0
 keywords:

--- a/charts/hono/config/logging-quarkus-dev.yaml
+++ b/charts/hono/config/logging-quarkus-dev.yaml
@@ -1,0 +1,11 @@
+quarkus:
+  log:
+    category:
+      "io.netty.handler.logging.LoggingHandler":
+        level: DEBUG
+      "org.apache.kafka":
+        level: INFO
+      "org.eclipse.hono":
+        level: DEBUG
+      "org.infinispan":
+        level: DEBUG

--- a/charts/hono/config/logging-quarkus-prod.yaml
+++ b/charts/hono/config/logging-quarkus-prod.yaml
@@ -1,0 +1,9 @@
+quarkus:
+  log:
+    category:
+      "org.apache.kafka":
+        level: ERROR
+      "org.eclipse.hono":
+        level: INFO
+      "org.eclipse.hono.client.impl.HonoConnectionImpl":
+        level: ERROR

--- a/charts/hono/config/logging-quarkus-trace.yaml
+++ b/charts/hono/config/logging-quarkus-trace.yaml
@@ -1,0 +1,11 @@
+quarkus:
+  log:
+    category:
+      "io.netty.handler.logging.LoggingHandler":
+        level: DEBUG
+      "org.apache.kafka":
+        level: INFO
+      "org.eclipse.hono":
+        level: TRACE
+      "org.infinispan":
+        level: DEBUG

--- a/charts/hono/templates/hono-adapter-amqp/hono-adapter-amqp-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-amqp/hono-adapter-amqp-vertx-deployment.yaml
@@ -53,7 +53,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        {{- include "hono.component.springEnv" $args | indent 8 }}
+        {{- include "hono.component.frameworkEnv" $args | indent 8 }}
         {{- include "hono.jaeger.clientConf" $args | indent 8 }}
         {{- include "hono.component.envConfigMap" $args | indent 8 }}
         volumeMounts:

--- a/charts/hono/templates/hono-adapter-amqp/hono-adapter-amqp-vertx-secret.yaml
+++ b/charts/hono/templates/hono-adapter-amqp/hono-adapter-amqp-vertx-secret.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.adapters.amqp.enabled }}
 #
-# Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -18,6 +18,12 @@ metadata:
   {{- include "hono.metadata" $args | nindent 2 }}
 type: Opaque
 stringData:
+  logging-quarkus-prod.yml: |
+    {{- .Files.Get "config/logging-quarkus-prod.yaml" | nindent 4 }}
+  logging-quarkus-dev.yml: |
+    {{- .Files.Get "config/logging-quarkus-dev.yaml" | nindent 4 }}
+  logging-quarkus-trace.yml: |
+    {{- .Files.Get "config/logging-quarkus-trace.yaml" | nindent 4 }}
   application.yml: |
     hono:
       app:

--- a/charts/hono/templates/hono-adapter-coap/hono-adapter-coap-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-coap/hono-adapter-coap-vertx-deployment.yaml
@@ -53,7 +53,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        {{- include "hono.component.springEnv" $args | indent 8 }}
+        {{- include "hono.component.frameworkEnv" $args | indent 8 }}
         {{- include "hono.jaeger.clientConf" $args | indent 8 }}
         {{- include "hono.component.envConfigMap" $args | indent 8 }}
         volumeMounts:

--- a/charts/hono/templates/hono-adapter-coap/hono-adapter-coap-vertx-secret.yaml
+++ b/charts/hono/templates/hono-adapter-coap/hono-adapter-coap-vertx-secret.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.adapters.coap.enabled }}
 #
-# Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -18,6 +18,12 @@ metadata:
   {{- include "hono.metadata" $args | nindent 2 }}
 type: Opaque
 stringData:
+  logging-quarkus-prod.yml: |
+    {{- .Files.Get "config/logging-quarkus-prod.yaml" | nindent 4 }}
+  logging-quarkus-dev.yml: |
+    {{- .Files.Get "config/logging-quarkus-dev.yaml" | nindent 4 }}
+  logging-quarkus-trace.yml: |
+    {{- .Files.Get "config/logging-quarkus-trace.yaml" | nindent 4 }}
   application.yml: |
     hono:
       app:

--- a/charts/hono/templates/hono-adapter-http/hono-adapter-http-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-http/hono-adapter-http-vertx-deployment.yaml
@@ -53,7 +53,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        {{- include "hono.component.springEnv" $args | indent 8 }}
+        {{- include "hono.component.frameworkEnv" $args | indent 8 }}
         {{- include "hono.jaeger.clientConf" $args | indent 8 }}
         {{- include "hono.component.envConfigMap" $args | indent 8 }}
         volumeMounts:

--- a/charts/hono/templates/hono-adapter-http/hono-adapter-http-vertx-secret.yaml
+++ b/charts/hono/templates/hono-adapter-http/hono-adapter-http-vertx-secret.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.adapters.http.enabled }}
 #
-# Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -18,6 +18,12 @@ metadata:
   {{- include "hono.metadata" $args | nindent 2 }}
 type: Opaque
 stringData:
+  logging-quarkus-prod.yml: |
+    {{- .Files.Get "config/logging-quarkus-prod.yaml" | nindent 4 }}
+  logging-quarkus-dev.yml: |
+    {{- .Files.Get "config/logging-quarkus-dev.yaml" | nindent 4 }}
+  logging-quarkus-trace.yml: |
+    {{- .Files.Get "config/logging-quarkus-trace.yaml" | nindent 4 }}
   application.yml: |
     hono:
       app:

--- a/charts/hono/templates/hono-adapter-kura/hono-adapter-kura-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-kura/hono-adapter-kura-deployment.yaml
@@ -53,7 +53,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        {{- include "hono.component.springEnv" $args | indent 8 }}
+        {{- include "hono.component.frameworkEnv" $args | indent 8 }}
         {{- include "hono.jaeger.clientConf" $args | indent 8 }}
         {{- include "hono.component.envConfigMap" $args | indent 8 }}
         volumeMounts:

--- a/charts/hono/templates/hono-adapter-kura/hono-adapter-kura-secret.yaml
+++ b/charts/hono/templates/hono-adapter-kura/hono-adapter-kura-secret.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.adapters.kura.enabled }}
 #
-# Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/hono/templates/hono-adapter-lora/hono-adapter-lora-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-lora/hono-adapter-lora-vertx-deployment.yaml
@@ -53,7 +53,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        {{- include "hono.component.springEnv" $args | indent 8 }}
+        {{- include "hono.component.frameworkEnv" $args | indent 8 }}
         {{- include "hono.jaeger.clientConf" $args | indent 8 }}
         {{- include "hono.component.envConfigMap" $args | indent 8 }}
         volumeMounts:

--- a/charts/hono/templates/hono-adapter-lora/hono-adapter-lora-vertx-secret.yaml
+++ b/charts/hono/templates/hono-adapter-lora/hono-adapter-lora-vertx-secret.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.adapters.lora.enabled }}
 #
-# Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -18,6 +18,12 @@ metadata:
   {{- include "hono.metadata" $args | nindent 2 }}
 type: Opaque
 stringData:
+  logging-quarkus-prod.yml: |
+    {{- .Files.Get "config/logging-quarkus-prod.yaml" | nindent 4 }}
+  logging-quarkus-dev.yml: |
+    {{- .Files.Get "config/logging-quarkus-dev.yaml" | nindent 4 }}
+  logging-quarkus-trace.yml: |
+    {{- .Files.Get "config/logging-quarkus-trace.yaml" | nindent 4 }}
   application.yml: |
     hono:
       app:

--- a/charts/hono/templates/hono-adapter-mqtt/hono-adapter-mqtt-vertx-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-mqtt/hono-adapter-mqtt-vertx-deployment.yaml
@@ -53,7 +53,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        {{- include "hono.component.springEnv" $args | indent 8 }}
+        {{- include "hono.component.frameworkEnv" $args | indent 8 }}
         {{- include "hono.jaeger.clientConf" $args | indent 8 }}
         {{- include "hono.component.envConfigMap" $args | indent 8 }}
         volumeMounts:

--- a/charts/hono/templates/hono-adapter-mqtt/hono-adapter-mqtt-vertx-secret.yaml
+++ b/charts/hono/templates/hono-adapter-mqtt/hono-adapter-mqtt-vertx-secret.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.adapters.mqtt.enabled }}
 #
-# Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -18,6 +18,12 @@ metadata:
   {{- include "hono.metadata" $args | nindent 2 }}
 type: Opaque
 stringData:
+  logging-quarkus-prod.yml: |
+    {{- .Files.Get "config/logging-quarkus-prod.yaml" | nindent 4 }}
+  logging-quarkus-dev.yml: |
+    {{- .Files.Get "config/logging-quarkus-dev.yaml" | nindent 4 }}
+  logging-quarkus-trace.yml: |
+    {{- .Files.Get "config/logging-quarkus-trace.yaml" | nindent 4 }}
   application.yml: |
     hono:
       app:

--- a/charts/hono/templates/hono-service-auth/hono-service-auth-deployment.yaml
+++ b/charts/hono/templates/hono-service-auth/hono-service-auth-deployment.yaml
@@ -51,7 +51,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        {{- include "hono.component.springEnv" $args | indent 8 }}
+        {{- include "hono.component.frameworkEnv" $args | indent 8 }}
         {{- include "hono.component.envConfigMap" $args | indent 8 }}
         volumeMounts:
         {{- include "hono.container.secretVolumeMounts" $args | indent 8 }}

--- a/charts/hono/templates/hono-service-auth/hono-service-auth-secret.yaml
+++ b/charts/hono/templates/hono-service-auth/hono-service-auth-secret.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -17,6 +17,12 @@ metadata:
   {{- include "hono.metadata" $args | nindent 2 }}
 type: Opaque
 stringData:
+  logging-quarkus-prod.yml: |
+    {{- .Files.Get "config/logging-quarkus-prod.yaml" | nindent 4 }}
+  logging-quarkus-dev.yml: |
+    {{- .Files.Get "config/logging-quarkus-dev.yaml" | nindent 4 }}
+  logging-quarkus-trace.yml: |
+    {{- .Files.Get "config/logging-quarkus-trace.yaml" | nindent 4 }}
   application.yml: |
     hono:
       app:

--- a/charts/hono/templates/hono-service-command-router/hono-service-command-router-deployment.yaml
+++ b/charts/hono/templates/hono-service-command-router/hono-service-command-router-deployment.yaml
@@ -53,7 +53,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        {{- include "hono.component.springEnv" $args | indent 8 }}
+        {{- include "hono.component.frameworkEnv" $args | indent 8 }}
         {{- include "hono.jaeger.clientConf" $args | indent 8 }}
         {{- include "hono.component.envConfigMap" $args | indent 8 }}
         volumeMounts:

--- a/charts/hono/templates/hono-service-command-router/hono-service-command-router-secret.yaml
+++ b/charts/hono/templates/hono-service-command-router/hono-service-command-router-secret.yaml
@@ -20,6 +20,12 @@ type: Opaque
 stringData:
   dns-cache-config.properties: |
     networkaddress.cache.negative.ttl=0
+  logging-quarkus-prod.yml: |
+    {{- .Files.Get "config/logging-quarkus-prod.yaml" | nindent 4 }}
+  logging-quarkus-dev.yml: |
+    {{- .Files.Get "config/logging-quarkus-dev.yaml" | nindent 4 }}
+  logging-quarkus-trace.yml: |
+    {{- .Files.Get "config/logging-quarkus-trace.yaml" | nindent 4 }}
   application.yml: |
     hono:
       app:

--- a/charts/hono/templates/hono-service-device-connection/hono-service-device-connection-deployment.yaml
+++ b/charts/hono/templates/hono-service-device-connection/hono-service-device-connection-deployment.yaml
@@ -53,7 +53,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        {{- include "hono.component.springEnv" ( merge $args ( dict "additionalProfile" ( ( or .Values.dataGridSpec ( or .Values.deviceConnectionService.hono.deviceConnection.remote .Values.dataGridExample.enabled ) ) | ternary "" "embedded-cache" ) ) ) | indent 8 }}
+        {{- include "hono.component.frameworkEnv" ( merge $args ( dict "additionalProfile" ( ( or .Values.dataGridSpec ( or .Values.deviceConnectionService.hono.deviceConnection.remote .Values.dataGridExample.enabled ) ) | ternary "" "embedded-cache" ) ) ) | indent 8 }}
         {{- include "hono.jaeger.clientConf" $args | indent 8 }}
         {{- include "hono.component.envConfigMap" $args | indent 8 }}
         volumeMounts:

--- a/charts/hono/templates/hono-service-device-registry-embedded/hono-service-device-registry-statefulset.yaml
+++ b/charts/hono/templates/hono-service-device-registry-embedded/hono-service-device-registry-statefulset.yaml
@@ -58,7 +58,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        {{- include "hono.component.springEnv" $args | indent 8 }}
+        {{- include "hono.component.frameworkEnv" $args | indent 8 }}
         {{- include "hono.jaeger.clientConf" $args | indent 8 }}
         {{- include "hono.component.envConfigMap" $args | indent 8 }}
         securityContext:

--- a/charts/hono/templates/hono-service-device-registry-file/hono-service-device-registry-statefulset.yaml
+++ b/charts/hono/templates/hono-service-device-registry-file/hono-service-device-registry-statefulset.yaml
@@ -58,7 +58,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        {{- include "hono.component.springEnv" $args | indent 8 }}
+        {{- include "hono.component.frameworkEnv" $args | indent 8 }}
         {{- include "hono.jaeger.clientConf" $args | indent 8 }}
         {{- include "hono.component.envConfigMap" $args | indent 8 }}
         securityContext:

--- a/charts/hono/templates/hono-service-device-registry-jdbc/hono-service-device-registry-deployment.yaml
+++ b/charts/hono/templates/hono-service-device-registry-jdbc/hono-service-device-registry-deployment.yaml
@@ -55,7 +55,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        {{- include "hono.component.springEnv" $args | indent 8 }}
+        {{- include "hono.component.frameworkEnv" $args | indent 8 }}
         {{- include "hono.jaeger.clientConf" $args | indent 8 }}
         {{- include "hono.component.envConfigMap" $args | indent 8 }}
         securityContext:

--- a/charts/hono/templates/hono-service-device-registry-mongodb/hono-service-device-registry-deployment.yaml
+++ b/charts/hono/templates/hono-service-device-registry-mongodb/hono-service-device-registry-deployment.yaml
@@ -55,7 +55,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        {{- include "hono.component.springEnv" $args | indent 8 }}
+        {{- include "hono.component.frameworkEnv" $args | indent 8 }}
         {{- include "hono.jaeger.clientConf" $args | indent 8 }}
         {{- include "hono.component.envConfigMap" $args | indent 8 }}
         securityContext:

--- a/charts/hono/templates/hono-service-device-registry-mongodb/hono-service-device-registry-secret.yaml
+++ b/charts/hono/templates/hono-service-device-registry-mongodb/hono-service-device-registry-secret.yaml
@@ -18,6 +18,12 @@ metadata:
   {{- include "hono.metadata" $args | nindent 2 }}
 type: Opaque
 stringData:
+  logging-quarkus-prod.yml: |
+    {{- .Files.Get "config/logging-quarkus-prod.yaml" | nindent 4 }}
+  logging-quarkus-dev.yml: |
+    {{- .Files.Get "config/logging-quarkus-dev.yaml" | nindent 4 }}
+  logging-quarkus-trace.yml: |
+    {{- .Files.Get "config/logging-quarkus-trace.yaml" | nindent 4 }}
   application.yml: |
     hono:
       app:
@@ -69,6 +75,7 @@ stringData:
         {{- end }}
       {{- include "hono.messagingNetworkClientConfig" ( dict "dot" . "component" $args.component "kafkaMessagingSpec" .Values.deviceRegistryExample.hono.kafka ) | nindent 6 }}
       {{- include "hono.healthServerConfig" .Values.deviceRegistryExample.hono.healthCheck | nindent 6 }}
+    {{- include "hono.quarkusConfig" $args | indent 4 }}
 data:
   key.pem: {{ .Files.Get "example/certs/device-registry-key.pem" | b64enc }}
   cert.pem: {{ .Files.Get "example/certs/device-registry-cert.pem" | b64enc }}

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -520,6 +520,22 @@ adapters:
     # javaOptions contains options to pass to the JVM when starting
     # up the service
     javaOptions: -XX:MinRAMPercentage=80 -XX:MaxRAMPercentage=80
+    # quarkusConfigLocations contains resources that the Quarkus based variant of the component should read
+    # additional configuration from.
+    # Properties are read in the following sequence with properties further down in the list overwriting property
+    # values read from resources further up in the list.
+    # 1. Properties defined in file "/opt/hono/application.yml".
+    # 2. Properties read from the resources defined here.
+    # 3. Properties defined in operating system environment variables.
+    # 4. Properties defined in Java system properties.
+    # See https://smallrye.io/docs/smallrye-config/config/config.html#locations for details regarding supported resource
+    # types.
+    # If not set, default resources configuring logging levels based on the value of "quarkusLoggingProfile" are
+    # being read.
+    quarkusConfigLocations:
+    # quarkusLoggingProfile indicates at which level the Quarkus based variant of the component should log.
+    # Supported values are "prod", "dev" or "trace"
+    quarkusLoggingProfile: "dev"
     # springConfigLocation contains the location of the Spring application configuration file(s).
     # See https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config-files
     # for details.
@@ -617,6 +633,22 @@ adapters:
     # javaOptions contains options to pass to the JVM when starting
     # up the service
     javaOptions: -XX:MinRAMPercentage=80 -XX:MaxRAMPercentage=80
+    # quarkusConfigLocations contains resources that the Quarkus based variant of the component should read
+    # additional configuration from.
+    # Properties are read in the following sequence with properties further down in the list overwriting property
+    # values read from resources further up in the list.
+    # 1. Properties defined in file "/opt/hono/application.yml".
+    # 2. Properties read from the resources defined here.
+    # 3. Properties defined in operating system environment variables.
+    # 4. Properties defined in Java system properties.
+    # See https://smallrye.io/docs/smallrye-config/config/config.html#locations for details regarding supported resource
+    # types.
+    # If not set, default resources configuring logging levels based on the value of "quarkusLoggingProfile" are
+    # being read.
+    quarkusConfigLocations:
+    # quarkusLoggingProfile indicates at which level the Quarkus based variant of the component should log.
+    # Supported values are "prod", "dev" or "trace"
+    quarkusLoggingProfile: "dev"
     # springConfigLocation contains the location of the Spring application configuration file(s).
     # See https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config-files
     # for details.
@@ -705,6 +737,22 @@ adapters:
     # javaOptions contains options to pass to the JVM when starting
     # up the service
     javaOptions: -XX:MinRAMPercentage=80 -XX:MaxRAMPercentage=80
+    # quarkusConfigLocations contains resources that the Quarkus based variant of the component should read
+    # additional configuration from.
+    # Properties are read in the following sequence with properties further down in the list overwriting property
+    # values read from resources further up in the list.
+    # 1. Properties defined in file "/opt/hono/application.yml".
+    # 2. Properties read from the resources defined here.
+    # 3. Properties defined in operating system environment variables.
+    # 4. Properties defined in Java system properties.
+    # See https://smallrye.io/docs/smallrye-config/config/config.html#locations for details regarding supported resource
+    # types.
+    # If not set, default resources configuring logging levels based on the value of "quarkusLoggingProfile" are
+    # being read.
+    quarkusConfigLocations:
+    # quarkusLoggingProfile indicates at which level the Quarkus based variant of the component should log.
+    # Supported values are "prod", "dev" or "trace"
+    quarkusLoggingProfile: "dev"
     # springConfigLocation contains the location of the Spring application configuration file(s).
     # See https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config-files
     # for details.
@@ -899,6 +947,22 @@ adapters:
     # javaOptions contains options to pass to the JVM when starting
     # up the service
     javaOptions: -XX:MinRAMPercentage=80 -XX:MaxRAMPercentage=80
+    # quarkusConfigLocations contains resources that the Quarkus based variant of the component should read
+    # additional configuration from.
+    # Properties are read in the following sequence with properties further down in the list overwriting property
+    # values read from resources further up in the list.
+    # 1. Properties defined in file "/opt/hono/application.yml".
+    # 2. Properties read from the resources defined here.
+    # 3. Properties defined in operating system environment variables.
+    # 4. Properties defined in Java system properties.
+    # See https://smallrye.io/docs/smallrye-config/config/config.html#locations for details regarding supported resource
+    # types.
+    # If not set, default resources configuring logging levels based on the value of "quarkusLoggingProfile" are
+    # being read.
+    quarkusConfigLocations:
+    # quarkusLoggingProfile indicates at which level the Quarkus based variant of the component should log.
+    # Supported values are "prod", "dev" or "trace"
+    quarkusLoggingProfile: "dev"
     # springConfigLocation contains the location of the Spring application configuration file(s).
     # See https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config-files
     # for details.
@@ -995,6 +1059,22 @@ adapters:
     # javaOptions contains options to pass to the JVM when starting
     # up the service
     javaOptions: -XX:MinRAMPercentage=80 -XX:MaxRAMPercentage=80
+    # quarkusConfigLocations contains resources that the Quarkus based variant of the component should read
+    # additional configuration from.
+    # Properties are read in the following sequence with properties further down in the list overwriting property
+    # values read from resources further up in the list.
+    # 1. Properties defined in file "/opt/hono/application.yml".
+    # 2. Properties read from the resources defined here.
+    # 3. Properties defined in operating system environment variables.
+    # 4. Properties defined in Java system properties.
+    # See https://smallrye.io/docs/smallrye-config/config/config.html#locations for details regarding supported resource
+    # types.
+    # If not set, default resources configuring logging levels based on the value of "quarkusLoggingProfile" are
+    # being read.
+    quarkusConfigLocations:
+    # quarkusLoggingProfile indicates at which level the Quarkus based variant of the component should log.
+    # Supported values are "prod", "dev" or "trace"
+    quarkusLoggingProfile: "dev"
     # springConfigLocation contains the location of the Spring application configuration file(s).
     # See https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config-files
     # for details.
@@ -1092,6 +1172,22 @@ authServer:
   # javaOptions contains options to pass to the JVM when starting
   # up the service
   javaOptions: -XX:MinRAMPercentage=80 -XX:MaxRAMPercentage=80
+  # quarkusConfigLocations contains resources that the Quarkus based variant of the component should read
+  # additional configuration from.
+  # Properties are read in the following sequence with properties further down in the list overwriting property
+  # values read from resources further up in the list.
+  # 1. Properties defined in file "/opt/hono/application.yml".
+  # 2. Properties read from the resources defined here.
+  # 3. Properties defined in operating system environment variables.
+  # 4. Properties defined in Java system properties.
+  # See https://smallrye.io/docs/smallrye-config/config/config.html#locations for details regarding supported resource
+  # types.
+  # If not set, default resources configuring logging levels based on the value of "quarkusLoggingProfile" are
+  # being read.
+  quarkusConfigLocations:
+  # quarkusLoggingProfile indicates at which level the Quarkus based variant of the component should log.
+  # Supported values are "prod", "dev" or "trace"
+  quarkusLoggingProfile: "dev"
   # springConfigLocation contains the location of the Spring application configuration file(s).
   # See https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config-files
   # for details.
@@ -1395,6 +1491,22 @@ deviceRegistryExample:
     # the image from.
     # If not specified, the value of the "honoContainerRegistry" property is used.
     # containerRegistry:
+    # quarkusConfigLocations contains resources that the Quarkus based variant of the component should read
+    # additional configuration from.
+    # Properties are read in the following sequence with properties further down in the list overwriting property
+    # values read from resources further up in the list.
+    # 1. Properties defined in file "/opt/hono/application.yml".
+    # 2. Properties read from the resources defined here.
+    # 3. Properties defined in operating system environment variables.
+    # 4. Properties defined in Java system properties.
+    # See https://smallrye.io/docs/smallrye-config/config/config.html#locations for details regarding supported resource
+    # types.
+    # If not set, default resources configuring logging levels based on the value of "quarkusLoggingProfile" are
+    # being read.
+    quarkusConfigLocations:
+    # quarkusLoggingProfile indicates at which level the Quarkus based variant of the component should log.
+    # Supported values are "prod", "dev" or "trace"
+    quarkusLoggingProfile: "dev"
     # applicationProfiles contains the Spring application profiles that should be activated
     # in the Spring Boot based service variant.
     applicationProfiles: "dev"
@@ -1708,6 +1820,22 @@ commandRouterService:
   # javaOptions contains options to pass to the JVM when starting
   # up the service
   javaOptions: -XX:MinRAMPercentage=80 -XX:MaxRAMPercentage=80 -Djava.security.properties=/etc/hono/dns-cache-config.properties
+  # quarkusConfigLocations contains resources that the Quarkus based variant of the component should read
+  # additional configuration from.
+  # Properties are read in the following sequence with properties further down in the list overwriting property
+  # values read from resources further up in the list.
+  # 1. Properties defined in file "/opt/hono/application.yml".
+  # 2. Properties read from the resources defined here.
+  # 3. Properties defined in operating system environment variables.
+  # 4. Properties defined in Java system properties.
+  # See https://smallrye.io/docs/smallrye-config/config/config.html#locations for details regarding supported resource
+  # types.
+  # If not set, default resources configuring logging levels based on the value of "quarkusLoggingProfile" are
+  # being read.
+  quarkusConfigLocations:
+  # quarkusLoggingProfile indicates at which level the Quarkus based variant of the component should log.
+  # Supported values are "prod", "dev" or "trace"
+  quarkusLoggingProfile: "dev"
   # springConfigLocation contains the location of the Spring application configuration file(s).
   # See https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config-files
   # for details.


### PR DESCRIPTION
The logging level(s) used in the Quarkus based components can now be set
using the "quarkusLoggingProfile" configuration property that is defined
for all components for which a Quarkus based variant exists.

Fixes #303
