### PR TITLE
Upgrade to latest latest monitoring chart minor versions

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.12.2
+version: 1.12.3
 # Version of Hono being deployed by the chart
 appVersion: 1.12.0
 keywords:

--- a/charts/hono/requirements.yaml
+++ b/charts/hono/requirements.yaml
@@ -12,11 +12,11 @@
 #
 dependencies:
   - name: prometheus
-    version: ~14.6.0
+    version: ^14.x
     repository: "https://prometheus-community.github.io/helm-charts"
     condition: prometheus.createInstance
   - name: grafana
-    version: ~6.16.0
+    version: ^6.x
     repository: "https://grafana.github.io/helm-charts"
     condition: grafana.enabled
   - name: mongodb

--- a/charts/hono/templates/grafana/grafana-dashboard-jvm-configmap.yaml
+++ b/charts/hono/templates/grafana/grafana-dashboard-jvm-configmap.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.grafana.enabled }}
+#
+# Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  {{- $args := dict "dot" . "component" "dashboard" "name" "jvm-details" }}
+  {{- include "hono.metadata" $args | nindent 2 }}
+    grafana_dashboard: "1"
+data:
+  jvm-details.json: |
+    {{- .Files.Get "config/grafana/dashboard-definitions/jvm-details.json" | nindent 4 }}
+{{- end }}

--- a/charts/hono/templates/grafana/grafana-dashboard-message-details-configmap.yaml
+++ b/charts/hono/templates/grafana/grafana-dashboard-message-details-configmap.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.grafana.enabled }}
+#
+# Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  {{- $args := dict "dot" . "component" "dashboard" "name" "message-details" }}
+  {{- include "hono.metadata" $args | nindent 2 }}
+    grafana_dashboard: "1"
+data:
+  message-details.json: |
+    {{- .Files.Get "config/grafana/dashboard-definitions/message-details.json" | nindent 4 }}
+{{- end }}

--- a/charts/hono/templates/grafana/grafana-dashboard-overview-configmap.yaml
+++ b/charts/hono/templates/grafana/grafana-dashboard-overview-configmap.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.grafana.enabled }}
 #
-# Copyright (c) 2019 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -14,14 +14,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  {{- $args := dict "dot" . "component" "dashboard" "name" "grafana-dashboards" }}
+  {{- $args := dict "dot" . "component" "dashboard" "name" "overview" }}
   {{- include "hono.metadata" $args | nindent 2 }}
     grafana_dashboard: "1"
 data:
   overview.json: |
     {{- .Files.Get "config/grafana/dashboard-definitions/overview.json" | nindent 4 }}
-  message-details.json: |
-    {{- .Files.Get "config/grafana/dashboard-definitions/message-details.json" | nindent 4 }}
-  jvm-details.json: |
-    {{- .Files.Get "config/grafana/dashboard-definitions/jvm-details.json" | nindent 4 }}
 {{- end }}

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -2027,14 +2027,6 @@ grafana:
   enabled: false
   adminPassword: admin
 
-  # labels to be added to the Grafana Deployment
-  labels:
-    app.kubernetes.io/component: dashboard
-
-  # labels to be added to the Grafana Pod(s)
-  podLabels:
-    app.kubernetes.io/component: dashboard
-
   # do not run tests after deployment
   testFramework:
     enabled: false
@@ -2048,8 +2040,6 @@ grafana:
     port: 3000
     targetPort: 3000
     annotations: {}
-    labels:
-      app.kubernetes.io/component: dashboard
 
   ## Sidecars that collect the configmaps with specified label and stores the included files them into the respective folders
   ## Requires at least Grafana 5 to work and can't be used together with parameters dashboardProviders, datasources and dashboards


### PR DESCRIPTION
Always use latest minor versions of Prometheus and Grafana charts.
Also split up ConfigMap containing Grafana dashboard definitions into
separate ConfigMaps, each containing a single dashboard definition as
recommended by the Grafana chart documentation.