### PR TITLE
[#410] Do not set node port on Services when using LoadBalancers

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 2.1.3
+version: 2.1.4
 # Version of Hono being deployed by the chart
 appVersion: 2.1.0
 keywords:

--- a/charts/hono/templates/_helpers.tpl
+++ b/charts/hono/templates/_helpers.tpl
@@ -649,7 +649,9 @@ Adds port type declarations to a component's service spec.
 Configures NodePort on component's service spec.
 */}}
 {{- define "hono.nodePort" }}
-{{- if and (ne .dot.Values.platform "openshift") (ne (default "nil" .dot.Values.serviceType) "ClusterIP") }}
-nodePort: {{ .port  }}
+{{- if ne .dot.Values.platform "openshift" }}
+{{- if any ( eq (default "nil" .dot.Values.serviceType) "NodePort" ) ( eq .dot.Values.useLoadBalancer false ) }}
+nodePort: {{ .port }}
+{{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
The Hono service definitions had always also defined a node port unless the serviceType property had been set to "ClusterIP" explicitly.

This has been changed so that the node port is now only defined if the
 serviceType property is explicitly set to "NodePort" or if the
useLoadBalancer property is set to "false".

Fixes #410
