### PR TITLE
Use HTTP scheme for health checks and probes

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,21 +15,21 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 1.12.7
+version: 1.12.8
 # Version of Hono being deployed by the chart
-appVersion: 1.12.1
+appVersion: 1.12.2
 keywords:
-  - iot-chart
-  - IoT
-  - messaging
+- iot-chart
+- IoT
+- messaging
 home: https://www.eclipse.org/hono/
 sources:
-  - https://github.com/eclipse/hono
+- https://github.com/eclipse/hono
 icon: https://www.eclipse.org/hono/favicon/favicon-48x48.png
 maintainers:
-  - name: dejanb
-    email: dbosanac@redhat.com
-  - name: ctron
-    email: jreimann@redhat.com
-  - name: sophokles73
-    email: kai.hudalla@bosch.io
+- name: dejanb
+  email: dbosanac@redhat.com
+- name: ctron
+  email: jreimann@redhat.com
+- name: sophokles73
+  email: kai.hudalla@bosch.io

--- a/charts/hono/templates/_helpers.tpl
+++ b/charts/hono/templates/_helpers.tpl
@@ -127,6 +127,7 @@ Add annotations for marking an object to be scraped by Prometheus.
 prometheus.io/scrape: "true"
 prometheus.io/path: "/prometheus"
 prometheus.io/port: {{ default .Values.healthCheckPort .Values.monitoring.prometheus.port | quote }}
+prometheus.io/scheme: "http"
 {{- end }}
 
 
@@ -156,17 +157,15 @@ Configuration for the health check server of service components.
 If the scope passed in is not 'nil', then its value is
 used as the configuration for the health check server.
 Otherwise, a secure health check server will be configured to bind to all
-interfaces on the default port using the component's key and cert.
+interfaces on the default port.
 */}}
 {{- define "hono.healthServerConfig" -}}
 healthCheck:
 {{- if . }}
   {{- toYaml . | nindent 2 }}
 {{- else }}
-  port: 8088
-  bindAddress: "0.0.0.0"
-  keyPath: "/etc/hono/key.pem"
-  certPath: "/etc/hono/cert.pem"
+  insecurePort: 8088
+  insecurePortBindAddress: "0.0.0.0"
 {{- end }}
 {{- end }}
 
@@ -567,15 +566,15 @@ The scope passed in is expected to be a dict with keys
 {{- define "hono.component.healthChecks" }}
 livenessProbe:
   httpGet:
-    path: /liveness
-    port: health
-    scheme: HTTPS
+    path: "/liveness"
+    port: "health"
+    scheme: "HTTP"
   initialDelaySeconds: {{ default .dot.Values.livenessProbeInitialDelaySeconds .componentConfig.livenessProbeInitialDelaySeconds }}
 readinessProbe:
   httpGet:
-    path: /readiness
-    port: health
-    scheme: HTTPS
+    path: "/readiness"
+    port: "health"
+    scheme: "HTTP"
   initialDelaySeconds: {{ default .dot.Values.readinessProbeInitialDelaySeconds .componentConfig.readinessProbeInitialDelaySeconds }}
 {{- end }}
 

--- a/charts/hono/templates/prometheus/prometheus-config.yaml
+++ b/charts/hono/templates/prometheus/prometheus-config.yaml
@@ -39,18 +39,15 @@ data:
         # * `prometheus.io/port`: Scrape the pod on the indicated port instead of the default of `9102`.
         # * `prometheus.io/scheme`: Scrape the pod using the indicated scheme instead of the default of `https`.
       - job_name: 'hono-pods'
-        scheme: https
-        tls_config:
-          insecure_skip_verify: true
         kubernetes_sd_configs:
+        - role: pod
+          # make sure to only scrape pods of this release
+          namespaces:
+            names:
+            - {{ .Release.Namespace }}
+          selectors:
           - role: pod
-            # make sure to only scrape pods of this release
-            namespaces:
-              names:
-              - {{ .Release.Namespace }}
-            selectors:
-            - role: pod
-              label: {{ printf "app.kubernetes.io/instance=%s,helm.sh/chart=%s" .Release.Name ( include "hono.chart" . ) }}
+            label: {{ printf "app.kubernetes.io/instance=%s,helm.sh/chart=%s" .Release.Name ( include "hono.chart" . ) }}
 
         relabel_configs:
           - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]


### PR DESCRIPTION
Using the standard HTTP scheme will allow the chart to be used with Hono
2.0.0 container images as well. That is because Hono 2.0.0 uses SmallRye
Health to spin up an http server hosting the health check and readiness
endpoints and the http server's default configuration does not use HTTPS
and uses other configuration properties than Hono 1.x's custom rolled
health check server.

Using HTTP by default shouldn't be a big issue because the health check
server's endpoints are not exposed via k8s services anyway.

Also updated to Hono 1.12.2
