### PR TITLE
Update bitnami full index URL, fix Jenkins pipeline error

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -93,7 +93,9 @@ podTemplate(
 
                 stage('Helm Build') {
                     dir("build") {
+                        // adding the bitnami repo below serves as a workaround for sporadic "no cached repository" errors when packaging the hawkbit chart
                         sh '''
+                            ${WORKSPACE}/helm repo add bitnami-full https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
                             mkdir -p helm-repository
                             for i in $(ls charts/*/Chart.yaml packages/*/Chart.yaml); do
                                 echo "Building $(dirname $i) ..."

--- a/charts/hawkbit/Chart.yaml
+++ b/charts/hawkbit/Chart.yaml
@@ -10,7 +10,7 @@
 # SPDX-License-Identifier: EPL-2.0
 ---
 apiVersion: v1
-version: 1.4.1
+version: 1.4.2
 appVersion: "0.3.0M6-mysql"
 description: |
    Eclipse hawkBit™ is a domain independent back-end framework for rolling out software updates

--- a/charts/hawkbit/requirements.yaml
+++ b/charts/hawkbit/requirements.yaml
@@ -12,11 +12,11 @@
 dependencies:
   - name: mysql
     version: 6.14.10
-    # use older bitnami repo index, as referenced version is not in the current index any more (see https://github.com/bitnami/charts/issues/10539)
-    repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
+    # referenced chart version not in main bitnami index any more, therefore using the full index (see https://github.com/bitnami/charts/issues/10833)
+    repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     condition: mysql.enabled
   - name: rabbitmq
     version: 7.8.0
-    # use older bitnami repo index, as referenced version is not in the current index any more (see https://github.com/bitnami/charts/issues/10539)
-    repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
+    # referenced chart version not in main bitnami index any more, therefore using the full index (see https://github.com/bitnami/charts/issues/10833)
+    repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     condition: rabbitmq.enabled


### PR DESCRIPTION
Use recommended URL for full bitnami index in hawkbit chart.

Add workaround for errors when packaging the hawkbit chart in the Jenkins pipeline.
Errors looked like this:
```
Building charts/hawkbit ...
+ dirname charts/hawkbit/Chart.yaml
+ /home/jenkins/agent/workspace/Website_master/helm package -u charts/hawkbit -d helm-repository
Error: no cached repository for helm-manager-91b1e65e9b2f631e58d61eb3d53eb80c2121816ad48f02d75a9bdb09bf9356b2 found. (try 'helm repo update'): open /home/jenkins/agent/workspace/Website_master/helm-cache/helm/repository/helm-manager-91b1e65e9b2f631e58d61eb3d53eb80c2121816ad48f02d75a9bdb09bf9356b2-index.yaml: no such file or directory
```
(see also https://github.com/eclipse/packages/issues/372#issuecomment-1149568041)