### PR TITLE
Adopt latest k8s versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,10 +64,11 @@ jobs:
         # which a folder exists at
         # https://github.com/yannh/kubernetes-json-schema/
         k8s:
-          - v1.19.7
           - v1.20.9
-          - v1.21.5
-          - v1.22.2
+          - v1.21.9
+          - v1.22.9
+          - v1.23.7
+          - v1.24.1
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -94,10 +95,11 @@ jobs:
         # the versions supported by chart-testing are the tags
         # available for the docker.io/kindest/node image
         # https://hub.docker.com/r/kindest/node/tags
-          - v1.19.11
-          - v1.20.7
-          - v1.21.1
-          - v1.22.1
+          - v1.20.15
+          - v1.21.12
+          - v1.22.9
+          - v1.23.6
+          - v1.24.1
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -13,7 +13,7 @@ name: ci
 
 env:
   CONFIG_OPTION_CHART_TESTING: "--config .github/ct.yaml"
-  VERSION_CHART_TESTING: "v3.4.0"
+  VERSION_CHART_TESTING: "v3.5.1"
   VERSION_HELM: "v3.5.4"
   VERSION_PYTHON: "3.7"
 on:
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Lint Bash scripts
-        uses: docker://koalaman/shellcheck-alpine:v0.7.0
+        uses: docker://koalaman/shellcheck-alpine:v0.8.0
         with:
           args: .github/lint-scripts.sh
 
@@ -42,14 +42,14 @@ jobs:
       - name: Fetch history for chart testing
         run: git fetch --prune --unshallow
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v2.1
         with:
           version: ${{ env.VERSION_HELM }}
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ env.VERSION_PYTHON }}
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.1.0
+        uses: helm/chart-testing-action@v2.2.1
         with:
           version: ${{ env.VERSION_CHART_TESTING }}
       - name: Run chart-testing (lint)
@@ -75,7 +75,7 @@ jobs:
       - name: Fetch history for chart testing
         run: git fetch --prune --unshallow
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v2.1
         with:
           version: ${{ env.VERSION_HELM }}
       - name: Run kubeval
@@ -106,14 +106,14 @@ jobs:
       - name: Fetch history for chart testing
         run: git fetch --prune --unshallow
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v2.1
         with:
           version: ${{ env.VERSION_HELM }}
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ env.VERSION_PYTHON }}
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.1.0
+        uses: helm/chart-testing-action@v2.2.1
         with:
           version: ${{ env.VERSION_CHART_TESTING }}
       - name: Check for changed charts
@@ -126,7 +126,7 @@ jobs:
       - name: Create kind ${{ matrix.k8s }} cluster
         uses: helm/kind-action@v1.2.0
         with:
-          version: v0.11.1
+          version: v0.14.0
           config: .github/kind-config.yaml
           node_image: kindest/node:${{ matrix.k8s }}
         if: ${{ steps.list-changed.outputs.changed == 'true' }}


### PR DESCRIPTION
Adapt chart testing to use five most recent k8s versions.
Update tools for chart testing to latest versions

The change to the Hono chart version has been made to trigger the testing of the Hono chart. The change should be reverted before merging ...