### PR TITLE
Hono: Add default-container annotation

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 2.0.0
+version: 2.0.1
 # Version of Hono being deployed by the chart
 appVersion: 2.0.0
 keywords:

--- a/charts/hono/templates/_helpers.tpl
+++ b/charts/hono/templates/_helpers.tpl
@@ -128,13 +128,19 @@ app.kubernetes.io/component: {{ .component | quote }}
 {{- end }}
 
 {{/*
-Add annotations for marking an object to be scraped by Prometheus.
+Add standard annotations for Hono component pods.
+This includes annotations for marking a pod to be scraped by Prometheus
+and an annotation to define the default container.
+The scope passed in is expected to be a dict with keys
+- "dot": the "." scope and
+- "name": the value to use for the "default-container" annotation
 */}}
-{{- define "hono.monitoringAnnotations" -}}
+{{- define "hono.podAnnotations" -}}
 prometheus.io/scrape: "true"
 prometheus.io/path: "/prometheus"
-prometheus.io/port: {{ include "hono.healthCheckPort" . | quote }}
+prometheus.io/port: {{ include "hono.healthCheckPort" .dot | quote }}
 prometheus.io/scheme: "http"
+kubectl.kubernetes.io/default-container: {{ .name | quote }}
 {{- end }}
 
 

--- a/charts/hono/templates/hono-adapter-amqp/hono-adapter-amqp-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-amqp/hono-adapter-amqp-deployment.yaml
@@ -25,7 +25,7 @@ spec:
     metadata:
       {{- include "hono.metadata" $args | nindent 6 }}
       annotations:
-        {{- include "hono.monitoringAnnotations" . | nindent 8 }}
+        {{- include "hono.podAnnotations" $args | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/hono/templates/hono-adapter-coap/hono-adapter-coap-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-coap/hono-adapter-coap-deployment.yaml
@@ -25,7 +25,7 @@ spec:
     metadata:
       {{- include "hono.metadata" $args | nindent 6 }}
       annotations:
-        {{- include "hono.monitoringAnnotations" . | nindent 8 }}
+        {{- include "hono.podAnnotations" $args | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/hono/templates/hono-adapter-http/hono-adapter-http-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-http/hono-adapter-http-deployment.yaml
@@ -25,7 +25,7 @@ spec:
     metadata:
       {{- include "hono.metadata" $args | nindent 6 }}
       annotations:
-        {{- include "hono.monitoringAnnotations" . | nindent 8 }}
+        {{- include "hono.podAnnotations" $args | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/hono/templates/hono-adapter-lora/hono-adapter-lora-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-lora/hono-adapter-lora-deployment.yaml
@@ -25,7 +25,7 @@ spec:
     metadata:
       {{- include "hono.metadata" $args | nindent 6 }}
       annotations:
-        {{- include "hono.monitoringAnnotations" . | nindent 8 }}
+        {{- include "hono.podAnnotations" $args | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/hono/templates/hono-adapter-mqtt/hono-adapter-mqtt-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-mqtt/hono-adapter-mqtt-deployment.yaml
@@ -25,7 +25,7 @@ spec:
     metadata:
       {{- include "hono.metadata" $args | nindent 6 }}
       annotations:
-        {{- include "hono.monitoringAnnotations" . | nindent 8 }}
+        {{- include "hono.podAnnotations" $args | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/hono/templates/hono-service-auth/hono-service-auth-deployment.yaml
+++ b/charts/hono/templates/hono-service-auth/hono-service-auth-deployment.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       {{- include "hono.metadata" $args | nindent 6 }}
       annotations:
-        {{- include "hono.monitoringAnnotations" . | nindent 8 }}
+        {{- include "hono.podAnnotations" $args | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/hono/templates/hono-service-command-router/hono-service-command-router-deployment.yaml
+++ b/charts/hono/templates/hono-service-command-router/hono-service-command-router-deployment.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       {{- include "hono.metadata" $args | nindent 6 }}
       annotations:
-        {{- include "hono.monitoringAnnotations" . | nindent 8 }}
+        {{- include "hono.podAnnotations" $args | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/hono/templates/hono-service-device-registry-embedded/hono-service-device-registry-statefulset.yaml
+++ b/charts/hono/templates/hono-service-device-registry-embedded/hono-service-device-registry-statefulset.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.deviceRegistryExample.enabled ( eq .Values.deviceRegistryExample.type "embedded" ) }}
 #
-# Copyright (c) 2021 Contributors to the Eclipse Foundation
+# Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -26,7 +26,7 @@ spec:
     metadata:
       {{- include "hono.metadata" $args | nindent 6 }}
       annotations:
-        {{- include "hono.monitoringAnnotations" . | nindent 8 }}
+        {{- include "hono.podAnnotations" $args | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/hono/templates/hono-service-device-registry-jdbc/hono-service-device-registry-deployment.yaml
+++ b/charts/hono/templates/hono-service-device-registry-jdbc/hono-service-device-registry-deployment.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.deviceRegistryExample.enabled ( eq .Values.deviceRegistryExample.type "jdbc" ) }}
 #
-# Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+# Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -25,7 +25,7 @@ spec:
     metadata:
       {{- include "hono.metadata" $args | nindent 6 }}
       annotations:
-        {{- include "hono.monitoringAnnotations" . | nindent 8 }}
+        {{- include "hono.podAnnotations" $args | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/hono/templates/hono-service-device-registry-mongodb/hono-service-device-registry-deployment.yaml
+++ b/charts/hono/templates/hono-service-device-registry-mongodb/hono-service-device-registry-deployment.yaml
@@ -25,7 +25,7 @@ spec:
     metadata:
       {{- include "hono.metadata" $args | nindent 6 }}
       annotations:
-        {{- include "hono.monitoringAnnotations" . | nindent 8 }}
+        {{- include "hono.podAnnotations" $args | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -1201,9 +1201,8 @@ deviceRegistryExample:
 # The configuration properties below are intended to set up a MongoDB instance that is sufficient
 # for demonstration and/or testing purposes. In order to use a production level MongoDB instance, users
 # should not adapt these properties, but instead set the "createInstance" property to false, set up a
-# separate MongoDB instance according to
-# https://github.com/bitnami/charts/tree/master/bitnami/mongodb#production-configuration-and-horizontal-scaling
-# and configure the registry's connection details under "deviceRegistryExample.mongoDBBasedDeviceRegistry.mongodb".
+# separate MongoDB instance and configure the registry's connection details under
+# "deviceRegistryExample.mongoDBBasedDeviceRegistry.mongodb".
 mongodb:
   # createInstance indicates whether a MongoDB database instance should be created.
   createInstance: false
@@ -1230,7 +1229,7 @@ mongodb:
   # Use StatefulSet instead of Deployment when deploying standalone
   useStatefulSet: false
   # Setting up replication
-  # ref: https://github.com/bitnami/bitnami-docker-mongodb#setting-up-a-replication
+  # ref: https://github.com/bitnami/bitnami-docker-mongodb#setting-up-replication
   # Whether to create a MongoDB replica set for high availability or not
   replicaSet:
     enabled: false


### PR DESCRIPTION
This sets the default container to be used by "kubectl logs" or "kubectl exec". The `kubectl.kubernetes.io/default-container` annotation has been introduced with Kubernetes 1.21.
Also fixes outdated links in values.yaml documentation.