### PR TITLE
Fix high CPU usage of Ditto mongodb container

### DIFF
--- a/charts/ditto/Chart.yaml
+++ b/charts/ditto/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -16,7 +16,7 @@ description: |
   Eclipse Ditto™ is a technology in the IoT implementing a software pattern called “digital twins”.
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
-version: 2.5.6
+version: 2.5.7
 appVersion: 2.4.2
 keywords:
   - iot-chart

--- a/charts/ditto/requirements.yaml
+++ b/charts/ditto/requirements.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -13,5 +13,5 @@
 dependencies:
   - name: mongodb
     repository: https://charts.bitnami.com/bitnami
-    version: ~11.2.0
+    version: ~11.1.10
     condition: mongodb.enabled

--- a/charts/ditto/values.yaml
+++ b/charts/ditto/values.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -143,7 +143,7 @@ akka:
 
 # Set "dittoTag" in order to specify another Ditto version to use for all Ditto services:
 # you may also use "1" (for latest Ditto 1.x.x) or "1.5" (for latest Ditto 1.5.x)
-# dittoTag: 2.4.1
+# dittoTag: 2.4.2
 
 ## ----------------------------------------------------------------------------
 ## concierge configuration
@@ -169,7 +169,7 @@ concierge:
     ## repository for the concierge docker image
     repository: docker.io/eclipse/ditto-concierge
     ## tag for the concierge docker image - overwrite to specify something else than Chart.AppVersion
-    # tag: 2.4.1
+    # tag: 2.4.2
     ## pullPolicy for the concierge docker image
     pullPolicy: IfNotPresent
   ## additional JVM options to put into JAVA_TOOL_OPTIONS
@@ -255,7 +255,7 @@ connectivity:
     ## repository for the connectivity docker image
     repository: docker.io/eclipse/ditto-connectivity
     ## tag for the connectivity docker image - overwrite to specify something else than Chart.AppVersion
-    # tag: 2.4.1
+    # tag: 2.4.2
     ## pullPolicy for the connectivity docker image
     pullPolicy: IfNotPresent
   ## additional JVM options to put into JAVA_TOOL_OPTIONS
@@ -357,7 +357,7 @@ gateway:
     ## repository for the gateway docker image
     repository: docker.io/eclipse/ditto-gateway
     ## tag for the gateway docker image - overwrite to specify something else than Chart.AppVersion
-    # tag: 2.4.1
+    # tag: 2.4.2
     ## pullPolicy for the gateway docker image
     pullPolicy: IfNotPresent
   ## systemProps used to define arbitrary system properties for gateway service
@@ -514,7 +514,7 @@ policies:
     ## repository for the policies docker image
     repository: docker.io/eclipse/ditto-policies
     ## tag for the policies docker image - overwrite to specify something else than Chart.AppVersion
-    # tag: 2.4.1
+    # tag: 2.4.2
     ## pullPolicy for the policies docker image
     pullPolicy: IfNotPresent
   ## additional JVM options to put into JAVA_TOOL_OPTIONS
@@ -645,7 +645,7 @@ things:
     ## repository for the things docker image
     repository: docker.io/eclipse/ditto-things
     ## tag for the things docker image- overwrite to specify something else than Chart.AppVersion
-    # tag: 2.4.1
+    # tag: 2.4.2
     ## pullPolicy for the things docker image
     pullPolicy: IfNotPresent
   ## additional JVM options to put into JAVA_TOOL_OPTIONS
@@ -731,7 +731,7 @@ thingsSearch:
     ## repository for the things-search docker image
     repository: docker.io/eclipse/ditto-things-search
     ## tag for the things-search docker image- overwrite to specify something else than Chart.AppVersion
-    # tag: 2.4.1
+    # tag: 2.4.2
     ## pullPolicy for the things-search docker image
     pullPolicy: IfNotPresent
   ## additional JVM options to put into JAVA_TOOL_OPTIONS


### PR DESCRIPTION
When testing the cloud2edge Helm chart version with the latest Ditto chart version (using the changes from #395), I noticed that the `ditto-mongodb` pod never got ready. There were always liveness/readiness check timeouts.

The issue here seems to be, that with the MongoDB chart version 11.2.0 (see #374), there is a considerably higher consumption of CPU and also memory resources due to the usage of the MongoDB `mongosh` tool instead of `mongo` for the health probes.

This is described and tracked in https://github.com/bitnami/charts/issues/10316, https://github.com/bitnami/charts/issues/10264 and [MONGOSH-1240](https://jira.mongodb.org/browse/MONGOSH-1240).

The last chart version that doesn't show this issue is 11.1.10. It uses the same MongoDB version as the 11.2.0 chart (MongoDB 4.4.13). Therefore I think the straightforward solution for now is a downgrade to 11.1.10.


----
Here some charts showing metrics after deploying Ditto with mongoDB chart 11.2.0:
![MongoDB_11 2 0](https://user-images.githubusercontent.com/891931/189377116-aff1ca86-a2cb-4b5f-a7e9-88d39c7cb9c3.png)

And here with 11.1.10:
![MongoDB_11 1 10](https://user-images.githubusercontent.com/891931/189377271-c5fca8fa-d5fd-4668-86dc-318a8cc9f30e.png)

