### PR TITLE
Hono: Allow adding additional labels and annotations to PodSpecs

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 2.1.2
+version: 2.1.3
 # Version of Hono being deployed by the chart
 appVersion: 2.1.0
 keywords:

--- a/charts/hono/README.md
+++ b/charts/hono/README.md
@@ -103,6 +103,10 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Release Notes
 
+### 2.1.3
+
+* Allow adding labels and annotations to pods by using *pod.labels* and *pod.annotations* properties per component.
+
 ### 2.1.2
 
 * The Jaeger 'all-in-one' container, deployed if *jaegerBackendExample.enabled: true* is set, now supports collecting

--- a/charts/hono/templates/_helpers.tpl
+++ b/charts/hono/templates/_helpers.tpl
@@ -144,6 +144,32 @@ kubectl.kubernetes.io/default-container: {{ .name | quote }}
 {{- end }}
 
 {{/*
+Add additional annotations for Hono component pods.
+The scope passed in is expected to be a dict with keys
+- (mandatory) "componentConfig": the component's configuration properties from the values.yaml file
+*/}}
+{{- define "hono.podAdditionalAnnotations" -}}
+{{- if .componentConfig.pod.annotations }}
+{{- with .componentConfig.pod.annotations }}
+{{- toYaml . }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Add additional labels for Hono component pods.
+The scope passed in is expected to be a dict with keys
+- (mandatory) "componentConfig": the component's configuration properties from the values.yaml file
+*/}}
+{{- define "hono.podAdditionalLabels" -}}
+{{- if .componentConfig.pod.labels }}
+{{- with .componentConfig.pod.labels }}
+{{- toYaml . }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
 Add annotations for Hono component deployments.
 The scope passed in is expected to be a dict with keys
 - (mandatory) "componentConfig": the component's configuration properties from the values.yaml file

--- a/charts/hono/templates/hono-adapter-amqp/hono-adapter-amqp-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-amqp/hono-adapter-amqp-deployment.yaml
@@ -25,8 +25,10 @@ spec:
   template:
     metadata:
       {{- include "hono.metadata" $args | nindent 6 }}
+      {{- include "hono.podAdditionalLabels" $args | nindent 8 }}
       annotations:
         {{- include "hono.podAnnotations" $args | nindent 8 }}
+        {{- include "hono.podAdditionalAnnotations" $args | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/hono/templates/hono-adapter-coap/hono-adapter-coap-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-coap/hono-adapter-coap-deployment.yaml
@@ -25,8 +25,10 @@ spec:
   template:
     metadata:
       {{- include "hono.metadata" $args | nindent 6 }}
+      {{- include "hono.podAdditionalLabels" $args | nindent 8 }}
       annotations:
         {{- include "hono.podAnnotations" $args | nindent 8 }}
+        {{- include "hono.podAdditionalAnnotations" $args | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/hono/templates/hono-adapter-http/hono-adapter-http-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-http/hono-adapter-http-deployment.yaml
@@ -25,8 +25,10 @@ spec:
   template:
     metadata:
       {{- include "hono.metadata" $args | nindent 6 }}
+      {{- include "hono.podAdditionalLabels" $args | nindent 8 }}
       annotations:
         {{- include "hono.podAnnotations" $args | nindent 8 }}
+        {{- include "hono.podAdditionalAnnotations" $args | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/hono/templates/hono-adapter-lora/hono-adapter-lora-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-lora/hono-adapter-lora-deployment.yaml
@@ -25,8 +25,10 @@ spec:
   template:
     metadata:
       {{- include "hono.metadata" $args | nindent 6 }}
+      {{- include "hono.podAdditionalLabels" $args | nindent 8 }}
       annotations:
         {{- include "hono.podAnnotations" $args | nindent 8 }}
+        {{- include "hono.podAdditionalAnnotations" $args | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/hono/templates/hono-adapter-mqtt/hono-adapter-mqtt-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-mqtt/hono-adapter-mqtt-deployment.yaml
@@ -25,8 +25,10 @@ spec:
   template:
     metadata:
       {{- include "hono.metadata" $args | nindent 6 }}
+      {{- include "hono.podAdditionalLabels" $args | nindent 8 }}
       annotations:
         {{- include "hono.podAnnotations" $args | nindent 8 }}
+        {{- include "hono.podAdditionalAnnotations" $args | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/hono/templates/hono-service-auth/hono-service-auth-deployment.yaml
+++ b/charts/hono/templates/hono-service-auth/hono-service-auth-deployment.yaml
@@ -24,8 +24,10 @@ spec:
   template:
     metadata:
       {{- include "hono.metadata" $args | nindent 6 }}
+      {{- include "hono.podAdditionalLabels" $args | nindent 8 }}
       annotations:
         {{- include "hono.podAnnotations" $args | nindent 8 }}
+        {{- include "hono.podAdditionalAnnotations" $args | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/hono/templates/hono-service-command-router/hono-service-command-router-deployment.yaml
+++ b/charts/hono/templates/hono-service-command-router/hono-service-command-router-deployment.yaml
@@ -24,8 +24,10 @@ spec:
   template:
     metadata:
       {{- include "hono.metadata" $args | nindent 6 }}
+      {{- include "hono.podAdditionalLabels" $args | nindent 8 }}
       annotations:
         {{- include "hono.podAnnotations" $args | nindent 8 }}
+        {{- include "hono.podAdditionalAnnotations" $args | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/hono/templates/hono-service-device-registry-embedded/hono-service-device-registry-statefulset.yaml
+++ b/charts/hono/templates/hono-service-device-registry-embedded/hono-service-device-registry-statefulset.yaml
@@ -25,8 +25,10 @@ spec:
   template:
     metadata:
       {{- include "hono.metadata" $args | nindent 6 }}
+      {{- include "hono.podAdditionalLabels" $args | nindent 8 }}
       annotations:
         {{- include "hono.podAnnotations" $args | nindent 8 }}
+        {{- include "hono.podAdditionalAnnotations" $args | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/hono/templates/hono-service-device-registry-jdbc/hono-service-device-registry-deployment.yaml
+++ b/charts/hono/templates/hono-service-device-registry-jdbc/hono-service-device-registry-deployment.yaml
@@ -25,8 +25,10 @@ spec:
   template:
     metadata:
       {{- include "hono.metadata" $args | nindent 6 }}
+      {{- include "hono.podAdditionalLabels" $args | nindent 8 }}
       annotations:
         {{- include "hono.podAnnotations" $args | nindent 8 }}
+        {{- include "hono.podAdditionalAnnotations" $args | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/hono/templates/hono-service-device-registry-mongodb/hono-service-device-registry-deployment.yaml
+++ b/charts/hono/templates/hono-service-device-registry-mongodb/hono-service-device-registry-deployment.yaml
@@ -25,8 +25,10 @@ spec:
   template:
     metadata:
       {{- include "hono.metadata" $args | nindent 6 }}
+      {{- include "hono.podAdditionalLabels" $args | nindent 8 }}
       annotations:
         {{- include "hono.podAnnotations" $args | nindent 8 }}
+        {{- include "hono.podAdditionalAnnotations" $args | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/hono/templates/jaeger/jaeger-deployment.yaml
+++ b/charts/hono/templates/jaeger/jaeger-deployment.yaml
@@ -25,10 +25,12 @@ spec:
   template:
     metadata:
       {{- include "hono.metadata" $args | nindent 6 }}
+      {{- include "hono.podAdditionalLabels" $args | nindent 8 }}
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ $healthCheckPort | quote }}
         prometheus.io/scheme: "http"
+        {{- include "hono.podAdditionalAnnotations" $args | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -292,6 +292,10 @@ adapters:
     deployment:
       annotations: {}
 
+    pod:
+      labels: {}
+      annotations: {}
+
     # extraVolumes contains additional kubernetes Volume definitions representing volumes
     # that can mounted into the container's file system.
     # The syntax is defined in https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volume-v1-core
@@ -413,6 +417,10 @@ adapters:
     deployment:
       annotations: {}
 
+    pod:
+      labels: {}
+      annotations: {}
+
     # extraVolumes contains additional kubernetes Volume definitions representing volumes
     # that can mounted into the container's file system.
     # The syntax is defined in https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volume-v1-core
@@ -523,6 +531,10 @@ adapters:
       loadBalancerIP:
 
     deployment:
+      annotations: {}
+
+    pod:
+      labels: {}
       annotations: {}
 
     # extraVolumes contains additional kubernetes Volume definitions representing volumes
@@ -646,6 +658,10 @@ adapters:
     deployment:
       annotations: {}
 
+    pod:
+      labels: {}
+      annotations: {}
+
     # extraVolumes contains additional kubernetes Volume definitions representing volumes
     # that can mounted into the container's file system.
     # The syntax is defined in https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volume-v1-core
@@ -766,6 +782,10 @@ adapters:
     deployment:
       annotations: {}
 
+    pod:
+      labels: {}
+      annotations: {}
+
     # extraVolumes contains additional kubernetes Volume definitions representing volumes
     # that can mounted into the container's file system.
     # The syntax is defined in https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volume-v1-core
@@ -881,6 +901,10 @@ authServer:
       memory: "256Mi"
 
   deployment:
+    annotations: {}
+
+  pod:
+    labels: {}
     annotations: {}
 
   # extraVolumes contains additional kubernetes Volume definitions representing volumes
@@ -1137,6 +1161,10 @@ deviceRegistryExample:
         cpu: "1"
         memory: "500Mi"
 
+    pod:
+      labels: {}
+      annotations: {}
+
     # The configMap to get additional environment variables from for this device registry.
     envConfigMap:
 
@@ -1212,6 +1240,10 @@ deviceRegistryExample:
     deployment:
       annotations: {}
 
+    pod:
+      labels: {}
+      annotations: {}
+
   # jdbcBasedDeviceRegistry contains configuration properties specific to the
   # jdbc based device registry.
   jdbcBasedDeviceRegistry:
@@ -1264,6 +1296,10 @@ deviceRegistryExample:
     envConfigMap:
 
     deployment:
+      annotations: {}
+
+    pod:
+      labels: {}
       annotations: {}
 
     registry:
@@ -1416,6 +1452,10 @@ commandRouterService:
     annotations: {}
 
   deployment:
+    annotations: {}
+
+  pod:
+    labels: {}
     annotations: {}
 
   # extraVolumes contains additional kubernetes Volume definitions representing volumes
@@ -1969,6 +2009,10 @@ jaegerBackendExample:
   svc:
     annotations: {}
     loadBalancerIP:
+
+  pod:
+    labels: {}
+    annotations: {}
 
   # env contains environment variables to set for the Jaeger all-in-one container.
   # The default variables configure the container to keep up to 100000 traces in memory.


### PR DESCRIPTION
This PR adds the ability to add additional labels and annotations to PodSpecs in the hono chart on a per component basis.

Low level reasoning: I needed to inject connection secrets from HashiCorp Vault and the mutating webhook is triggered by adding the correct annotations.

I took the liberty to bump the chart version as well 😄 