### PR TITLE
Remove egress from policyType for swaggerui-networkpolicy.yaml 

### DIFF
--- a/charts/ditto/Chart.yaml
+++ b/charts/ditto/Chart.yaml
@@ -15,7 +15,7 @@ description: |
   Eclipse Ditto™ is a technology in the IoT implementing a software pattern called “digital twins”.
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
-version: 2.3.3
+version: 2.3.4
 appVersion: 2.3.2
 keywords:
   - iot-chart

--- a/charts/ditto/templates/concierge-deployment.yaml
+++ b/charts/ditto/templates/concierge-deployment.yaml
@@ -92,8 +92,10 @@ spec:
             - "-jar"
             - "/opt/ditto/starter.jar"
           env:
+            {{- if .Values.global.logging.logstash.enabled }}
             - name: DITTO_LOGGING_FILE_APPENDER
-              value: "{{ if .Values.global.logging.logFiles.enabled }}true{{ else }}false{{ end }}"
+              value: "true"
+            {{- end }}
             {{- if .Values.global.logging.logstash.enabled }}
             - name: DITTO_LOGGING_LOGSTASH_SERVER
               value: "{{ .Values.global.logging.logstash.endpoint }}"

--- a/charts/ditto/templates/connectivity-deployment.yaml
+++ b/charts/ditto/templates/connectivity-deployment.yaml
@@ -92,8 +92,10 @@ spec:
             - "-jar"
             - "/opt/ditto/starter.jar"
           env:
+            {{- if .Values.global.logging.logstash.enabled }}
             - name: DITTO_LOGGING_FILE_APPENDER
-              value: "{{ if .Values.global.logging.logFiles.enabled }}true{{ else }}false{{ end }}"
+              value: "true"
+            {{- end }}
             {{- if .Values.global.logging.logstash.enabled }}
             - name: DITTO_LOGGING_LOGSTASH_SERVER
               value: "{{ .Values.global.logging.logstash.endpoint }}"

--- a/charts/ditto/templates/gateway-deployment.yaml
+++ b/charts/ditto/templates/gateway-deployment.yaml
@@ -93,8 +93,10 @@ spec:
             - "-jar"
             - "/opt/ditto/starter.jar"
           env:
+            {{- if .Values.global.logging.logstash.enabled }}
             - name: DITTO_LOGGING_FILE_APPENDER
-              value: "{{ if .Values.global.logging.logFiles.enabled }}true{{ else }}false{{ end }}"
+              value: "true"
+            {{- end }}
             {{- if .Values.global.logging.logstash.enabled }}
             - name: DITTO_LOGGING_LOGSTASH_SERVER
               value: "{{ .Values.global.logging.logstash.endpoint }}"

--- a/charts/ditto/templates/policies-deployment.yaml
+++ b/charts/ditto/templates/policies-deployment.yaml
@@ -92,8 +92,10 @@ spec:
             - "-jar"
             - "/opt/ditto/starter.jar"
           env:
+            {{- if .Values.global.logging.logstash.enabled }}
             - name: DITTO_LOGGING_FILE_APPENDER
-              value: "{{ if .Values.global.logging.logFiles.enabled }}true{{ else }}false{{ end }}"
+              value: "true"
+            {{- end }}
             {{- if .Values.global.logging.logstash.enabled }}
             - name: DITTO_LOGGING_LOGSTASH_SERVER
               value: "{{ .Values.global.logging.logstash.endpoint }}"

--- a/charts/ditto/templates/swaggerui-networkpolicy.yaml
+++ b/charts/ditto/templates/swaggerui-networkpolicy.yaml
@@ -24,7 +24,6 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
   policyTypes:
   - Ingress
-  - Egress
   ingress:
   - from:
     - podSelector:

--- a/charts/ditto/templates/things-deployment.yaml
+++ b/charts/ditto/templates/things-deployment.yaml
@@ -92,8 +92,10 @@ spec:
             - "-jar"
             - "/opt/ditto/starter.jar"
           env:
+            {{- if .Values.global.logging.logstash.enabled }}
             - name: DITTO_LOGGING_FILE_APPENDER
-              value: "{{ if .Values.global.logging.logFiles.enabled }}true{{ else }}false{{ end }}"
+              value: "true"
+            {{- end }}
             {{- if .Values.global.logging.logstash.enabled }}
             - name: DITTO_LOGGING_LOGSTASH_SERVER
               value: "{{ .Values.global.logging.logstash.endpoint }}"

--- a/charts/ditto/templates/thingssearch-deployment.yaml
+++ b/charts/ditto/templates/thingssearch-deployment.yaml
@@ -92,8 +92,10 @@ spec:
             - "-jar"
             - "/opt/ditto/starter.jar"
           env:
+            {{- if .Values.global.logging.logstash.enabled }}
             - name: DITTO_LOGGING_FILE_APPENDER
-              value: "{{ if .Values.global.logging.logFiles.enabled }}true{{ else }}false{{ end }}"
+              value: "true"
+            {{- end }}
             {{- if .Values.global.logging.logstash.enabled }}
             - name: DITTO_LOGGING_LOGSTASH_SERVER
               value: "{{ .Values.global.logging.logstash.endpoint }}"

--- a/packages/cloud2edge/profileKafkaMessaging.yaml
+++ b/packages/cloud2edge/profileKafkaMessaging.yaml
@@ -19,3 +19,8 @@ hono:
 
   amqpMessagingNetworkExample:
     enabled: false
+
+  kafka:
+    externalAccess:
+      service:
+        type: NodePort

--- a/packages/cloud2edge/templates/post-install-job.yaml
+++ b/packages/cloud2edge/templates/post-install-job.yaml
@@ -25,7 +25,7 @@ metadata:
     # job is considered part of the release.
     helm.sh/hook: post-install
     helm.sh/hook-weight: "-5"
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:
   template:
     metadata:

--- a/packages/cloud2edge/values.yaml
+++ b/packages/cloud2edge/values.yaml
@@ -94,13 +94,13 @@ hono:
 
 # Configuration properties for Eclipse Ditto.
 ditto:
-
+  # do not set cpu limits for Ditto to avoid CFS scheduler limits
+  # ref: https://doc.akka.io/docs/akka/snapshot/additional/deploy.html#in-kubernetes
   concierge:
     resources:
       requests:
         cpu: 200m
       limits:
-        cpu: 1
         memory: "512Mi"
 
   connectivity:
@@ -108,7 +108,6 @@ ditto:
       requests:
         cpu: 200m
       limits:
-        cpu: 1
         memory: "512Mi"
 
   gateway:
@@ -116,7 +115,6 @@ ditto:
       requests:
         cpu: 200m
       limits:
-        cpu: 1
         memory: "512Mi"
 
   nginx:
@@ -134,7 +132,6 @@ ditto:
       requests:
         cpu: 200m
       limits:
-        cpu: 1
         memory: "512Mi"
 
   swaggerui:
@@ -150,7 +147,6 @@ ditto:
       requests:
         cpu: 200m
       limits:
-        cpu: 1
         memory: "512Mi"
 
   thingsSearch:
@@ -158,7 +154,6 @@ ditto:
       requests:
         cpu: 200m
       limits:
-        cpu: 1
         memory: "512Mi"
 
   mongodb:

--- a/packages/cloud2edge/values.yaml
+++ b/packages/cloud2edge/values.yaml
@@ -108,7 +108,7 @@ ditto:
       requests:
         cpu: 200m
       limits:
-        memory: "512Mi"
+        memory: "2Gi"
 
   gateway:
     resources:


### PR DESCRIPTION
Because swagger ui definition is loaded from Github during start of container.
