### PR TITLE
[#396] Use Hono 2.1.0 in Hono chart

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,17 +15,18 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 2.0.7
+version: 2.1.0
 # Version of Hono being deployed by the chart
-appVersion: 2.0.1
+appVersion: 2.1.0
 keywords:
 - iot-chart
 - IoT
 - connectivity
 - messaging
+- Kafka
 home: https://www.eclipse.org/hono/
 sources:
-- https://github.com/eclipse/hono
+- https://github.com/eclipse-hono/hono
 icon: https://www.eclipse.org/hono/favicon/favicon-48x48.png
 maintainers:
 - name: dejanb

--- a/charts/hono/README.md
+++ b/charts/hono/README.md
@@ -103,6 +103,12 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Release Notes
 
+### 2.1.0
+
+* Upgraded app version to Hono 2.1.0
+* The Device Registry and the Command Router components are no longer explicitly configured with the Auth server's certificate for
+  validating tokens but instead download the required public key(s) from the Auth server during runtime via its JWK resource.
+
 ### 2.0.6
 
 * Upgraded app version to Hono 2.0.1

--- a/charts/hono/templates/hono-service-auth/hono-service-auth-svc.yaml
+++ b/charts/hono/templates/hono-service-auth/hono-service-auth-svc.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -21,5 +21,9 @@ spec:
     port: 5671
     protocol: TCP
     targetPort: amqps
+  - name: validation-keys
+    port: 8088
+    protocol: TCP
+    targetPort: health
   selector:
     {{- include "hono.matchLabels" $args | nindent 4 }}

--- a/charts/hono/templates/hono-service-command-router/hono-service-command-router-secret.yaml
+++ b/charts/hono/templates/hono-service-command-router/hono-service-command-router-secret.yaml
@@ -38,8 +38,6 @@ stringData:
         trustStorePath: "/opt/hono/tls/ca.crt"
         hostnameVerificationRequired: false
         name: {{ printf "Hono %s" $args.component | quote }}
-        validation:
-          certPath: "/opt/hono/config/auth-server-cert.pem"
         {{- end }}
       commandRouter:
         amqp:
@@ -106,5 +104,4 @@ stringData:
   {{- tpl ( .Files.Get "config/command-router/embedded-cache-config.xml" ) . | nindent 4 }}
   {{- end }}
 data:
-  auth-server-cert.pem: {{ .Files.Get "example/certs/auth-server-cert.pem" | b64enc }}
   adapter.credentials: {{ .Files.Get "example/command-router.credentials" | b64enc }}

--- a/charts/hono/templates/hono-service-device-registry-embedded/hono-service-device-registry-secret.yaml
+++ b/charts/hono/templates/hono-service-device-registry-embedded/hono-service-device-registry-secret.yaml
@@ -32,8 +32,6 @@ stringData:
         hostnameVerificationRequired: false
         name: {{ printf "Hono %s" $args.component | quote }}
         supportedSaslMechanisms: "PLAIN"
-        validation:
-          certPath: "/opt/hono/config/auth-server-cert.pem"
         connectTimeout: 2000
         {{- end }}
       registry:
@@ -78,6 +76,4 @@ stringData:
             driverClass: "org.h2.Driver"
       {{- include "hono.messagingNetworkClientConfig" ( dict "dot" . "component" $args.component "kafkaMessagingSpec" .Values.deviceRegistryExample.hono.kafka ) | nindent 6 }}
     {{- include "hono.quarkusConfig" $args | indent 4 }}
-data:
-  auth-server-cert.pem: {{ .Files.Get "example/certs/auth-server-cert.pem" | b64enc }}
 {{- end }}

--- a/charts/hono/templates/hono-service-device-registry-jdbc/hono-service-device-registry-secret.yaml
+++ b/charts/hono/templates/hono-service-device-registry-jdbc/hono-service-device-registry-secret.yaml
@@ -32,8 +32,6 @@ stringData:
         hostnameVerificationRequired: false
         name: {{ printf "Hono %s" $args.component | quote }}
         supportedSaslMechanisms: "PLAIN"
-        validation:
-          certPath: "/opt/hono/config/auth-server-cert.pem"
         connectTimeout: 2000
         {{- end }}
       registry:
@@ -72,6 +70,4 @@ stringData:
           {{- end }}
       {{- include "hono.messagingNetworkClientConfig" ( dict "dot" . "component" $args.component "kafkaMessagingSpec" .Values.deviceRegistryExample.hono.kafka ) | nindent 6 }}
     {{- include "hono.quarkusConfig" $args | indent 4 }}
-data:
-  auth-server-cert.pem: {{ .Files.Get "example/certs/auth-server-cert.pem" | b64enc }}
 {{- end }}

--- a/charts/hono/templates/hono-service-device-registry-mongodb/hono-service-device-registry-secret.yaml
+++ b/charts/hono/templates/hono-service-device-registry-mongodb/hono-service-device-registry-secret.yaml
@@ -32,8 +32,6 @@ stringData:
         hostnameVerificationRequired: false
         name: {{ printf "Hono %s" $args.component | quote }}
         supportedSaslMechanisms: "PLAIN"
-        validation:
-          certPath: "/opt/hono/config/auth-server-cert.pem"
         connectTimeout: 2000
         {{- end }}
       registry:
@@ -73,6 +71,4 @@ stringData:
         {{- end }}
       {{- include "hono.messagingNetworkClientConfig" ( dict "dot" . "component" $args.component "kafkaMessagingSpec" .Values.deviceRegistryExample.hono.kafka ) | nindent 6 }}
     {{- include "hono.quarkusConfig" $args | indent 4 }}
-data:
-  auth-server-cert.pem: {{ .Files.Get "example/certs/auth-server-cert.pem" | b64enc }}
 {{- end }}


### PR DESCRIPTION
Changed configuration so that components now dynamically retrieve
validation key(s) from Auth server instead of requiring static
configuration of Auth server's public key.

Fixes #396
