### PR TITLE
Ditto: Replace enableDummyAuth by enablePreAuthentication

### DIFF
--- a/charts/ditto/Chart.yaml
+++ b/charts/ditto/Chart.yaml
@@ -15,7 +15,7 @@ description: |
   Eclipse Ditto™ is a technology in the IoT implementing a software pattern called “digital twins”.
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
-version: 2.3.0
+version: 2.3.1
 appVersion: 2.3.0
 keywords:
   - iot-chart

--- a/charts/ditto/README.md
+++ b/charts/ditto/README.md
@@ -90,7 +90,6 @@ To secure /devops and /status resource adjust configuration to (username will be
 
 ```yaml
 gateway:
-  enablePreAuthentication: false
   devopsSecureStatus: true
   devopsPassword: foo
   statusPassword: bar

--- a/charts/ditto/README.md
+++ b/charts/ditto/README.md
@@ -79,7 +79,7 @@ global:
   jwtOnly: true
 
 gateway:
-  enableDummyAuth: false
+  enablePreAuthentication: false
   systemProps:
     - "-Dditto.gateway.authentication.oauth.openid-connect-issuers.myprovider.issuer=openid-connect.onelogin.com/oidc"
 ```
@@ -90,11 +90,12 @@ To secure /devops and /status resource adjust configuration to (username will be
 
 ```yaml
 gateway:
-  enableDummyAuth: false
+  enablePreAuthentication: false
   devopsSecureStatus: true
   devopsPassword: foo
   statusPassword: bar
 ```
+
 
 ## Troubleshooting
 

--- a/charts/ditto/templates/gateway-deployment.yaml
+++ b/charts/ditto/templates/gateway-deployment.yaml
@@ -95,8 +95,8 @@ spec:
               value: "app.kubernetes.io/name=%s"
             - name: POD_NAMESPACE
               value: {{ .Release.Namespace }}
-            - name: ENABLE_DUMMY_AUTH
-              value: {{ .Values.gateway.enableDummyAuth | quote }}
+            - name: ENABLE_PRE_AUTHENTICATION
+              value: {{ .Values.gateway.enablePreAuthentication | quote }}
             - name: INSTANCE_INDEX
               valueFrom:
                 fieldRef:

--- a/charts/ditto/values.yaml
+++ b/charts/ditto/values.yaml
@@ -286,8 +286,8 @@ gateway:
   ## devopsSecureStatus is used as value for DEVOPS_SECURE_STATUS environment var
   ## this controls whether /status resource is secured or not
   devopsSecureStatus: false
-  ## enableDummyAuth is used as value for ENABLE_DUMMY_AUTH environment var
-  enableDummyAuth: true
+  ## enablePreAuthentication is used as value for ENABLE_PRE_AUTHENTICATION environment var
+  enablePreAuthentication: true
   ## devopsPassword will be used for accessing /devops resource (username: devops)
   ## if not set a random password will be set
   devopsPassword:


### PR DESCRIPTION
ENABLE_DUMMY_AUTH was replaced by ENABLE_PRE_AUTHENTICATION.
You can see that here https://github.com/eclipse/ditto/blob/e25c34e044b2d4c0428874942fa75e078c74ce82/gateway/service/src/main/resources/gateway.conf

I replaced ENABLE_DUMMY_AUTH with ENABLE_PRE_AUTHENTICATION in the README.md, values.yaml and gateway-deployment.yaml accordingly.
I don't know if backward compatibility is required nether I found an easy way to introduce it because the env-variables would affect each other.

