### PR TITLE
Add support for passing command line arguments to container CMDs

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 2.0.1
+version: 2.0.2
 # Version of Hono being deployed by the chart
 appVersion: 2.0.0
 keywords:

--- a/charts/hono/README.md
+++ b/charts/hono/README.md
@@ -485,6 +485,30 @@ The Helm chart can be configured to use these *native* images by means of explic
 name as described in *Using specific Container Images*. The names of the images based on native executables are the
 standard image names appended by `-native`.
 
+The native executables used in the images currently do not properly detect the memory and CPU resource limits defined on the
+container. This is due to a bug in the native-image builder in GraalVM versions before 22.1. Future versions of Hono will
+probably not be affected by this anymore.
+
+In order to make the native executables aware of the memory limits, the
+[`-Xmx` GraalVM parameter](https://www.graalvm.org/22.0/reference-manual/native-image/MemoryManagement/#java-heap-size) can
+be passed to the native executable as a command line parameter. This can be done by setting the `cmdLineArgs` property of the
+component in the `values.yaml`. For example, the Authentication server can be configured to use the native executable based image
+with 80% of the container's memory limit being available to the process like this:
+
+```yaml
+authServer:
+  imageName: "eclipse/hono-service-auth-native"
+  cmdLineArgs:
+  - "-Xmx24m"
+  resources:
+    requests:
+      cpu:
+      memory: "30Mi"
+    limits:
+      cpu:
+      memory: "30Mi"
+```
+
 ## Configuring Storage for Command Routing Data
 
 Hono needs to store information about the connection status of devices during runtime.

--- a/charts/hono/ci/quarkus-native-images-values.yaml
+++ b/charts/hono/ci/quarkus-native-images-values.yaml
@@ -39,23 +39,27 @@ kafka:
 
 authServer:
   imageName: "eclipse/hono-service-auth-native"
+  cmdLineArgs:
+  - "-Xmx24m"
   resources:
     requests:
       cpu:
-      memory: "32Mi"
+      memory: "30Mi"
     limits:
       cpu:
-      memory: "32Mi"
+      memory: "30Mi"
 
 commandRouterService:
   imageName: "eclipse/hono-service-command-router-native"
+  cmdLineArgs:
+  - "-Xmx96m"
   resources:
     requests:
       cpu:
-      memory: "128Mi"
+      memory: "120Mi"
     limits:
       cpu:
-      memory: "128Mi"
+      memory: "120Mi"
 
 adapters:
   amqp:
@@ -63,6 +67,8 @@ adapters:
   coap:
     enabled: true
     imageName: "eclipse/hono-adapter-coap-native"
+    cmdLineArgs:
+    - "-Xmx96m"
     hono:
       coap:
         bindAddress: "0.0.0.0"

--- a/charts/hono/templates/hono-adapter-amqp/hono-adapter-amqp-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-amqp/hono-adapter-amqp-deployment.yaml
@@ -34,6 +34,12 @@ spec:
       containers:
       {{- include "hono.otel.agent" . | indent 6 }}
       {{- include "hono.container" $args | indent 6 }}
+        {{- with $args.componentConfig.cmdLineArgs }}
+        args:
+        {{- range . }}
+        - {{ . | quote }}
+        {{- end }}
+        {{- end }}
         ports:
         - name: health
           containerPort: {{ include "hono.healthCheckPort" . }}

--- a/charts/hono/templates/hono-adapter-coap/hono-adapter-coap-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-coap/hono-adapter-coap-deployment.yaml
@@ -34,6 +34,12 @@ spec:
       containers:
       {{- include "hono.otel.agent" . | indent 6 }}
       {{- include "hono.container" $args | indent 6 }}
+        {{- with $args.componentConfig.cmdLineArgs }}
+        args:
+        {{- range . }}
+        - {{ . | quote }}
+        {{- end }}
+        {{- end }}
         ports:
         - name: health
           containerPort: {{ include "hono.healthCheckPort" . }}

--- a/charts/hono/templates/hono-adapter-http/hono-adapter-http-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-http/hono-adapter-http-deployment.yaml
@@ -34,6 +34,12 @@ spec:
       containers:
       {{- include "hono.otel.agent" . | indent 6 }}
       {{- include "hono.container" $args | indent 6 }}
+        {{- with $args.componentConfig.cmdLineArgs }}
+        args:
+        {{- range . }}
+        - {{ . | quote }}
+        {{- end }}
+        {{- end }}
         ports:
         - name: health
           containerPort: {{ include "hono.healthCheckPort" . }}

--- a/charts/hono/templates/hono-adapter-lora/hono-adapter-lora-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-lora/hono-adapter-lora-deployment.yaml
@@ -34,6 +34,12 @@ spec:
       containers:
       {{- include "hono.otel.agent" . | indent 6 }}
       {{- include "hono.container" $args | indent 6 }}
+        {{- with $args.componentConfig.cmdLineArgs }}
+        args:
+        {{- range . }}
+        - {{ . | quote }}
+        {{- end }}
+        {{- end }}
         ports:
         - name: health
           containerPort: {{ include "hono.healthCheckPort" . }}

--- a/charts/hono/templates/hono-adapter-mqtt/hono-adapter-mqtt-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-mqtt/hono-adapter-mqtt-deployment.yaml
@@ -34,6 +34,12 @@ spec:
       containers:
       {{- include "hono.otel.agent" . | indent 6 }}
       {{- include "hono.container" $args | indent 6 }}
+        {{- with $args.componentConfig.cmdLineArgs }}
+        args:
+        {{- range . }}
+        - {{ . | quote }}
+        {{- end }}
+        {{- end }}
         ports:
         - name: health
           containerPort: {{ include "hono.healthCheckPort" . }}

--- a/charts/hono/templates/hono-service-auth/hono-service-auth-deployment.yaml
+++ b/charts/hono/templates/hono-service-auth/hono-service-auth-deployment.yaml
@@ -32,6 +32,12 @@ spec:
       {{- end }}
       containers:
       {{- include "hono.container" $args | indent 6 }}
+        {{- with $args.componentConfig.cmdLineArgs }}
+        args:
+        {{- range . }}
+        - {{ . | quote }}
+        {{- end }}
+        {{- end }}
         ports:
         - name: health
           containerPort: {{ include "hono.healthCheckPort" . }}

--- a/charts/hono/templates/hono-service-command-router/hono-service-command-router-deployment.yaml
+++ b/charts/hono/templates/hono-service-command-router/hono-service-command-router-deployment.yaml
@@ -33,6 +33,12 @@ spec:
       containers:
       {{- include "hono.otel.agent" . | indent 6 }}
       {{- include "hono.container" $args | indent 6 }}
+        {{- with $args.componentConfig.cmdLineArgs }}
+        args:
+        {{- range . }}
+        - {{ . | quote }}
+        {{- end }}
+        {{- end }}
         ports:
         - name: health
           containerPort: {{ include "hono.healthCheckPort" . }}

--- a/charts/hono/templates/hono-service-device-registry-embedded/hono-service-device-registry-statefulset.yaml
+++ b/charts/hono/templates/hono-service-device-registry-embedded/hono-service-device-registry-statefulset.yaml
@@ -35,6 +35,12 @@ spec:
       containers:
       {{- include "hono.otel.agent" . | indent 6 }}
       {{- include "hono.container" $args | indent 6 }}
+        {{- with $args.componentConfig.cmdLineArgs }}
+        args:
+        {{- range . }}
+        - {{ . | quote }}
+        {{- end }}
+        {{- end }}
         ports:
           - name: health
             containerPort: {{ include "hono.healthCheckPort" . }}

--- a/charts/hono/templates/hono-service-device-registry-jdbc/hono-service-device-registry-deployment.yaml
+++ b/charts/hono/templates/hono-service-device-registry-jdbc/hono-service-device-registry-deployment.yaml
@@ -34,6 +34,12 @@ spec:
       containers:
       {{- include "hono.otel.agent" . | indent 6 }}
       {{- include "hono.container" $args | indent 6 }}
+        {{- with $args.componentConfig.cmdLineArgs }}
+        args:
+        {{- range . }}
+        - {{ . | quote }}
+        {{- end }}
+        {{- end }}
         ports:
           - name: health
             containerPort: {{ include "hono.healthCheckPort" . }}

--- a/charts/hono/templates/hono-service-device-registry-mongodb/hono-service-device-registry-deployment.yaml
+++ b/charts/hono/templates/hono-service-device-registry-mongodb/hono-service-device-registry-deployment.yaml
@@ -34,6 +34,12 @@ spec:
       containers:
       {{- include "hono.otel.agent" . | indent 6 }}
       {{- include "hono.container" $args | indent 6 }}
+        {{- with $args.componentConfig.cmdLineArgs }}
+        args:
+        {{- range . }}
+        - {{ . | quote }}
+        {{- end }}
+        {{- end }}
         ports:
           - name: health
             containerPort: {{ include "hono.healthCheckPort" . }}

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -219,6 +219,8 @@ adapters:
     # javaOptions contains options to pass to the JVM when starting
     # up the service
     javaOptions: "-XX:MinRAMPercentage=80 -XX:MaxRAMPercentage=80"
+    # cmdLineArgs contains additional arguments to be passed to the container's CMD.
+    cmdLineArgs: []
     # quarkusConfigLocations contains resources that the Quarkus based variant of the component should read
     # additional configuration from.
     # Properties are read in the following sequence with properties further down in the list overwriting property
@@ -333,6 +335,8 @@ adapters:
     # javaOptions contains options to pass to the JVM when starting
     # up the service
     javaOptions: "-XX:MinRAMPercentage=80 -XX:MaxRAMPercentage=80"
+    # cmdLineArgs contains additional arguments to be passed to the container's CMD.
+    cmdLineArgs: []
     # quarkusConfigLocations contains resources that the Quarkus based variant of the component should read
     # additional configuration from.
     # Properties are read in the following sequence with properties further down in the list overwriting property
@@ -438,6 +442,8 @@ adapters:
     # javaOptions contains options to pass to the JVM when starting
     # up the service
     javaOptions: "-XX:MinRAMPercentage=80 -XX:MaxRAMPercentage=80"
+    # cmdLineArgs contains additional arguments to be passed to the container's CMD.
+    cmdLineArgs: []
     # quarkusConfigLocations contains resources that the Quarkus based variant of the component should read
     # additional configuration from.
     # Properties are read in the following sequence with properties further down in the list overwriting property
@@ -552,6 +558,8 @@ adapters:
     # javaOptions contains options to pass to the JVM when starting
     # up the service
     javaOptions: "-XX:MinRAMPercentage=80 -XX:MaxRAMPercentage=80"
+    # cmdLineArgs contains additional arguments to be passed to the container's CMD.
+    cmdLineArgs: []
     # quarkusConfigLocations contains resources that the Quarkus based variant of the component should read
     # additional configuration from.
     # Properties are read in the following sequence with properties further down in the list overwriting property
@@ -665,6 +673,8 @@ adapters:
     # javaOptions contains options to pass to the JVM when starting
     # up the service
     javaOptions: "-XX:MinRAMPercentage=80 -XX:MaxRAMPercentage=80"
+    # cmdLineArgs contains additional arguments to be passed to the container's CMD.
+    cmdLineArgs: []
     # quarkusConfigLocations contains resources that the Quarkus based variant of the component should read
     # additional configuration from.
     # Properties are read in the following sequence with properties further down in the list overwriting property
@@ -779,6 +789,8 @@ authServer:
   # javaOptions contains options to pass to the JVM when starting
   # up the service
   javaOptions: "-XX:MinRAMPercentage=80 -XX:MaxRAMPercentage=80"
+  # cmdLineArgs contains additional arguments to be passed to the container's CMD.
+  cmdLineArgs: []
   # quarkusConfigLocations contains resources that the component should read
   # additional configuration from.
   # Properties are read in the following sequence with properties further down in the list overwriting property
@@ -1028,6 +1040,24 @@ deviceRegistryExample:
     # should be used for the example registry's persistent volume claim.
     # If not set, the cluster's default storage class is used.
     storageClass:
+    # cmdLineArgs contains additional arguments to be passed to the container's CMD.
+    cmdLineArgs: []
+    # quarkusConfigLocations contains resources that the Quarkus based variant of the component should read
+    # additional configuration from.
+    # Properties are read in the following sequence with properties further down in the list overwriting property
+    # values read from resources further up in the list.
+    # 1. Properties defined in file "/opt/hono/application.yml".
+    # 2. Properties read from the resources defined here.
+    # 3. Properties defined in operating system environment variables.
+    # 4. Properties defined in Java system properties.
+    # See https://smallrye.io/docs/smallrye-config/config/config.html#locations for details regarding supported resource
+    # types.
+    # If not set, default resources configuring logging levels based on the value of "quarkusLoggingProfile" are
+    # being read.
+    quarkusConfigLocations:
+    # quarkusLoggingProfile indicates at which level the Quarkus based variant of the component should log.
+    # Supported values are "prod", "dev" or "trace"
+    quarkusLoggingProfile: "dev"
     # livenessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
     # configuration property of the component's liveness probe.
     # The value of the top level "livenessProbeInitialDelaySeconds" property will be used if not set.
@@ -1065,6 +1095,8 @@ deviceRegistryExample:
     # the image from.
     # If not specified, the value of the "honoContainerRegistry" property is used.
     # containerRegistry:
+    # cmdLineArgs contains additional arguments to be passed to the container's CMD.
+    cmdLineArgs: []
     # quarkusConfigLocations contains resources that the Quarkus based variant of the component should read
     # additional configuration from.
     # Properties are read in the following sequence with properties further down in the list overwriting property
@@ -1130,6 +1162,24 @@ deviceRegistryExample:
     # the image from.
     # If not specified, the value of the "honoContainerRegistry" property is used.
     # containerRegistry:
+    # cmdLineArgs contains additional arguments to be passed to the container's CMD.
+    cmdLineArgs: []
+    # quarkusConfigLocations contains resources that the Quarkus based variant of the component should read
+    # additional configuration from.
+    # Properties are read in the following sequence with properties further down in the list overwriting property
+    # values read from resources further up in the list.
+    # 1. Properties defined in file "/opt/hono/application.yml".
+    # 2. Properties read from the resources defined here.
+    # 3. Properties defined in operating system environment variables.
+    # 4. Properties defined in Java system properties.
+    # See https://smallrye.io/docs/smallrye-config/config/config.html#locations for details regarding supported resource
+    # types.
+    # If not set, default resources configuring logging levels based on the value of "quarkusLoggingProfile" are
+    # being read.
+    quarkusConfigLocations:
+    # quarkusLoggingProfile indicates at which level the Quarkus based variant of the component should log.
+    # Supported values are "prod", "dev" or "trace"
+    quarkusLoggingProfile: "dev"
     # livenessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
     # configuration property of the component's liveness probe.
     # The value of the top level "livenessProbeInitialDelaySeconds" property will be used if not set.
@@ -1254,6 +1304,8 @@ commandRouterService:
   # javaOptions contains options to pass to the JVM when starting
   # up the service
   javaOptions: "-XX:MinRAMPercentage=80 -XX:MaxRAMPercentage=80 -Djava.security.properties=/opt/hono/config/dns-cache-config.properties"
+  # cmdLineArgs contains additional arguments to be passed to the container's CMD.
+  cmdLineArgs: []
   # quarkusConfigLocations contains resources that the Quarkus based variant of the component should read
   # additional configuration from.
   # Properties are read in the following sequence with properties further down in the list overwriting property


### PR DESCRIPTION
The Hono chart already supports setting JAVA_OPTIONS to be passed to the
Hono containers. These options can be used to e.g. specify the amount of
memory to use. However, the native executable variants of the Hono
containers ignore the JAVA_OPTIONS but instead require passing options
as command line arguments to set memory limits etc.

The values.yaml now contains a cmdLineArgs property for each component
which can be used to specify an array of Strings to be passed as command
line arguments to the container's CMD.