### PR TITLE
Use Secret for nginx authentication

### DIFF
--- a/charts/ditto/Chart.yaml
+++ b/charts/ditto/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   Eclipse Ditto™ is a technology in the IoT implementing a software pattern called “digital twins”.
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
-version: 2.5.3
+version: 2.5.4
 appVersion: 2.4.0
 keywords:
   - iot-chart

--- a/charts/ditto/templates/nginx-auth.yaml
+++ b/charts/ditto/templates/nginx-auth.yaml
@@ -15,14 +15,15 @@
 {{- $labels := include "ditto.labels" . -}}
 ---
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
   name: {{ $releaseName }}-nginx-config-nginx-htpasswd
   labels:
     app.kubernetes.io/name: {{ $name }}-nginx-config
 {{ $labels | indent 4 }}
-data:
-  "nginx.htpasswd": |-
+type: Opaque
+stringData:
+  nginx.htpasswd: |-
 {{- if .Values.global.hashedBasicAuthUsers }}
 {{ range .Values.global.hashedBasicAuthUsers }}
 {{- . | indent 4 }}

--- a/charts/ditto/templates/nginx-deployment.yaml
+++ b/charts/ditto/templates/nginx-deployment.yaml
@@ -39,6 +39,7 @@ spec:
       annotations:
         checksum/nginx-conf: {{ include (print $.Template.BasePath "/nginx-configmap.yaml") . | sha256sum }}
         checksum/nginx-config: {{ include (print $.Template.BasePath "/nginx-config.yaml") . | sha256sum }}
+        checksum/nginx-auth: {{ include (print $.Template.BasePath "/nginx-auth.yaml") . | sha256sum }}
         {{- with .Values.nginx.additionalAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -109,8 +110,8 @@ spec:
           configMap:
             name: {{ .Release.Name }}-nginx-conf
         - name: nginx-htpasswd
-          configMap:
-            name: {{ .Release.Name }}-nginx-config-nginx-htpasswd
+          secret:
+            secretName: {{ .Release.Name }}-nginx-config-nginx-htpasswd
         - name: nginx-cors
           configMap:
             name: {{ .Release.Name }}-nginx-config-nginx-cors-conf


### PR DESCRIPTION
switched from kind ConfigMap to Secret for nginx-auth;
adapted nginx-deployment.yaml to use the secret instead of the configmap;
