### PR TITLE
Add AKS instructions from Hono code base

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 2.0.4
+version: 2.0.5
 # Version of Hono being deployed by the chart
 appVersion: 2.0.0
 keywords:

--- a/charts/hono/infra/azure/arm/honoInfrastructureDeployment.json
+++ b/charts/hono/infra/azure/arm/honoInfrastructureDeployment.json
@@ -1,0 +1,385 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "aks": {
+            "type": "bool",
+            "defaultValue": true,
+            "metadata": {
+                "description": "AKS deployment enabled."
+            }
+        },
+        "aksClusterName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Optional AKS cluster name. Otherwise calculated from uniqueSolutionPrefix."
+            }
+        },
+        "kubernetesVersion": {
+            "type": "string",
+            "defaultValue": "1.23",
+            "metadata": {
+                "description": "Kubernetes version."
+            }
+        },
+        "vnetName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Optional virtual network name. Otherwise calculated from uniqueSolutionPrefix."
+            }
+        },
+
+        "aksSubnetName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Optional subnet name for AKS nodes and pods. Otherwise calculated from uniqueSolutionPrefix."
+            }
+        },
+        "mqttDnsLabelPrefix": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Optional DNS Label for the Public IP that will be used by hono's MQTT adapter. Otherwise calculated from uniqueSolutionPrefix. Must be lowercase. It should match with the following regular expression: ^[a-z][a-z0-9-]{1,61}[a-z0-9]$ or it will raise an error."
+            }
+        },
+        "httpDnsLabelPrefix": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Optional DNS Label for the Public IP that will be used by hono's HTTP adapter. Otherwise calculated from uniqueSolutionPrefix. Must be lowercase. It should match with the following regular expression: ^[a-z][a-z0-9-]{1,61}[a-z0-9]$ or it will raise an error."
+            }
+        },
+        "amqpDnsLabelPrefix": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Optional DNS Label for the Public IP that will be used by hono's AMQP adapter. Otherwise calculated from uniqueSolutionPrefix. Must be lowercase. It should match with the following regular expression: ^[a-z][a-z0-9-]{1,61}[a-z0-9]$ or it will raise an error."
+            }
+        },
+        "networkDnsLabelPrefix": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Optional DNS Label for the Public IP that will be used by hono's AMQP network. Otherwise calculated from uniqueSolutionPrefix. Must be lowercase. It should match with the following regular expression: ^[a-z][a-z0-9-]{1,61}[a-z0-9]$ or it will raise an error."
+            }
+        },
+        "registryDnsLabelPrefix": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Optional DNS Label for the Public IP that will be used by hono's device registry. Otherwise calculated from uniqueSolutionPrefix. Must be lowercase. It should match with the following regular expression: ^[a-z][a-z0-9-]{1,61}[a-z0-9]$ or it will raise an error."
+            }
+        },
+        "mqttPublicIPAddressName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Optional IP address name that will be used by hono's MQTT adapter. Otherwise calculated from uniqueSolutionPrefix."
+            }
+        },
+        "amqpPublicIPAddressName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Optional IP address name that will be used by hono's AMQP adapter. Otherwise calculated from uniqueSolutionPrefix."
+            }
+        },
+        "networkPublicIPAddressName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Optional IP address name that will be used by hono's AMQP network. Otherwise calculated from uniqueSolutionPrefix."
+            }
+        },
+        "httpPublicIPAddressName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Optional IP address name that will be used by hono's HTTP adapter. Otherwise calculated from uniqueSolutionPrefix."
+            }
+        },
+        "registryPublicIPAddressName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Optional IP address name that will be used by hono's device registry. Otherwise calculated from uniqueSolutionPrefix."
+            }
+        },
+        "uniqueSolutionPrefix": {
+            "type": "string",
+            "metadata": {
+                "description": "Prefix used for resource names. Should be unique as this will also be used for domain names."
+            }
+        },
+        "location": {
+            "type": "string",
+            "defaultValue": "[resourceGroup().location]",
+            "metadata": {
+                "description": "Location for all resources."
+            }
+        },
+        "servicePrincipalObjectId": {
+            "type": "securestring",
+            "metadata": {
+                "description": "Object ID against which the Network Contributor roles will be assigned on the subnet"
+            }
+        },
+        "servicePrincipalClientId": {
+            "metadata": {
+                "description": "Client ID (used by cloudprovider)"
+            },
+            "type": "securestring"
+        },
+        "servicePrincipalClientSecret": {
+            "metadata": {
+                "description": "The Service Principal Client Secret."
+            },
+            "type": "securestring"
+        },
+        "serviceBus": {
+            "type": "bool",
+            "defaultValue": false,
+            "metadata": {
+                "description": "Service Bus deployment enabled."
+            }
+        },
+        "namespaceName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Optional Service Bus namespace name. Otherwise calculated from uniqueSolutionPrefix."
+            }
+        },
+        "serviceBusSku": {
+            "type": "string",
+            "allowedValues": [
+                "Basic",
+                "Standard",
+                "Premium"
+            ],
+            "defaultValue": "Premium",
+            "metadata": {
+                "description": "The messaging tier for service Bus namespace. Premium by default to support service endpoint."
+            }
+        }
+
+    },
+    "variables": {
+        "namespaceName": "[if(empty(parameters('namespaceName')),concat(parameters('uniqueSolutionPrefix'),'hono'),parameters('namespaceName'))]",
+        "mqttDnsLabelPrefix": "[if(empty(parameters('mqttDnsLabelPrefix')),concat(parameters('uniqueSolutionPrefix'),'-hono-mqtt'),parameters('mqttDnsLabelPrefix'))]",
+        "httpDnsLabelPrefix": "[if(empty(parameters('httpDnsLabelPrefix')),concat(parameters('uniqueSolutionPrefix'),'-hono-http'),parameters('httpDnsLabelPrefix'))]",
+        "amqpDnsLabelPrefix": "[if(empty(parameters('amqpDnsLabelPrefix')),concat(parameters('uniqueSolutionPrefix'),'-hono-amqp'),parameters('amqpDnsLabelPrefix'))]",
+        "registryDnsLabelPrefix": "[if(empty(parameters('registryDnsLabelPrefix')),concat(parameters('uniqueSolutionPrefix'),'-hono-registry'),parameters('registryDnsLabelPrefix'))]",
+        "networkDnsLabelPrefix": "[if(empty(parameters('networkDnsLabelPrefix')),concat(parameters('uniqueSolutionPrefix'),'-hono-network'),parameters('networkDnsLabelPrefix'))]",
+        "mqttPulicIPAddressName": "[if(empty(parameters('mqttPublicIPAddressName')),concat(parameters('uniqueSolutionPrefix'),'honomqttpip'),parameters('mqttPublicIPAddressName'))]",
+        "httpPulicIPAddressName": "[if(empty(parameters('httpPublicIPAddressName')),concat(parameters('uniqueSolutionPrefix'),'honohttppip'),parameters('httpPublicIPAddressName'))]",
+        "amqpPulicIPAddressName": "[if(empty(parameters('amqpPublicIPAddressName')),concat(parameters('uniqueSolutionPrefix'),'honoamqppip'),parameters('amqpPublicIPAddressName'))]",
+        "registryPublicIPAddressName": "[if(empty(parameters('registryPublicIPAddressName')),concat(parameters('uniqueSolutionPrefix'),'honoregistrypip'),parameters('registryPublicIPAddressName'))]",
+        "networkPublicIPAddressName": "[if(empty(parameters('networkPublicIPAddressName')),concat(parameters('uniqueSolutionPrefix'),'hononetworkpip'),parameters('networkPublicIPAddressName'))]",
+        "aksClusterName": "[if(empty(parameters('aksClusterName')),concat(parameters('uniqueSolutionPrefix'), 'honoaks'),parameters('aksClusterName'))]",
+        "vnetName": "[if(empty(parameters('vnetName')),concat(parameters('uniqueSolutionPrefix'), 'honovnet'),parameters('vnetName'))]",
+        "aksSubnetName": "[if(empty(parameters('aksSubnetName')),concat(parameters('uniqueSolutionPrefix'), 'honoakssubnet'),parameters('aksSubnetName'))]"
+    },
+    "resources": [
+        {
+            "condition": "[parameters('aks')]",
+            "name": "honoKubernetesDeployment",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2018-05-01",
+            "dependsOn": [
+                "[concat('Microsoft.Resources/deployments/', 'honoVnetDeployment')]"
+            ],
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "https://raw.githubusercontent.com/eclipse/packages/master/charts/hono/infra/azure/arm/templates/kubernetesDeploy.json"
+                },
+                "parameters": {
+                    "clusterName": {
+                        "value": "[variables('aksClusterName')]"
+                    },
+                    "kubernetesVersion": {
+                        "value": "[parameters('kubernetesVersion')]"
+                    },
+                    "location": {
+                        "value": "[parameters('location')]"
+                    },
+                    "dnsPrefix": {
+                        "value": "[parameters('uniqueSolutionPrefix')]"
+                    },
+                    "servicePrincipalObjectId": {
+                        "value": "[parameters('servicePrincipalObjectId')]"
+                    },
+                    "servicePrincipalClientId": {
+                        "value": "[parameters('servicePrincipalClientId')]"
+                    },
+                    "servicePrincipalClientSecret": {
+                        "value": "[parameters('servicePrincipalClientSecret')]"
+                    },
+                    "virtualNetworkName": {
+                        "value": "[variables('vnetName')]"
+                    },
+                    "subnetName": {
+                        "value": "[variables('aksSubnetName')]"
+                    },
+                    "virtualNetworkResourceGroup": {
+                        "value": "[resourceGroup().name]"
+                    },
+                    "mqttPublicIPAddressName": {
+                        "value": "[variables('mqttPulicIPAddressName')]"
+                    },
+                    "httpPublicIPAddressName": {
+                        "value": "[variables('httpPulicIPAddressName')]"
+                    },
+                    "amqpPublicIPAddressName": {
+                        "value": "[variables('amqpPulicIPAddressName')]"
+                    },
+                    "registryPublicIPAddressName": {
+                        "value": "[variables('registryPublicIPAddressName')]"
+                    },
+                    "networkPublicIPAddressName": {
+                        "value": "[variables('networkPublicIPAddressName')]"
+                    },
+                    "mqttDnsLabelPrefix": {
+                        "value": "[variables('mqttDnsLabelPrefix')]"
+                    },
+                    "httpDnsLabelPrefix": {
+                        "value": "[variables('httpDnsLabelPrefix')]"
+                    },
+                    "amqpDnsLabelPrefix": {
+                        "value": "[variables('amqpDnsLabelPrefix')]"
+                    },
+                    "registryDnsLabelPrefix": {
+                        "value": "[variables('registryDnsLabelPrefix')]"
+                    },
+                    "networkDnsLabelPrefix": {
+                        "value": "[variables('networkDnsLabelPrefix')]"
+                    }
+                }
+            }
+        },
+        {
+            "condition": "[parameters('serviceBus')]",
+            "name": "honoServiceBusDeployment",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2018-05-01",
+            "dependsOn": [
+                "[concat('Microsoft.Resources/deployments/', 'honoVnetDeployment')]"
+            ],
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "https://raw.githubusercontent.com/eclipse/packages/master/charts/hono/infra/azure/arm/templates/serviceBusDeploy.json"
+                },
+                "parameters": {
+                    "serviceBusNamespaceName": {
+                        "value": "[variables('namespaceName')]"
+                    },
+                    "location": {
+                        "value": "[parameters('location')]"
+                    },
+                    "serviceBusSku": {
+                        "value": "[parameters('serviceBusSku')]"
+                    },
+                    "virtualNetworkName": {
+                        "value": "[variables('vnetName')]"
+                    },
+                    "subnetName": {
+                        "value": "[variables('aksSubnetName')]"
+                    },
+                    "virtualNetworkResourceGroup": {
+                        "value": "[resourceGroup().name]"
+                    }
+                }
+            }
+        },
+        {
+            "name": "honoVnetDeployment",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2018-05-01",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "https://raw.githubusercontent.com/eclipse/packages/master/charts/hono/infra/azure/arm/templates/vnetDeploy.json"
+                },
+                "parameters": {
+                    "vnetName": {
+                        "value": "[variables('vnetName')]"
+                    },
+                    "aksSubnetName": {
+                        "value": "[variables('aksSubnetName')]"
+                    },
+                    "location": {
+                        "value": "[parameters('location')]"
+                    }
+                }
+            }
+        }
+    ],
+    "outputs": {
+        "aksClusterName": {
+            "type": "string",
+            "value": "[variables('aksClusterName')]"
+        },
+        "vnetName": {
+            "type": "string",
+            "value": "[variables('vnetName')]"
+        },
+        "mqttPublicIPAddress": {
+            "type": "string",
+            "value": "[reference('honoKubernetesDeployment', '2019-06-01').outputs.mqttIpAddress.value]"
+        },
+        "mqttPublicIPFQDN": {
+            "type": "string",
+            "value": "[reference('honoKubernetesDeployment', '2019-06-01').outputs.mqttIpFQDN.value]"
+        },
+        "httpPublicIPAddress": {
+            "type": "string",
+            "value": "[reference('honoKubernetesDeployment', '2019-06-01').outputs.httpIpAddress.value]"
+        },
+        "httpPublicIPFQDN": {
+            "type": "string",
+            "value": "[reference('honoKubernetesDeployment', '2019-06-01').outputs.httpIpFQDN.value]"
+        },
+        "amqpPublicIPAddress": {
+            "type": "string",
+            "value": "[reference('honoKubernetesDeployment', '2019-06-01').outputs.amqpIpAddress.value]"
+        },
+        "amqpPublicIPFQDN": {
+            "type": "string",
+            "value": "[reference('honoKubernetesDeployment', '2019-06-01').outputs.amqpIpFQDN.value]"
+        },
+        "registryPublicIPAddress": {
+            "type": "string",
+            "value": "[reference('honoKubernetesDeployment', '2019-06-01').outputs.registryIpAddress.value]"
+        },
+        "registryPublicIPFQDN": {
+            "type": "string",
+            "value": "[reference('honoKubernetesDeployment', '2019-06-01').outputs.registryIpFQDN.value]"
+        },
+        "networkPublicIPAddress": {
+            "type": "string",
+            "value": "[reference('honoKubernetesDeployment', '2019-06-01').outputs.networkIpAddress.value]"
+        },
+        "networkPublicIPFQDN": {
+            "type": "string",
+            "value": "[reference('honoKubernetesDeployment', '2019-06-01').outputs.networkIpFQDN.value]"
+        },
+        "serviceBusKey": {
+            "type": "string",
+            "value": "[if(parameters('serviceBus'), reference('honoServiceBusDeployment', '2019-06-01').outputs.DefaultSharedAccessPolicyPrimaryKey.value, 'n/a')]"
+        },
+        "serviceBusKeyName": {
+            "type": "string",
+            "value": "[if(parameters('serviceBus'), reference('honoServiceBusDeployment', '2019-06-01').outputs.DefaultSharedAccessPolicyKeyName.value, 'n/a')]"
+        },
+        "serviceBusNamespaceName": {
+            "type": "string",
+            "value": "[variables('namespaceName')]"
+        }
+
+    }
+}

--- a/charts/hono/infra/azure/arm/templates/kubernetesDeploy.json
+++ b/charts/hono/infra/azure/arm/templates/kubernetesDeploy.json
@@ -1,0 +1,442 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "kubernetesVersion": {
+      "type": "string",
+      "metadata": {
+        "description": "Kubernetes version."
+      }
+    },
+    "clusterName": {
+      "type": "string",
+      "defaultValue": "Honoakscluster",
+      "metadata": {
+        "description": "The name of the Managed Cluster resource."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "The location of the Managed Cluster resource."
+      }
+    },
+    "dnsPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Optional DNS prefix to use with hosted Kubernetes API server FQDN."
+      }
+    },
+    "mqttDnsLabelPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "DNS Label for the Public IP of hono's MQTT adapter. Must be lowercase. It should match with the following regular expression: ^[a-z][a-z0-9-]{1,61}[a-z0-9]$ or it will raise an error."
+      }
+    },
+    "httpDnsLabelPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "DNS Label for the Public IP of hono's HTTP adapter. Must be lowercase. It should match with the following regular expression: ^[a-z][a-z0-9-]{1,61}[a-z0-9]$ or it will raise an error."
+      }
+    },
+    "amqpDnsLabelPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "DNS Label for the Public IP of hono's AMQP adapter. Must be lowercase. It should match with the following regular expression: ^[a-z][a-z0-9-]{1,61}[a-z0-9]$ or it will raise an error."
+      }
+    },
+    "registryDnsLabelPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "DNS Label for the Public IP of hono's device registry. Must be lowercase. It should match with the following regular expression: ^[a-z][a-z0-9-]{1,61}[a-z0-9]$ or it will raise an error."
+      }
+    },
+    "networkDnsLabelPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "DNS Label for the Public IP of hono's AMQP network. Must be lowercase. It should match with the following regular expression: ^[a-z][a-z0-9-]{1,61}[a-z0-9]$ or it will raise an error."
+      }
+    },
+    "osDiskSizeGB": {
+      "type": "int",
+      "defaultValue": 0,
+      "metadata": {
+        "description": "Disk size (in GB) to provision for each of the agent pool nodes. This value ranges from 0 to 1023. Specifying 0 will apply the default disk size for that agentVMSize."
+      },
+      "minValue": 0,
+      "maxValue": 1023
+    },
+    "agentCount": {
+      "type": "int",
+      "defaultValue": 3,
+      "metadata": {
+        "description": "The number of nodes for the cluster."
+      },
+      "minValue": 1,
+      "maxValue": 50
+    },
+    "agentVMSize": {
+      "type": "string",
+      "defaultValue": "Standard_DS2_v2",
+      "metadata": {
+        "description": "The size of the Virtual Machine."
+      }
+    },
+    "servicePrincipalObjectId": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Object ID against which the Network Contributor roles will be assigned on the subnet"
+      }
+    },
+    "servicePrincipalClientId": {
+      "metadata": {
+        "description": "Client ID (used by cloudprovider)"
+      },
+      "type": "securestring"
+    },
+    "servicePrincipalClientSecret": {
+      "metadata": {
+        "description": "The Service Principal Client Secret."
+      },
+      "type": "securestring"
+    },
+    "osType": {
+      "type": "string",
+      "defaultValue": "Linux",
+      "allowedValues": [
+        "Linux"
+      ],
+      "metadata": {
+        "description": "The type of operating system."
+      }
+    },
+    "enableHttpApplicationRouting": {
+      "defaultValue": false,
+      "type": "bool",
+      "metadata": {
+        "description": "boolean flag to turn on and off of http application routing"
+      }
+    },
+    "networkPlugin": {
+      "allowedValues": [
+        "azure",
+        "kubenet"
+      ],
+      "defaultValue": "azure",
+      "type": "string",
+      "metadata": {
+        "description": "Network plugin used for building Kubernetes network."
+      }
+    },
+    "networkPolicy": {
+      "allowedValues": [
+        "azure",
+        "calico"
+      ],
+      "defaultValue": "azure",
+      "type": "string",
+      "metadata": {
+        "description": "Network policy option."
+      }
+    },
+    "maxPods": {
+      "defaultValue": 30,
+      "type": "int",
+      "metadata": {
+        "description": "Maximum number of pods that can run on a node."
+      }
+    },
+    "enableRBAC": {
+      "defaultValue": true,
+      "type": "bool",
+      "metadata": {
+        "description": "boolean flag to turn on and off of RBAC"
+      }
+    },
+    "virtualNetworkName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of an existing VNET that will contain this AKS deployment."
+      }
+    },
+    "virtualNetworkResourceGroup": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the existing VNET resource group"
+      }
+    },
+    "subnetName": {
+      "type": "string",
+      "metadata": {
+        "description": "Subnet name that will contain the AKS nodes."
+      }
+    },
+    "mqttPublicIPAddressName": {
+      "type": "string",
+      "defaultValue": "honomqtt",
+      "metadata": {
+        "description": "Public IP address name that will be used by hono's MQTT adapter."
+      }
+    },
+    "httpPublicIPAddressName": {
+      "type": "string",
+      "defaultValue": "honohttp",
+      "metadata": {
+        "description": "Public IP address name that will be used by hono's HTTP adapter."
+      }
+    },
+    "amqpPublicIPAddressName": {
+      "type": "string",
+      "defaultValue": "honoamqp",
+      "metadata": {
+        "description": "Public IP address name that will be used by hono's AMQP adapter."
+      }
+    },
+    "registryPublicIPAddressName": {
+      "type": "string",
+      "defaultValue": "honoregistry",
+      "metadata": {
+        "description": "Public IP address name that will be used by hono's device registry."
+      }
+    },
+    "networkPublicIPAddressName": {
+      "type": "string",
+      "defaultValue": "honoregistry",
+      "metadata": {
+        "description": "Public IP address name that will be used by hono's AMQP network."
+      }
+    },
+    "serviceCidr": {
+      "type": "string",
+      "defaultValue": "10.0.0.0/16",
+      "metadata": {
+        "description": "A CIDR notation IP range from which to assign service cluster IPs."
+      }
+    },
+    "dnsServiceIP": {
+      "type": "string",
+      "defaultValue": "10.0.0.10",
+      "metadata": {
+        "description": "Containers DNS server IP address."
+      }
+    },
+    "dockerBridgeCidr": {
+      "type": "string",
+      "defaultValue": "172.17.0.1/16",
+      "metadata": {
+        "description": "A CIDR notation IP for Docker bridge."
+      }
+    }
+  },
+  "variables": {
+    "mqttPublicIPRef": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('mqttPublicIPAddressName'))]",
+    "httpPublicIPRef": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('httpPublicIPAddressName'))]",
+    "amqpPublicIPRef": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('amqpPublicIPAddressName'))]",
+    "registryPublicIPRef": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('registryPublicIPAddressName'))]",
+    "networkPublicIPRef": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('networkPublicIPAddressName'))]",
+    "vnetSubnetId": "[resourceId(parameters('virtualNetworkResourceGroup'),'Microsoft.Network/virtualNetworks/subnets',parameters('virtualNetworkName'),parameters('subnetName'))]"
+  },
+  "resources": [
+    {
+      "apiVersion": "2019-06-01",
+      "type": "Microsoft.ContainerService/managedClusters",
+      "location": "[parameters('location')]",
+      "name": "[parameters('clusterName')]",
+      "tags": {
+      },
+      "dependsOn": [
+        "[concat('Microsoft.Resources/deployments/', 'ClusterResourceGroupRoleAssignmentDeployment')]",
+        "[variables('mqttPublicIPRef')]",
+        "[variables('httpPublicIPRef')]",
+        "[variables('amqpPublicIPRef')]",
+        "[variables('registryPublicIPRef')]",
+        "[variables('networkPublicIPRef')]"
+      ],
+      "properties": {
+        "dnsPrefix": "[parameters('dnsPrefix')]",
+        "enableRBAC": "[parameters('enableRBAC')]",
+        "kubernetesVersion": "[parameters('kubernetesVersion')]",
+        "addonProfiles": {
+          "httpApplicationRouting": {
+            "enabled": "[parameters('enableHttpApplicationRouting')]"
+          }
+        },
+        "agentPoolProfiles": [
+          {
+            "name": "agentpool",
+            "osDiskSizeGB": "[parameters('osDiskSizeGB')]",
+            "count": "[parameters('agentCount')]",
+            "vmSize": "[parameters('agentVMSize')]",
+            "osType": "[parameters('osType')]",
+            "storageProfile": "ManagedDisks",
+            "vnetSubnetID": "[variables('vnetSubnetID')]",
+            "maxPods": "[parameters('maxPods')]"
+          }
+        ],
+        "servicePrincipalProfile": {
+          "clientId": "[parameters('servicePrincipalClientId')]",
+          "Secret": "[parameters('servicePrincipalClientSecret')]"
+        },
+        "networkProfile": {
+          "networkPlugin": "[parameters('networkPlugin')]",
+          "networkPolicy": "[parameters('networkPolicy')]",
+          "serviceCidr": "[parameters('serviceCidr')]",
+          "dnsServiceIP": "[parameters('dnsServiceIP')]",
+          "dockerBridgeCidr": "[parameters('dockerBridgeCidr')]"
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "name": "ClusterResourceGroupRoleAssignmentDeployment",
+      "apiVersion": "2017-05-10",
+      "subscriptionId": "[subscription().subscriptionId]",
+      "resourceGroup": "[parameters('virtualNetworkResourceGroup')]",
+      "properties": {
+        "mode": "Incremental",
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "parameters": {
+          },
+          "variables": {
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2017-05-01",
+              "name": "[guid(resourceGroup().id, deployment().name)]",
+              "properties": {
+                "scope": "[resourceGroup().id]",
+                "principalId": "[parameters('servicePrincipalObjectId')]",
+                "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '4d97b98b-1d4f-4787-a291-c67834d212e7')]"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "apiVersion": "2017-06-01",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[parameters('mqttPublicIPAddressName')]",
+      "location": "[parameters('location')]",
+      "dependsOn": [
+        "[concat('Microsoft.Resources/deployments/', 'ClusterResourceGroupRoleAssignmentDeployment')]"
+      ],
+      "properties": {
+        "publicIPAllocationMethod": "Static",
+        "dnsSettings": {
+          "domainNameLabel": "[parameters('mqttDnsLabelPrefix')]"
+        }
+      }
+    },
+    {
+      "apiVersion": "2017-06-01",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[parameters('amqpPublicIPAddressName')]",
+      "location": "[parameters('location')]",
+      "dependsOn": [
+        "[concat('Microsoft.Resources/deployments/', 'ClusterResourceGroupRoleAssignmentDeployment')]"
+      ],
+      "properties": {
+        "publicIPAllocationMethod": "Static",
+        "dnsSettings": {
+          "domainNameLabel": "[parameters('amqpDnsLabelPrefix')]"
+        }
+      }
+    },
+    {
+      "apiVersion": "2017-06-01",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[parameters('httpPublicIPAddressName')]",
+      "location": "[parameters('location')]",
+      "dependsOn": [
+        "[concat('Microsoft.Resources/deployments/', 'ClusterResourceGroupRoleAssignmentDeployment')]"
+      ],
+      "properties": {
+        "publicIPAllocationMethod": "Static",
+        "dnsSettings": {
+          "domainNameLabel": "[parameters('httpDnsLabelPrefix')]"
+        }
+      }
+    },
+    {
+      "apiVersion": "2017-06-01",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[parameters('registryPublicIPAddressName')]",
+      "location": "[parameters('location')]",
+      "dependsOn": [
+        "[concat('Microsoft.Resources/deployments/', 'ClusterResourceGroupRoleAssignmentDeployment')]"
+      ],
+      "properties": {
+        "publicIPAllocationMethod": "Static",
+        "dnsSettings": {
+          "domainNameLabel": "[parameters('registryDnsLabelPrefix')]"
+        }
+      }
+    },
+    {
+      "apiVersion": "2017-06-01",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[parameters('networkPublicIPAddressName')]",
+      "location": "[parameters('location')]",
+      "dependsOn": [
+        "[concat('Microsoft.Resources/deployments/', 'ClusterResourceGroupRoleAssignmentDeployment')]"
+      ],
+      "properties": {
+        "publicIPAllocationMethod": "Static",
+        "dnsSettings": {
+          "domainNameLabel": "[parameters('networkDnsLabelPrefix')]"
+        }
+      }
+    }
+  ],
+  "outputs": {
+    "controlPlaneFQDN": {
+      "type": "string",
+      "value": "[reference(parameters('clusterName')).fqdn]"
+    },
+    "mqttIpAddress": {
+      "value": "[reference(variables('mqttPublicIPRef'), '2017-11-01').ipAddress]",
+      "type": "string"
+    },
+    "mqttIpFQDN": {
+      "value": "[reference(variables('mqttPublicIPRef'), '2017-11-01').dnsSettings.fqdn]",
+      "type": "string"
+    },
+    "httpIpAddress": {
+      "value": "[reference(variables('httpPublicIPRef'), '2017-11-01').ipAddress]",
+      "type": "string"
+    },
+    "httpIpFQDN": {
+      "value": "[reference(variables('httpPublicIPRef'), '2017-11-01').dnsSettings.fqdn]",
+      "type": "string"
+    },
+    "amqpIpAddress": {
+      "value": "[reference(variables('amqpPublicIPRef'), '2017-11-01').ipAddress]",
+      "type": "string"
+    },
+    "amqpIpFQDN": {
+      "value": "[reference(variables('amqpPublicIPRef'), '2017-11-01').dnsSettings.fqdn]",
+      "type": "string"
+    },
+    "registryIpAddress": {
+      "value": "[reference(variables('registryPublicIPRef'), '2017-11-01').ipAddress]",
+      "type": "string"
+    },
+    "registryIpFQDN": {
+      "value": "[reference(variables('registryPublicIPRef'), '2017-11-01').dnsSettings.fqdn]",
+      "type": "string"
+    },
+    "networkIpAddress": {
+      "value": "[reference(variables('networkPublicIPRef'), '2017-11-01').ipAddress]",
+      "type": "string"
+    },
+    "networkIpFQDN": {
+      "value": "[reference(variables('networkPublicIPRef'), '2017-11-01').dnsSettings.fqdn]",
+      "type": "string"
+    }
+  }
+}

--- a/charts/hono/infra/azure/arm/templates/serviceBusDeploy.json
+++ b/charts/hono/infra/azure/arm/templates/serviceBusDeploy.json
@@ -1,0 +1,90 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "serviceBusNamespaceName": {
+            "type": "string",
+            "metadata": {
+                "description": "Name of the Service Bus namespace"
+            }
+        },
+        "serviceBusSku": {
+            "type": "string",
+            "allowedValues": [
+                "Basic",
+                "Standard",
+                "Premium"
+            ],
+            "defaultValue": "Premium",
+            "metadata": {
+                "description": "The messaging tier for service Bus namespace. Premium by default to support service endpoint."
+            }
+        },
+        "location": {
+            "type": "string",
+            "defaultValue": "[resourceGroup().location]",
+            "metadata": {
+                "description": "Location for all resources."
+            }
+        },
+        "virtualNetworkName": {
+            "type": "string",
+            "metadata": {
+                "description": "Name of an existing VNET that will contain this deployment."
+            }
+        },
+        "virtualNetworkResourceGroup": {
+            "type": "string",
+            "metadata": {
+                "description": "Name of the existing VNET resource group"
+            }
+        },
+        "subnetName": {
+            "type": "string",
+            "metadata": {
+                "description": "Subnet name that will contain the nodes."
+            }
+        }
+    },
+    "variables": {
+        "defaultSASKeyName": "RootManageSharedAccessKey",
+        "defaultAuthRuleResourceId": "[resourceId('Microsoft.ServiceBus/namespaces/authorizationRules', parameters('serviceBusNamespaceName'), variables('defaultSASKeyName'))]",
+        "namespaceNetworkRuleSetName": "[concat(parameters('serviceBusNamespaceName'), concat('/', 'default'))]",
+        "vnetSubnetId": "[resourceId(parameters('virtualNetworkResourceGroup'),'Microsoft.Network/virtualNetworks/subnets',parameters('virtualNetworkName'),parameters('subnetName'))]",
+        "sbVersion": "2017-04-01"
+    },
+    "resources": [{
+        "apiVersion": "2017-04-01",
+        "name": "[parameters('serviceBusNamespaceName')]",
+        "type": "Microsoft.ServiceBus/namespaces",
+        "location": "[parameters('location')]",
+        "sku": {
+            "name": "[parameters('serviceBusSku')]"
+        }
+    }, {
+        "apiVersion": "2018-01-01-preview",
+        "condition": "[equals(parameters('serviceBusSku'),'Premium')]",
+        "name": "[variables('namespaceNetworkRuleSetName')]",
+        "type": "Microsoft.ServiceBus/namespaces/VirtualNetworkRules",
+        "dependsOn": [
+            "[concat('Microsoft.ServiceBus/namespaces/', parameters('serviceBusNamespaceName'))]"
+        ],
+        "properties": {
+            "virtualNetworkSubnetId": "[variables('vnetSubnetId')]"
+        }
+    }],
+    "outputs": {
+        "NamespaceDefaultConnectionString": {
+            "type": "string",
+            "value": "[listkeys(variables('defaultAuthRuleResourceId'), variables('sbVersion')).primaryConnectionString]"
+        },
+        "DefaultSharedAccessPolicyPrimaryKey": {
+            "type": "string",
+            "value": "[listkeys(variables('defaultAuthRuleResourceId'), variables('sbVersion')).primaryKey]"
+        },
+        "DefaultSharedAccessPolicyKeyName": {
+            "type": "string",
+            "value": "[variables('defaultSASKeyName')]"
+        }
+    }
+}

--- a/charts/hono/infra/azure/arm/templates/vnetDeploy.json
+++ b/charts/hono/infra/azure/arm/templates/vnetDeploy.json
@@ -1,0 +1,70 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "vnetName": {
+            "type": "string",
+            "defaultValue": "HonoVNet",
+            "metadata": {
+                "description": "Hono VNet name"
+            }
+        },
+        "vnetAddressPrefix": {
+            "type": "string",
+            "defaultValue": "10.0.0.0/8",
+            "metadata": {
+                "description": "Hono Address Prefix"
+            }
+        },
+        "aksSubnetPrefix": {
+            "type": "string",
+            "defaultValue": "10.240.0.0/16",
+            "metadata": {
+                "description": "Hono AKS Subnet Prefix"
+            }
+        },
+        "aksSubnetName": {
+            "type": "string",
+            "defaultValue": "AksSubnet",
+            "metadata": {
+                "description": "Hono AKS Subnet Name"
+            }
+        },
+        "location": {
+            "type": "string",
+            "defaultValue": "[resourceGroup().location]",
+            "metadata": {
+                "description": "Location for all resources."
+            }
+        }
+    },
+    "variables": {},
+    "resources": [{
+        "apiVersion": "2018-10-01",
+        "type": "Microsoft.Network/virtualNetworks",
+        "name": "[parameters('vnetName')]",
+        "location": "[parameters('location')]",
+        "properties": {
+            "addressSpace": {
+                "addressPrefixes": [
+                    "[parameters('vnetAddressPrefix')]"
+                ]
+            }
+        },
+        "resources": [{
+            "apiVersion": "2018-10-01",
+            "type": "subnets",
+            "location": "[parameters('location')]",
+            "name": "[parameters('aksSubnetName')]",
+            "dependsOn": [
+                "[parameters('vnetName')]"
+            ],
+            "properties": {
+                "addressPrefix": "[parameters('aksSubnetPrefix')]",
+                "serviceEndpoints": [{
+                    "service": "Microsoft.ServiceBus"
+                }]
+            }
+        }]
+    }]
+}

--- a/charts/hono/infra/azure/managed-premium-retain.yaml
+++ b/charts/hono/infra/azure/managed-premium-retain.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2019 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: managed-premium-retain
+provisioner: kubernetes.io/azure-disk
+reclaimPolicy: Retain
+parameters:
+  storageaccounttype: Premium_LRS
+  kind: Managed


### PR DESCRIPTION
The instructions for setting up an AKS instance and installing Hono to
it have been cpoied from the Hono code base to the chart as proposed in
https://github.com/eclipse/hono/issues/2815
