### PR TITLE
Use Jolokia HTTP API for k8s probes

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.12.1
+version: 1.12.2
 # Version of Hono being deployed by the chart
 appVersion: 1.12.0
 keywords:

--- a/charts/hono/config/artemis/broker.xml
+++ b/charts/hono/config/artemis/broker.xml
@@ -26,7 +26,7 @@
 
       <!-- this could be ASYNCIO or NIO
        -->
-      <journal-type>NIO</journal-type>
+      <journal-type>ASYNCIO</journal-type>
 
       <paging-directory>./data/paging</paging-directory>
 
@@ -40,7 +40,7 @@
 
       <journal-min-files>2</journal-min-files>
 
-      <journal-pool-files>-1</journal-pool-files>
+      <journal-pool-files>10</journal-pool-files>
 
       <!--
         You can specify the NIC you want to use to verify if the network

--- a/charts/hono/config/artemis/liveness-probe.sh
+++ b/charts/hono/config/artemis/liveness-probe.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# liveness-probe - checks if a given ActiveMQ Artemis broker instance is running
+#
+# Copyright (c) 2022 Contributors to the Eclipse Foundation
+##
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# liveness-probe [broker_name]
+#
+
+brokerName=${1:-hono-broker}
+url="http://localhost:8161/console/jolokia/read/org.apache.activemq.artemis:broker=%22${brokerName}%22/Version"
+
+curl -s --user artemis:artemis -H "Origin: http://localhost" ${url}
+

--- a/charts/hono/config/artemis/readiness-probe.sh
+++ b/charts/hono/config/artemis/readiness-probe.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# readiness-probe - checks if a given ActiveMQ Artemis broker instance's acceptor is running
+#
+# Copyright (c) 2022 Contributors to the Eclipse Foundation
+##
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# readiness-probe [broker_name acceptor_name]
+#
+
+brokerName=${1:-hono-broker}
+acceptorName=${2:-amqps}
+url="http://localhost:8161/console/jolokia/read/org.apache.activemq.artemis:broker=%22${brokerName}%22,component=acceptors,name=%22${acceptorName}%22/Started"
+
+curl -s --user artemis:artemis -H "Origin: http://localhost" ${url} | grep "\"value\":true"
+

--- a/charts/hono/templates/artemis/artemis-deployment.yaml
+++ b/charts/hono/templates/artemis/artemis-deployment.yaml
@@ -15,7 +15,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  {{- $args := dict "dot" . "component" "amqp-messaging-network-broker" "name" "artemis" "componentConfig" .Values.amqpMessagingNetworkExample.broker.artemis }}
+  {{- $args := dict "dot" . "component" "amqp-messaging-network-broker" "name" "artemis" "componentConfig" .Values.amqpMessagingNetworkExample.broker.artemis "configMountPath" "/opt/apache-artemis/conf" }}
   {{- include "hono.metadata" $args | nindent 2 }}
 spec:
   replicas: 1
@@ -60,20 +60,24 @@ spec:
         {{- end }}
         livenessProbe:
           initialDelaySeconds: {{ $args.componentConfig.livenessProbeInitialDelaySeconds }}
-          periodSeconds: 9
-          tcpSocket:
-            port: 5671
-          timeoutSeconds: 1
+          periodSeconds: 17
+          exec:
+            command:
+            - "/bin/bash"
+            - {{ printf "%s/liveness-probe.sh" $args.configMountPath | quote }}
+          timeoutSeconds: 3
         readinessProbe:
           initialDelaySeconds: {{ $args.componentConfig.readinessProbeInitialDelaySeconds }}
-          periodSeconds: 5
-          tcpSocket:
-            port: 5671
-          timeoutSeconds: 1
+          periodSeconds: 10
+          exec:
+            command:
+            - "/bin/bash"
+            - {{ printf "%s/readiness-probe.sh" $args.configMountPath | quote }}
+          timeoutSeconds: 3
         securityContext:
           privileged: false
         volumeMounts:
-        {{- include "hono.container.secretVolumeMounts" ( dict "name" $args.name "componentConfig" $args.componentConfig "configMountPath" "/opt/apache-artemis/conf" ) | indent 8 }}
+        {{- include "hono.container.secretVolumeMounts" $args | indent 8 }}
       volumes:
       {{- include "hono.pod.secretVolumes" $args | indent 6 }}
 {{- end }}

--- a/charts/hono/templates/artemis/artemis-secret.yaml
+++ b/charts/hono/templates/artemis/artemis-secret.yaml
@@ -29,6 +29,10 @@ stringData:
     {{- .Files.Get "config/artemis/login.config" | nindent 4 }}
   "logging.properties": |
     {{- .Files.Get "config/artemis/logging.properties" | nindent 4 }}
+  "liveness-probe.sh": |
+    {{- .Files.Get "config/artemis/lifeness-probe.sh" | nindent 4 }}
+  "readiness-probe.sh": |
+    {{- .Files.Get "config/artemis/readiness-probe.sh" | nindent 4 }}
 data:
   "artemisKeyStore.p12": {{ .Files.Get "example/certs/artemisKeyStore.p12" | b64enc }}
 {{- end }}


### PR DESCRIPTION
The k8s readiness and liveness probes have been changed to no longer use
a TCP connection attempt but to instead query the broker state via the
Jolokia HTTP API.

Fixes #345
