### PR TITLE
[#383] Use "artemiscloud/activemq-artemis-broker" image

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 2.0.2
+version: 2.0.3
 # Version of Hono being deployed by the chart
 appVersion: 2.0.0
 keywords:

--- a/charts/hono/config/artemis/broker.xml
+++ b/charts/hono/config/artemis/broker.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 
 <!--
-    Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
+    Copyright (c) 2016, 2022 Contributors to the Eclipse Foundation
    
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -15,6 +15,7 @@
 
 <configuration xmlns="urn:activemq"
                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xmlns:xi="http://www.w3.org/2001/XInclude"
                xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
 
    <core xmlns="urn:activemq:core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -22,19 +23,36 @@
 
       <name>hono-broker</name>
 
+
       <persistence-enabled>true</persistence-enabled>
 
-      <!-- this could be ASYNCIO or NIO
+      <!-- this could be ASYNCIO, MAPPED, NIO
+           ASYNCIO: Linux Libaio
+           MAPPED: mmap files
+           NIO: Plain Java Files
        -->
       <journal-type>ASYNCIO</journal-type>
 
-      <paging-directory>./data/paging</paging-directory>
+      <paging-directory>data/paging</paging-directory>
 
-      <bindings-directory>./data/bindings</bindings-directory>
+      <bindings-directory>data/bindings</bindings-directory>
 
-      <journal-directory>./data/journal</journal-directory>
+      <journal-directory>data/journal</journal-directory>
 
-      <large-messages-directory>./data/large-messages</large-messages-directory>
+      <large-messages-directory>data/large-messages</large-messages-directory>
+
+      
+      <!-- if you want to retain your journal uncomment this following configuration.
+
+      This will allow your system to keep 7 days of your data, up to 10G. Tweak it accordingly to your use case and capacity.
+
+      it is recommended to use a separate storage unit from the journal for performance considerations.
+
+      <journal-retention-directory period="7" unit="DAYS" storage-limit="10G">data/retention</journal-retention-directory>
+
+      You can also enable retention by using the argument journal-retention on the `artemis create` command -->
+
+
 
       <journal-datasync>true</journal-datasync>
 
@@ -42,9 +60,29 @@
 
       <journal-pool-files>10</journal-pool-files>
 
+      <journal-device-block-size>4096</journal-device-block-size>
+
+      <journal-file-size>10M</journal-file-size>
+      
       <!--
-        You can specify the NIC you want to use to verify if the network
-         <network-check-NIC>theNickName</network-check-NIC>
+       This value was determined through a calculation.
+       Your system could perform 7.58 writes per millisecond
+       on the current journal configuration.
+       That translates as a sync write every 132000 nanoseconds.
+
+       Note: If you specify 0 the system will perform writes directly to the disk.
+             We recommend this to be 0 if you are using journalType=MAPPED and journal-datasync=false.
+      -->
+      <journal-buffer-timeout>132000</journal-buffer-timeout>
+
+
+      <!--
+        When using ASYNCIO, this will determine the writing queue depth for libaio.
+       -->
+      <journal-max-io>4096</journal-max-io>
+      <!--
+        You can verify the network health of a particular NIC by specifying the <network-check-NIC> element.
+         <network-check-NIC>theNicName</network-check-NIC>
         -->
 
       <!--
@@ -70,14 +108,6 @@
 
 
 
-      <!--
-       This value was determined through a calculation.
-       Your system could perform 7.58 writes per millisecond
-       on the current journal configuration.
-       That translates as a sync write every 132000 nanoseconds
-      -->
-      <journal-buffer-timeout>132000</journal-buffer-timeout>
-
 
       <!-- how often we are looking for how many bytes are being used on the disk in ms -->
       <disk-scan-period>5000</disk-scan-period>
@@ -86,17 +116,49 @@
            that won't support flow control. -->
       <max-disk-usage>90</max-disk-usage>
 
-      <!-- the system will enter into page mode once you hit this limit.
-           This is an estimate in bytes of how much the messages are using in memory -->
-      <global-max-size>100Mb</global-max-size>
+      <!-- should the broker detect dead locks and other issues -->
+      <critical-analyzer>true</critical-analyzer>
+
+      <critical-analyzer-timeout>120000</critical-analyzer-timeout>
+
+      <critical-analyzer-check-period>60000</critical-analyzer-check-period>
+
+      <critical-analyzer-policy>HALT</critical-analyzer-policy>
+
+      
+      <page-sync-timeout>136000</page-sync-timeout>
+
+
+      <!-- the system will enter into page mode once you hit this limit. This is an estimate in bytes of how much the messages are using in memory
+
+      The system will use half of the available memory (-Xmx) by default for the global-max-size.
+      You may specify a different value here if you need to customize it to your needs.
+
+      <global-max-size>100Mb</global-max-size> -->
+
+      <!-- the maximum number of messages accepted before entering full address mode.
+           if global-max-size is specified the full address mode will be specified by whatever hits it first. -->
+      <global-max-messages>-1</global-max-messages>
 
       <acceptors>
 
+         <!-- useEpoll means: it will use Netty epoll if you are on a system (Linux) that supports it -->
+         <!-- amqpCredits: The number of credits sent to AMQP producers -->
+         <!-- amqpLowCredits: The server will send the # credits specified at amqpCredits at this low mark -->
+         <!-- amqpDuplicateDetection: If you are not using duplicate detection, set this to false
+                                      as duplicate detection requires applicationProperties to be parsed on the server. -->
+         <!-- amqpMinLargeMessageSize: Determines how many bytes are considered large, so we start using files to hold their data.
+                                       default: 102400, -1 would mean to disable large mesasge control -->
+
+         <!-- Note: If an acceptor needs to be compatible with HornetQ and/or Artemis 1.x clients add
+                    "anycastPrefix=jms.queue.;multicastPrefix=jms.topic." to the acceptor url.
+                    See https://issues.apache.org/jira/browse/ARTEMIS-1644 for more information. -->
+
          <!-- AMQP Acceptor.  Listens on default AMQP port for AMQP traffic.-->
-         <!--<acceptor name="amqp">tcp://0.0.0.0:5672?protocols=AMQP</acceptor>-->
+         <!--<acceptor name="amqp">tcp://0.0.0.0:5672?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=AMQP;useEpoll=true;amqpCredits=1000;amqpLowCredits=300;amqpMinLargeMessageSize=102400;amqpDuplicateDetection=true</acceptor>-->
          <acceptor name="amqps">
              tcp://0.0.0.0:5671?protocols=AMQP;sslEnabled=true;
-             keyStorePath=file:/run/artemis/split-1/custom/etc/artemisKeyStore.p12;keyStorePassword=artemiskeys;
+             keyStorePath=file:/home/jboss/broker/etc/artemisKeyStore.p12;keyStorePassword=artemiskeys;
          </acceptor>
 
       </acceptors>
@@ -130,22 +192,26 @@
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
             <dead-letter-address>DLQ</dead-letter-address>
             <expiry-address>ExpiryQueue</expiry-address>
             <redelivery-delay>0</redelivery-delay>
-            <!-- with -1 only the global-max-size is in use for limiting -->
+
+
+            <!-- if max-size-bytes and max-size-messages were both enabled, the system will enter into paging
+                 based on the first attribute to hits the maximum value -->
+            <!-- limit for the address in bytes, -1 means unlimited -->
             <max-size-bytes>-1</max-size-bytes>
+            <!-- limit for the address in messages, -1 means unlimited -->
+            <max-size-messages>-1</max-size-messages>
             <message-counter-history-day-limit>10</message-counter-history-day-limit>
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
+            <auto-delete-queues>false</auto-delete-queues>
+            <auto-delete-addresses>false</auto-delete-addresses>
             <default-address-routing-type>ANYCAST</default-address-routing-type>
          </address-setting>
       </address-settings>
@@ -153,6 +219,21 @@
        <wildcard-addresses>
            <delimiter>/</delimiter>
        </wildcard-addresses>
+
+
+      <!-- Uncomment the following if you want to use the Standard LoggingActiveMQServerPlugin pluging to log in events
+      <broker-plugins>
+         <broker-plugin class-name="org.apache.activemq.artemis.core.server.plugin.impl.LoggingActiveMQServerPlugin">
+            <property key="LOG_ALL_EVENTS" value="true"/>
+            <property key="LOG_CONNECTION_EVENTS" value="true"/>
+            <property key="LOG_SESSION_EVENTS" value="true"/>
+            <property key="LOG_CONSUMER_EVENTS" value="true"/>
+            <property key="LOG_DELIVERING_EVENTS" value="true"/>
+            <property key="LOG_SENDING_EVENTS" value="true"/>
+            <property key="LOG_INTERNAL_EVENTS" value="true"/>
+         </broker-plugin>
+      </broker-plugins>
+      -->
 
    </core>
 </configuration>

--- a/charts/hono/config/artemis/launch.sh
+++ b/charts/hono/config/artemis/launch.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Artemis launch script. Adapts and invokes the default Artemis image launch script.
+#
+# Copyright (c) 2022 Contributors to the Eclipse Foundation
+##
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+# Adapt launch.sh script (https://github.com/artemiscloud/activemq-artemis-broker-image/blob/1fa767251b3c345d6faf3c4b5a0c509ed294ad97/modules/activemq-artemis-install/added/launch.sh),
+# replacing
+#   configure
+# with
+#   configure
+#   cp $AMQ_HOME/conf/* ~/broker/etc/
+# .
+# This allows usage of a custom broker.xml and other config files, provided in the "$AMQ_HOME/conf/" directory.
+sed -i -E 's/^([[:space:]]*)configure[[:space:]]*$/\0\n\1cp $AMQ_HOME\/conf\/\* ~\/broker\/etc\//g' $AMQ_HOME/bin/launch.sh
+$AMQ_HOME/bin/launch.sh

--- a/charts/hono/config/artemis/liveness-probe.sh
+++ b/charts/hono/config/artemis/liveness-probe.sh
@@ -16,5 +16,5 @@
 brokerName=${1:-hono-broker}
 url="http://localhost:8161/console/jolokia/read/org.apache.activemq.artemis:broker=%22${brokerName}%22/Version"
 
-curl -s --user artemis:artemis -H "Origin: http://localhost" ${url}
+curl -s --user artemis:artemis -H "Origin: http://0.0.0.0" ${url}
 

--- a/charts/hono/config/artemis/readiness-probe.sh
+++ b/charts/hono/config/artemis/readiness-probe.sh
@@ -17,5 +17,5 @@ brokerName=${1:-hono-broker}
 acceptorName=${2:-amqps}
 url="http://localhost:8161/console/jolokia/read/org.apache.activemq.artemis:broker=%22${brokerName}%22,component=acceptors,name=%22${acceptorName}%22/Started"
 
-curl -s --user artemis:artemis -H "Origin: http://localhost" ${url} | grep "\"value\":true"
+curl -s --user artemis:artemis -H "Origin: http://0.0.0.0" ${url} | grep "\"value\":true"
 

--- a/charts/hono/templates/artemis/artemis-deployment.yaml
+++ b/charts/hono/templates/artemis/artemis-deployment.yaml
@@ -15,7 +15,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  {{- $args := dict "dot" . "component" "amqp-messaging-network-broker" "name" "artemis" "componentConfig" .Values.amqpMessagingNetworkExample.broker.artemis "configMountPath" "/opt/apache-artemis/conf" }}
+  {{- $args := dict "dot" . "component" "amqp-messaging-network-broker" "name" "artemis" "componentConfig" .Values.amqpMessagingNetworkExample.broker.artemis "configMountPath" "/opt/amq/conf" }}
   {{- include "hono.metadata" $args | nindent 2 }}
 spec:
   replicas: 1
@@ -34,13 +34,19 @@ spec:
       - name: apache-activemq-artemis
         image: {{ .Values.amqpMessagingNetworkExample.broker.artemis.imageName | quote }}
         command:
-        - /opt/apache-artemis/bin/launch.sh
-        - start
+        - "/bin/bash"
+        - "/opt/amq/conf/launch.sh"
         env:
         - name: AMQ_NAME
-          value: custom
+          value: hono-broker
+        - name: AMQ_USER
+          value: admin
+        - name: AMQ_PASSWORD
+          value: admin
         - name: HOME
-          value: /run/artemis/split-1/
+          value: /home/jboss
+        - name: AMQ_EXTRA_ARGS
+          value: "--http-host 0.0.0.0"
         - name: JAVA_INITIAL_MEM_RATIO
           value: "30"
         - name: JAVA_MAX_MEM_RATIO

--- a/charts/hono/templates/artemis/artemis-secret.yaml
+++ b/charts/hono/templates/artemis/artemis-secret.yaml
@@ -30,9 +30,11 @@ stringData:
   "logging.properties": |
     {{- .Files.Get "config/artemis/logging.properties" | nindent 4 }}
   "liveness-probe.sh": |
-    {{- .Files.Get "config/artemis/lifeness-probe.sh" | nindent 4 }}
+    {{- .Files.Get "config/artemis/liveness-probe.sh" | nindent 4 }}
   "readiness-probe.sh": |
     {{- .Files.Get "config/artemis/readiness-probe.sh" | nindent 4 }}
+  "launch.sh": |
+    {{- .Files.Get "config/artemis/launch.sh" | nindent 4 }}
 data:
   "artemisKeyStore.p12": {{ .Files.Get "example/certs/artemisKeyStore.p12" | b64enc }}
 {{- end }}

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -1739,7 +1739,7 @@ amqpMessagingNetworkExample:
     artemis:
       # imageName contains the name (including tag) of the container
       # image to use for the example AMQP Messaging Network Broker
-      imageName: "quay.io/enmasse/artemis-base:2.16.0"
+      imageName: "quay.io/artemiscloud/activemq-artemis-broker:1.0.6"
       # livenessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
       # configuration property of the component's liveness probe.
       livenessProbeInitialDelaySeconds: 300


### PR DESCRIPTION
This fixes #383:
No newer version of "enmasse/artemis-base" available, therefore switching to another Artemis image.
This updates Artemis from 2.16.0 to 2.23.0 and updates the used OpenJDK version from 11.0.3 to 17.0.3.
The JDK update fixes the keystore loading issue.

The basic Artemis broker image from https://github.com/artemiscloud/activemq-artemis-broker-image is used here.

Using the extended image version for Kubernetes (https://github.com/artemiscloud/activemq-artemis-broker-kubernetes-image) may also be an option. It has a lot more configuration options and we could use it to move some of the `broker.xml` adaptations into separate environment variables (e.g. the SSL config). At first glance, I don't see though, how the `<wildcard-addresses/>` and `default-address-routing-type` adaptions can be externalized. And using a completely custom `broker.xml` doesn't seem straightforward there. So, that would need more effort.
Another alternative could be to use the [activemq-artemis-operator](https://github.com/artemiscloud/activemq-artemis-operator). Again, this needs effort into how this can be done exactly.

The changes to the `broker.xml` here makes the file more in line with the default config.