### PR TITLE
Fix leftover c2e usage of extraSecretMounts

### DIFF
--- a/packages/cloud2edge/templates/permissions-secret.yaml
+++ b/packages/cloud2edge/templates/permissions-secret.yaml
@@ -14,7 +14,13 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ default "permissions" .Values.hono.authServer.extraSecretMounts.permissions.secretName | quote }}
+  {{ $permissionsSecret := "permissions" }}
+  {{- range $mount := .Values.hono.authServer.extraVolumes }}
+    {{- if eq $mount.name "permissions" }}
+      {{ $permissionsSecret := $mount.secret.secretName }}
+    {{- end }}
+  {{- end }}
+  name: {{ $permissionsSecret | quote }}
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ template "c2e.name" . }}

--- a/packages/cloud2edge/values.yaml
+++ b/packages/cloud2edge/values.yaml
@@ -52,9 +52,12 @@ hono:
       limits:
         cpu: "1"
         memory: "256Mi"
-    extraSecretMounts:
-      permissions:
-        secretName: "permissions"
+    extraVolumes:
+      - name: "permissions"
+        secret:
+          secretName: "permissions"
+    extraVolumeMounts:
+      - name: "permissions"
         mountPath: "/var/run/hono/auth"
     hono:
       auth:


### PR DESCRIPTION
122aa27dd8cf5eefa6d9ea4bd9650a29bd23af54 split this out in Hono into extraVolumes & extraVolumeMounts, but cloud2edge's chart was never updated with it.

Signed-off-by: Ryan Gonzalez <ryan.gonzalez@collabora.com>