### PR TITLE
feat: make hono probes configurable

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 2.0.3
+version: 2.0.4
 # Version of Hono being deployed by the chart
 appVersion: 2.0.0
 keywords:

--- a/charts/hono/README.md
+++ b/charts/hono/README.md
@@ -103,6 +103,12 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Release Notes
 
+### 2.0.4
+
+* *livenessProbeInitialDelaySeconds* and *readinessProbeInitialDelaySeconds* have been deprecated due to the introduction of the
+  *probes* parameter which allows you to configure the HTTP GET probes more specifically instead of just the initialDelaySeconds. The
+  *probes* parameter is configurable globally but can be overwritten per component.
+
 ### 2.0.0
 
 * The chart now uses Helm API version 2 and thus requires at least Helm version 3 to install.

--- a/charts/hono/templates/_helpers.tpl
+++ b/charts/hono/templates/_helpers.tpl
@@ -479,18 +479,31 @@ The scope passed in is expected to be a dict with keys
 - (mandatory) "componentConfig": the component's configuration properties from the values.yaml file
 */}}
 {{- define "hono.component.healthChecks" }}
+{{- $global := .dot.Values -}}
+{{- $component := .componentConfig -}}
+{{- $probes := mergeOverwrite ( $global.probes | deepCopy ) ( $component.probes | default dict | deepCopy ) -}}
+{{- $deprecatedLivenessProbeInitialDelaySeconds := default .dot.Values.livenessProbeInitialDelaySeconds .componentConfig.livenessProbeInitialDelaySeconds -}}
+{{- $deprecatedReadinessProbeInitialDelaySeconds := default .dot.Values.readinessProbeInitialDelaySeconds .componentConfig.readinessProbeInitialDelaySeconds -}} 
 livenessProbe:
   httpGet:
-    path: "/liveness"
-    port: "health"
-    scheme: "HTTP"
-  initialDelaySeconds: {{ default .dot.Values.livenessProbeInitialDelaySeconds .componentConfig.livenessProbeInitialDelaySeconds }}
+    path: {{ $probes.livenessProbe.httpGet.path }}
+    port: {{ $probes.livenessProbe.httpGet.port }}
+    scheme: {{ $probes.livenessProbe.httpGet.scheme }}
+  periodSeconds: {{ $probes.livenessProbe.periodSeconds }}
+  failureThreshold: {{ $probes.livenessProbe.failureThreshold }}
+  initialDelaySeconds: {{ default $probes.livenessProbe.initialDelaySeconds $deprecatedLivenessProbeInitialDelaySeconds }}
+  successThreshold: {{ $probes.livenessProbe.successThreshold }}
+  timeoutSeconds: {{ $probes.livenessProbe.timeoutSeconds }}
 readinessProbe:
   httpGet:
-    path: "/readiness"
-    port: "health"
-    scheme: "HTTP"
-  initialDelaySeconds: {{ default .dot.Values.readinessProbeInitialDelaySeconds .componentConfig.readinessProbeInitialDelaySeconds }}
+    path: {{ $probes.readinessProbe.httpGet.path }}
+    port: {{ $probes.readinessProbe.httpGet.port }}
+    scheme: {{ $probes.readinessProbe.httpGet.scheme }}
+  periodSeconds: {{ $probes.readinessProbe.periodSeconds }}
+  failureThreshold: {{ $probes.readinessProbe.failureThreshold }}
+  initialDelaySeconds: {{ default $probes.readinessProbe.initialDelaySeconds $deprecatedReadinessProbeInitialDelaySeconds }}
+  successThreshold: {{ $probes.readinessProbe.successThreshold }}
+  timeoutSeconds: {{ $probes.readinessProbe.timeoutSeconds }}
 {{- end }}
 
 {{/*

--- a/charts/hono/templates/artemis/artemis-deployment.yaml
+++ b/charts/hono/templates/artemis/artemis-deployment.yaml
@@ -65,21 +65,21 @@ spec:
           {{- . | toYaml | nindent 10 }}
         {{- end }}
         livenessProbe:
-          initialDelaySeconds: {{ $args.componentConfig.livenessProbeInitialDelaySeconds }}
-          periodSeconds: 17
+          initialDelaySeconds: {{ $args.componentConfig.probes.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ $args.componentConfig.probes.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ $args.componentConfig.probes.livenessProbe.timeoutSeconds }}
           exec:
             command:
             - "/bin/bash"
             - {{ printf "%s/liveness-probe.sh" $args.configMountPath | quote }}
-          timeoutSeconds: 3
         readinessProbe:
-          initialDelaySeconds: {{ $args.componentConfig.readinessProbeInitialDelaySeconds }}
-          periodSeconds: 10
+          initialDelaySeconds: {{ $args.componentConfig.probes.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ $args.componentConfig.probes.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ $args.componentConfig.probes.readinessProbe.timeoutSeconds }}
           exec:
             command:
             - "/bin/bash"
             - {{ printf "%s/readiness-probe.sh" $args.configMountPath | quote }}
-          timeoutSeconds: 3
         securityContext:
           privileged: false
         volumeMounts:

--- a/charts/hono/templates/dispatch-router/dispatch-router-deployment.yaml
+++ b/charts/hono/templates/dispatch-router/dispatch-router-deployment.yaml
@@ -60,18 +60,7 @@ spec:
         resources:
           {{- . | toYaml | nindent 10 }}
         {{- end }}
-        livenessProbe:
-          initialDelaySeconds: {{ .Values.amqpMessagingNetworkExample.dispatchRouter.livenessProbeInitialDelaySeconds }}
-          periodSeconds: 9
-          httpGet:
-            path: /healthz
-            port: health
-        readinessProbe:
-          initialDelaySeconds: {{ .Values.amqpMessagingNetworkExample.dispatchRouter.readinessProbeInitialDelaySeconds }}
-          periodSeconds: 5
-          httpGet:
-            path: /healthz
-            port: health
+        {{- include "hono.component.healthChecks" $args | nindent 8 }}
         securityContext:
           privileged: false
         volumeMounts:

--- a/charts/hono/templates/example-data-grid/statefulset.yaml
+++ b/charts/hono/templates/example-data-grid/statefulset.yaml
@@ -14,7 +14,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  {{- $args := dict "dot" . "component" "data-grid" "name" "data-grid" }}
+  {{- $args := dict "dot" . "component" "data-grid" "name" "data-grid" "componentConfig" .Values.dataGridExample }}
   {{- include "hono.metadata" $args | nindent 2 }}
 spec:
   replicas: 1
@@ -65,22 +65,7 @@ spec:
           name: conf
           subPath: mgmt-groups.properties
           readOnly: true
-        livenessProbe:
-          httpGet:
-            path: /rest/v2/cache-managers/routing-info/health/status
-            port: hotrod
-          failureThreshold: 5
-          initialDelaySeconds: {{ .Values.dataGridExample.livenessProbeInitialDelaySeconds }}
-          successThreshold: 1
-          timeoutSeconds: 3
-        readinessProbe:
-          httpGet:
-            path: /rest/v2/cache-managers/routing-info/health/status
-            port: hotrod
-          failureThreshold: 5
-          initialDelaySeconds: {{ .Values.dataGridExample.readinessProbeInitialDelaySeconds }}
-          successThreshold: 1
-          timeoutSeconds: 3
+        {{- include "hono.component.healthChecks" $args | nindent 8 }}
         {{- with .Values.dataGridExample.resources }}
         resources:
           {{- . | toYaml | nindent 10 }}

--- a/charts/hono/templates/hono-adapter-amqp/hono-adapter-amqp-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-amqp/hono-adapter-amqp-deployment.yaml
@@ -67,7 +67,7 @@ spec:
         resources:
           {{- . | toYaml | nindent 10 }}
         {{- end }}
-        {{- include "hono.component.healthChecks" $args | indent 8 }}
+        {{- include "hono.component.healthChecks" $args | nindent 8 }}
       volumes:
       {{- include "hono.pod.volumes" $args | indent 6 }}
 {{- end }}

--- a/charts/hono/templates/hono-adapter-coap/hono-adapter-coap-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-coap/hono-adapter-coap-deployment.yaml
@@ -67,7 +67,7 @@ spec:
         resources:
           {{- . | toYaml | nindent 10 }}
         {{- end }}
-        {{- include "hono.component.healthChecks" $args | indent 8 }}
+        {{- include "hono.component.healthChecks" $args | nindent 8 }}
       volumes:
       {{- include "hono.pod.volumes" $args | indent 6 }}
 {{- end }}

--- a/charts/hono/templates/hono-adapter-http/hono-adapter-http-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-http/hono-adapter-http-deployment.yaml
@@ -67,7 +67,7 @@ spec:
         resources:
           {{- . | toYaml | nindent 10 }}
         {{- end }}
-        {{- include "hono.component.healthChecks" $args | indent 8 }}
+        {{- include "hono.component.healthChecks" $args | nindent 8 }}
       volumes:
       {{- include "hono.pod.volumes" $args | indent 6 }}
 {{- end }}

--- a/charts/hono/templates/hono-adapter-lora/hono-adapter-lora-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-lora/hono-adapter-lora-deployment.yaml
@@ -67,7 +67,7 @@ spec:
         resources:
           {{- . | toYaml | nindent 10 }}
         {{- end }}
-        {{- include "hono.component.healthChecks" $args | indent 8 }}
+        {{- include "hono.component.healthChecks" $args | nindent 8 }}
       volumes:
       {{- include "hono.pod.volumes" $args | indent 6 }}
 {{- end }}

--- a/charts/hono/templates/hono-adapter-mqtt/hono-adapter-mqtt-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-mqtt/hono-adapter-mqtt-deployment.yaml
@@ -67,7 +67,7 @@ spec:
         resources:
           {{- . | toYaml | nindent 10 }}
         {{- end }}
-        {{- include "hono.component.healthChecks" $args | indent 8 }}
+        {{- include "hono.component.healthChecks" $args | nindent 8 }}
       volumes:
       {{- include "hono.pod.volumes" $args | indent 6 }}
 {{- end }}

--- a/charts/hono/templates/hono-service-auth/hono-service-auth-deployment.yaml
+++ b/charts/hono/templates/hono-service-auth/hono-service-auth-deployment.yaml
@@ -65,6 +65,6 @@ spec:
         resources:
           {{- . | toYaml | nindent 10 }}
         {{- end }}
-        {{- include "hono.component.healthChecks" $args | indent 8 }}
+        {{- include "hono.component.healthChecks" $args | nindent 8 }}
       volumes:
       {{- include "hono.pod.volumes" $args | indent 6 }}

--- a/charts/hono/templates/hono-service-command-router/hono-service-command-router-deployment.yaml
+++ b/charts/hono/templates/hono-service-command-router/hono-service-command-router-deployment.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           {{- . | toYaml | nindent 10 }}
         {{- end }}
-        {{- include "hono.component.healthChecks" $args | indent 8 }}
+        {{- include "hono.component.healthChecks" $args | nindent 8 }}
       volumes:
       {{- include "hono.pod.volumes" $args | indent 6 }}
       serviceAccountName: {{ printf "%s-%s" .Release.Name $args.name | quote }}

--- a/charts/hono/templates/hono-service-device-registry-embedded/hono-service-device-registry-statefulset.yaml
+++ b/charts/hono/templates/hono-service-device-registry-embedded/hono-service-device-registry-statefulset.yaml
@@ -76,7 +76,7 @@ spec:
         resources:
           {{- . | toYaml | nindent 10 }}
         {{- end }}
-        {{- include "hono.component.healthChecks" $args | indent 8 }}
+        {{- include "hono.component.healthChecks" $args | nindent 8 }}
       volumes:
       {{- include "hono.pod.volumes" ( dict "dot" $args.dot "name" $args.name "componentConfig" .Values.deviceRegistryExample ) | indent 6 }}
       - name: "registry"

--- a/charts/hono/templates/hono-service-device-registry-jdbc/hono-service-device-registry-deployment.yaml
+++ b/charts/hono/templates/hono-service-device-registry-jdbc/hono-service-device-registry-deployment.yaml
@@ -73,7 +73,7 @@ spec:
         resources:
           {{- . | toYaml | nindent 10 }}
         {{- end }}
-        {{- include "hono.component.healthChecks" $args | indent 8 }}
+        {{- include "hono.component.healthChecks" $args | nindent 8 }}
       volumes:
       {{- include "hono.pod.volumes" ( dict "dot" $args.dot "name" $args.name "componentConfig" .Values.deviceRegistryExample ) | indent 6 }}
 {{- end }}

--- a/charts/hono/templates/hono-service-device-registry-mongodb/hono-service-device-registry-deployment.yaml
+++ b/charts/hono/templates/hono-service-device-registry-mongodb/hono-service-device-registry-deployment.yaml
@@ -73,7 +73,7 @@ spec:
         resources:
           {{- . | toYaml | nindent 10 }}
         {{- end }}
-        {{- include "hono.component.healthChecks" $args | indent 8 }}
+        {{- include "hono.component.healthChecks" $args | nindent 8 }}
       volumes:
       {{- include "hono.pod.volumes" ( dict "dot" $args.dot "name" $args.name "componentConfig" .Values.deviceRegistryExample ) | indent 6 }}
 {{- end }}

--- a/charts/hono/templates/jaeger/jaeger-deployment.yaml
+++ b/charts/hono/templates/jaeger/jaeger-deployment.yaml
@@ -64,14 +64,5 @@ spec:
         resources:
           {{- . | toYaml | nindent 10 }}
         {{- end }}
-        livenessProbe:
-          httpGet:
-            path: "/"
-            port: health
-          initialDelaySeconds: {{ .Values.jaegerBackendExample.livenessProbeInitialDelaySeconds }}
-        readinessProbe:
-          httpGet:
-            path: "/"
-            port: health
-          initialDelaySeconds: {{ .Values.jaegerBackendExample.readinessProbeInitialDelaySeconds }}
+        {{- include "hono.component.healthChecks" $args | nindent 8 }}
 {{- end }}

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -30,23 +30,49 @@ honoContainerRegistry: "index.docker.io"
 # be added to every deployment and statefulset.
 imagePullSecrets: []
 
+# probes allows you to configure http GET probes on most hono services
+# the values below will be used by default but can be overwritten by
+# configuring more specific config in the probes config of the component.
+# Note that only the parameters below can be overwritten.
+probes:
+  livenessProbe:
+    httpGet:
+      path: "/liveness"
+      port: "health"
+      scheme: "HTTP"
+    periodSeconds: 10
+    failureThreshold: 3
+    initialDelaySeconds: 300
+    successThreshold: 1
+    timeoutSeconds: 3
+  readinessProbe:
+    httpGet:
+      path: "/liveness"
+      port: "health"
+      scheme: "HTTP"
+    periodSeconds: 10
+    failureThreshold: 3
+    initialDelaySeconds: 20
+    successThreshold: 1
+    timeoutSeconds: 3
+
 # color indicates if the information printed to the console by components should be
 # formatted in multi-color using ANSI escape sequences.
 console:
   color: false
 
-# livenessProbeInitialDelaySeconds contains the default value to use
+# [DEPRECATED: use probes instead] livenessProbeInitialDelaySeconds contains the default value to use
 # for the "initialDelaySeconds" configuration property of a Hono
 # component's liveness probe.
 # The value can be overridden by the corresponding property at the
 # component level.
-livenessProbeInitialDelaySeconds: 300
-# readinessProbeInitialDelaySeconds contains the default value to use
+livenessProbeInitialDelaySeconds:
+# [DEPRECATED: use probes instead] readinessProbeInitialDelaySeconds contains the default value to use
 # for the "initialDelaySeconds" configuration property of a Hono
 # component's readiness probe.
 # The value can be overridden by the corresponding property at the
 # component level.
-readinessProbeInitialDelaySeconds: 20
+readinessProbeInitialDelaySeconds:
 
 # platform indicates the type of container orchestration platform we are deploying to.
 # Supported values are:
@@ -237,14 +263,16 @@ adapters:
     # quarkusLoggingProfile indicates at which level the Quarkus based variant of the component should log.
     # Supported values are "prod", "dev" or "trace"
     quarkusLoggingProfile: "dev"
-    # livenessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
+    # [DEPRECATED: use probes instead] livenessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
     # configuration property of the component's liveness probe.
     # The value of the top level "livenessProbeInitialDelaySeconds" property will be used if not set.
     livenessProbeInitialDelaySeconds:
-    # readinessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
+    # [DEPRECATED: use probes instead] readinessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
     # configuration property of the component's readiness probe.
     # The value of the top level "readinessProbeInitialDelaySeconds" property will be used if not set.
     readinessProbeInitialDelaySeconds:
+    # probes allows you to overwrite the global probes config values for this specific component
+    probes: {}
     # resources contains the container's requests and limits for CPU and memory
     # as defined by the Kubernetes API.
     # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
@@ -353,14 +381,16 @@ adapters:
     # quarkusLoggingProfile indicates at which level the Quarkus based variant of the component should log.
     # Supported values are "prod", "dev" or "trace"
     quarkusLoggingProfile: "dev"
-    # livenessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
+    # [DEPRECATED: use probes instead] livenessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
     # configuration property of the component's liveness probe.
     # The value of the top level "livenessProbeInitialDelaySeconds" property will be used if not set.
     livenessProbeInitialDelaySeconds:
-    # readinessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
+    # [DEPRECATED: use probes instead] readinessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
     # configuration property of the component's readiness probe.
     # The value of the top level "readinessProbeInitialDelaySeconds" property will be used if not set.
     readinessProbeInitialDelaySeconds:
+    # probes allows you to overwrite the global probes config values for this specific component
+    probes: {}
     # resources contains the container's requests and limits for CPU and memory
     # as defined by the Kubernetes API.
     # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
@@ -460,14 +490,16 @@ adapters:
     # quarkusLoggingProfile indicates at which level the Quarkus based variant of the component should log.
     # Supported values are "prod", "dev" or "trace"
     quarkusLoggingProfile: "dev"
-    # livenessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
+    # [DEPRECATED: use probes instead] livenessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
     # configuration property of the component's liveness probe.
     # The value of the top level "livenessProbeInitialDelaySeconds" property will be used if not set.
     livenessProbeInitialDelaySeconds:
-    # readinessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
+    # [DEPRECATED: use probes instead] readinessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
     # configuration property of the component's readiness probe.
     # The value of the top level "readinessProbeInitialDelaySeconds" property will be used if not set.
     readinessProbeInitialDelaySeconds:
+    # probes allows you to overwrite the global probes config values for this specific component
+    probes: {}
     # resources contains the container's requests and limits for CPU and memory
     # as defined by the Kubernetes API.
     # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
@@ -576,14 +608,16 @@ adapters:
     # quarkusLoggingProfile indicates at which level the Quarkus based variant of the component should log.
     # Supported values are "prod", "dev" or "trace"
     quarkusLoggingProfile: "dev"
-    # livenessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
+    # [DEPRECATED: use probes instead] livenessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
     # configuration property of the component's liveness probe.
     # The value of the top level "livenessProbeInitialDelaySeconds" property will be used if not set.
     livenessProbeInitialDelaySeconds:
-    # readinessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
+    # [DEPRECATED: use probes instead] readinessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
     # configuration property of the component's readiness probe.
     # The value of the top level "readinessProbeInitialDelaySeconds" property will be used if not set.
     readinessProbeInitialDelaySeconds:
+    # probes allows you to overwrite the global probes config values for this specific component
+    probes: {}
     # resources contains the container's requests and limits for CPU and memory
     # as defined by the Kubernetes API.
     # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
@@ -691,14 +725,16 @@ adapters:
     # quarkusLoggingProfile indicates at which level the Quarkus based variant of the component should log.
     # Supported values are "prod", "dev" or "trace"
     quarkusLoggingProfile: "dev"
-    # livenessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
+    # [DEPRECATED: use probes instead] livenessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
     # configuration property of the component's liveness probe.
     # The value of the top level "livenessProbeInitialDelaySeconds" property will be used if not set.
     livenessProbeInitialDelaySeconds:
-    # readinessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
+    # [DEPRECATED: use probes instead] readinessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
     # configuration property of the component's readiness probe.
     # The value of the top level "readinessProbeInitialDelaySeconds" property will be used if not set.
     readinessProbeInitialDelaySeconds:
+    # probes allows you to overwrite the global probes config values for this specific component
+    probes: {}
     # resources contains the container's requests and limits for CPU and memory
     # as defined by the Kubernetes API.
     # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
@@ -807,14 +843,16 @@ authServer:
   # quarkusLoggingProfile indicates at which level the Quarkus based variant of the component should log.
   # Supported values are "prod", "dev" or "trace"
   quarkusLoggingProfile: "dev"
-  # livenessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
+  # [DEPRECATED: use probes instead] livenessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
   # configuration property of the component's liveness probe.
   # The value of the top level "livenessProbeInitialDelaySeconds" property will be used if not set.
   livenessProbeInitialDelaySeconds:
-  # readinessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
+  # [DEPRECATED: use probes instead] readinessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
   # configuration property of the component's readiness probe.
   # The value of the top level "readinessProbeInitialDelaySeconds" property will be used if not set.
   readinessProbeInitialDelaySeconds:
+  # probes allows you to overwrite the global probes config values for this specific component
+  probes: {}
   # resources contains the container's requests and limits for CPU and memory
   # as defined by the Kubernetes API.
   # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
@@ -1058,14 +1096,16 @@ deviceRegistryExample:
     # quarkusLoggingProfile indicates at which level the Quarkus based variant of the component should log.
     # Supported values are "prod", "dev" or "trace"
     quarkusLoggingProfile: "dev"
-    # livenessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
+    # [DEPRECATED: use probes instead] livenessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
     # configuration property of the component's liveness probe.
     # The value of the top level "livenessProbeInitialDelaySeconds" property will be used if not set.
     livenessProbeInitialDelaySeconds:
-    # readinessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
+    # [DEPRECATED: use probes instead] readinessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
     # configuration property of the component's readiness probe.
     # The value of the top level "readinessProbeInitialDelaySeconds" property will be used if not set.
     readinessProbeInitialDelaySeconds:
+    # probes allows you to overwrite the global probes config values for this specific component
+    probes: {}
     # resources contains the container's requests and limits for CPU and memory
     # as defined by the Kubernetes API.
     # If not specified here, then the values from "deviceRegistryExample.resources" are used.
@@ -1113,14 +1153,16 @@ deviceRegistryExample:
     # quarkusLoggingProfile indicates at which level the Quarkus based variant of the component should log.
     # Supported values are "prod", "dev" or "trace"
     quarkusLoggingProfile: "dev"
-    # livenessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
+    # [DEPRECATED: use probes instead] livenessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
     # configuration property of the component's liveness probe.
     # The value of the top level "livenessProbeInitialDelaySeconds" property will be used if not set.
     livenessProbeInitialDelaySeconds:
-    # readinessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
+    # [DEPRECATED: use probes instead] readinessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
     # configuration property of the component's readiness probe.
     # The value of the top level "readinessProbeInitialDelaySeconds" property will be used if not set.
     readinessProbeInitialDelaySeconds:
+    # probes allows you to overwrite the global probes config values for this specific component
+    probes: {}
     # If not specified here, then the values from "deviceRegistryExample.resources" are used.
     # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
     # for a description of the properties' semantics.
@@ -1180,14 +1222,16 @@ deviceRegistryExample:
     # quarkusLoggingProfile indicates at which level the Quarkus based variant of the component should log.
     # Supported values are "prod", "dev" or "trace"
     quarkusLoggingProfile: "dev"
-    # livenessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
+    # [DEPRECATED: use probes instead] livenessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
     # configuration property of the component's liveness probe.
     # The value of the top level "livenessProbeInitialDelaySeconds" property will be used if not set.
     livenessProbeInitialDelaySeconds:
-    # readinessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
+    # [DEPRECATED: use probes instead] readinessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
     # configuration property of the component's readiness probe.
     # The value of the top level "readinessProbeInitialDelaySeconds" property will be used if not set.
     readinessProbeInitialDelaySeconds:
+    # probes allows you to overwrite the global probes config values for this specific component
+    probes: {}
     # If not specified here, then the values from "deviceRegistryExample.resources" are used.
     # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
     # for a description of the properties' semantics.
@@ -1322,14 +1366,16 @@ commandRouterService:
   # quarkusLoggingProfile indicates at which level the Quarkus based variant of the component should log.
   # Supported values are "prod", "dev" or "trace"
   quarkusLoggingProfile: "dev"
-  # livenessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
+  # [DEPRECATED: use probes instead] livenessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
   # configuration property of the component's liveness probe.
   # The value of the top level "livenessProbeInitialDelaySeconds" property will be used if not set.
   livenessProbeInitialDelaySeconds:
-  # readinessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
+  # [DEPRECATED: use probes instead] readinessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
   # configuration property of the component's readiness probe.
   # The value of the top level "readinessProbeInitialDelaySeconds" property will be used if not set.
   readinessProbeInitialDelaySeconds:
+  # probes allows you to overwrite the global probes config values for this specific component
+  probes: {}
   # resources contains the container's requests and limits for CPU and memory
   # as defined by the Kubernetes API.
   # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
@@ -1663,12 +1709,26 @@ amqpMessagingNetworkExample:
     # The default value ("Eclipse IoT;Hono") includes all adapters that authenticate with their
     # demo certificate.
     adapterUids: "Eclipse IoT;Hono"
-    # livenessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
+    # [DEPRECATED: use probes instead] livenessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
     # configuration property of the component's liveness probe.
-    livenessProbeInitialDelaySeconds: 300
-    # readinessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
+    # The value of the top level "livenessProbeInitialDelaySeconds" property will be used if not set.
+    livenessProbeInitialDelaySeconds:
+    # [DEPRECATED: use probes instead] readinessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
     # configuration property of the component's readiness probe.
-    readinessProbeInitialDelaySeconds: 20
+    # The value of the top level "readinessProbeInitialDelaySeconds" property will be used if not set.
+    readinessProbeInitialDelaySeconds:
+    # probes allows you to overwrite the global probes config values for this specific component
+    probes:
+      livenessProbe:
+        httpGet:
+          path: "/healthz"
+        periodSeconds: 9
+        initialDelaySeconds: 300
+      readinessProbe:
+        httpGet:
+          path: "/healthz"
+        periodSeconds: 5
+        initialDelaySeconds: 20
 
     svc:
       annotations: {}
@@ -1740,16 +1800,24 @@ amqpMessagingNetworkExample:
       # imageName contains the name (including tag) of the container
       # image to use for the example AMQP Messaging Network Broker
       imageName: "quay.io/artemiscloud/activemq-artemis-broker:1.0.6"
-      # livenessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
+      # [DEPRECATED: use probes instead] livenessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
       # configuration property of the component's liveness probe.
-      livenessProbeInitialDelaySeconds: 300
-      # readinessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
+      # The value of the top level "livenessProbeInitialDelaySeconds" property will be used if not set.
+      livenessProbeInitialDelaySeconds:
+      # [DEPRECATED: use probes instead] readinessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
       # configuration property of the component's readiness probe.
-      readinessProbeInitialDelaySeconds: 20
-      # resources contains the container's requests and limits for CPU and memory
-      # as defined by the Kubernetes API.
-      # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
-      # for a description of the properties' semantics.
+      # The value of the top level "readinessProbeInitialDelaySeconds" property will be used if not set.
+      readinessProbeInitialDelaySeconds:
+      # probes allows you to overwrite the global probes config values for this specific component
+      probes:
+        livenessProbe:
+          periodSeconds: 17
+          timeoutSeconds: 3
+          initialDelaySeconds: 300
+        readinessProbe:
+          periodSeconds: 10
+          timeoutSeconds: 3
+          initialDelaySeconds: 20
       resources:
         requests:
           cpu: "150m"
@@ -1791,12 +1859,32 @@ dataGridExample:
   # imageName contains the name (including tag)
   # of the container image to use for the example data grid.
   imageName: "infinispan/server-native:13.0"
-  # livenessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
+  # [DEPRECATED: use probes instead] livenessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
   # configuration property of the component's liveness probe.
-  livenessProbeInitialDelaySeconds: 300
-  # readinessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
+  # The value of the top level "livenessProbeInitialDelaySeconds" property will be used if not set.
+  livenessProbeInitialDelaySeconds:
+  # [DEPRECATED: use probes instead] readinessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
   # configuration property of the component's readiness probe.
-  readinessProbeInitialDelaySeconds: 30
+  # The value of the top level "readinessProbeInitialDelaySeconds" property will be used if not set.
+  readinessProbeInitialDelaySeconds:
+  # probes allows you to overwrite the global probes config values for this specific component
+  probes:
+    livenessProbe:
+      httpGet:
+        path: "/rest/v2/cache-managers/routing-info/health/status"
+        port: "hotrod"
+      failureThreshold: 5
+      successThreshold: 1
+      timeoutSeconds: 3
+      initialDelaySeconds: 300
+    readinessProbe:
+      httpGet:
+        path: "/rest/v2/cache-managers/routing-info/health/status"
+        port: "hotrod"
+      failureThreshold: 5
+      successThreshold: 1
+      timeoutSeconds: 3
+      initialDelaySeconds: 30
   # resources contains the container's requests and limits for CPU and memory
   # as defined by the Kubernetes API.
   # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
@@ -1823,12 +1911,23 @@ jaegerBackendExample:
   # allInOneImage contains the name (including tag)
   # of the container image to use for the example Jaeger back end.
   allInOneImage: "jaegertracing/all-in-one:1.31"
-  # livenessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
+  # [DEPRECATED: use probes instead] livenessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
   # configuration property of the component's liveness probe.
-  livenessProbeInitialDelaySeconds: 300
-  # readinessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
+  # The value of the top level "livenessProbeInitialDelaySeconds" property will be used if not set.
+  livenessProbeInitialDelaySeconds:
+  # [DEPRECATED: use probes instead] readinessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
   # configuration property of the component's readiness probe.
-  readinessProbeInitialDelaySeconds: 10
+  # The value of the top level "readinessProbeInitialDelaySeconds" property will be used if not set.
+  readinessProbeInitialDelaySeconds:
+  probes:
+    livenessProbe:
+      initialDelaySeconds: 300
+      httpGet:
+        path: "/"
+    readinessProbe:
+      initialDelaySeconds: 10
+      httpGet:
+        path: "/"
   # resources contains the container's requests and limits for CPU and memory
   # as defined by the Kubernetes API.
   # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/


### PR DESCRIPTION
This change allows to easily configure the liveliness and readiness probe of the pods of all hono services.