### PR TITLE
Remove "Copyright holders" section from NOTICE file

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -29,12 +29,6 @@ The project maintains the following source code repositories:
 
 * https://github.com/eclipse/packages
 
-# Copyright holders
-
-* Copyright 2019 Red Hat Inc
-* Copyright 2019 Bosch Software Innovations GmbH
-* Copyright 2019 Kiwigrid GmbH
-
 ## Third-party Content
 
 This project leverages the following third party content.


### PR DESCRIPTION
Listing all copyright holders in the NOTICE file is not necessary and entries there were incomplete and not up-to-date.

See https://gitlab.eclipse.org/eclipse/technology/dash/org.eclipse.dash.handbook/-/issues/96
and the example NOTICE file [here](https://www.eclipse.org/projects/handbook/#legaldoc-notice).