### PR TITLE
Fix cloud2edge's post-install running before its deps are available

### DIFF
--- a/charts/hono/templates/hono-service-device-registry-base/hono-service-device-registry-ext-svc.yaml
+++ b/charts/hono/templates/hono-service-device-registry-base/hono-service-device-registry-ext-svc.yaml
@@ -22,6 +22,10 @@ metadata:
   {{- end }}
 spec:
   ports:
+  - name: health
+    port: 8088
+    protocol: TCP
+    targetPort: health
   - name: http
     port: 28080
     protocol: TCP

--- a/packages/cloud2edge/templates/post-install-job.yaml
+++ b/packages/cloud2edge/templates/post-install-job.yaml
@@ -36,6 +36,24 @@ spec:
         helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     spec:
       restartPolicy: Never
+      initContainers:
+        - name: "wait-for-services"
+          image: "curlimages/curl:7.68.0"
+          command:
+          - /bin/sh
+          - -c
+          - |
+            set -x
+
+            while [[ "$(curl -sL -w "%{http_code}\n" "http://{{ .Release.Name }}-service-device-registry-ext:8088/liveness" -o /dev/null)" != "200" ]]; do
+              echo '.'
+              sleep 10
+            done
+
+            while [[ "$(curl -sL -w "%{http_code}\n" "http://{{ .Release.Name }}-ditto-nginx:8080/health" -o /dev/null)" != "200" ]]; do
+              echo '.'
+              sleep 10
+            done
       containers:
       - name: "post-install"
         image: "curlimages/curl:7.68.0"


### PR DESCRIPTION
post-install runs when the chart is deployed, not when it's actually ready, so it's entirely possible for the post-install hook to try to access services that have not even started yet, resulting in a deployment failure. Instead, wait for the needed services to be ready, following the same pattern as used by the nginx-deployment template.

Signed-off-by: Ryan Gonzalez <ryan.gonzalez@collabora.com>