### PR TITLE
Support creating the default c2e tenant w/o the demo device

### DIFF
--- a/packages/cloud2edge/Chart.yaml
+++ b/packages/cloud2edge/Chart.yaml
@@ -11,8 +11,8 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 apiVersion: v1
-version: 0.3.0
-appVersion: 0.3.0
+version: 0.3.1
+appVersion: 0.3.1
 name: cloud2edge
 description: |
   Eclipse IoT Cloud2Edge (C2E) is an integrated suite of services developers can use to build IoT applications

--- a/packages/cloud2edge/example-permissions.json
+++ b/packages/cloud2edge/example-permissions.json
@@ -102,19 +102,19 @@
     ],
     "application_c2e": [
       {
-        "resource": "telemetry/{{ .Values.demoDevice.tenant }}",
+        "resource": "telemetry/{{ .Values.tenant }}",
         "activities": [ "READ" ]
       },
       {
-        "resource": "event/{{ .Values.demoDevice.tenant }}",
+        "resource": "event/{{ .Values.tenant }}",
         "activities": [ "READ" ]
       },
       {
-        "resource": "command/{{ .Values.demoDevice.tenant }}",
+        "resource": "command/{{ .Values.tenant }}",
         "activities": [ "WRITE" ]
       },
       {
-        "resource": "command_response/{{ .Values.demoDevice.tenant }}/*",
+        "resource": "command_response/{{ .Values.tenant }}/*",
         "activities": [ "READ" ]
       }
     ]

--- a/packages/cloud2edge/post-install/hono-amqp-connection.json
+++ b/packages/cloud2edge/post-install/hono-amqp-connection.json
@@ -14,8 +14,8 @@
       "sources": [
         {
           "addresses": [
-            "telemetry/{{ .Values.demoDevice.tenant }}",
-            "event/{{ .Values.demoDevice.tenant }}"
+            "telemetry/{{ .Values.tenant }}",
+            "event/{{ .Values.tenant }}"
           ],
           "authorizationContext": [
             "pre-authenticated:hono-connection"
@@ -34,7 +34,7 @@
             "enabled": true,
             "address": {{ "{{ header:reply-to }}" | quote }},
             "headerMapping": {
-              "to": {{ printf "command/%s/{{ header:hono-device-id }}" .Values.demoDevice.tenant | quote }},
+              "to": {{ printf "command/%s/{{ header:hono-device-id }}" .Values.tenant | quote }},
               "subject": {{ "{{ header:subject | fn:default(topic:action-subject) | fn:default(topic:criterion) }}-response" | quote }},
               "correlation-id": {{ "{{ header:correlation-id }}" | quote }},
               "content-type": {{ "{{ header:content-type | fn:default('application/vnd.eclipse.ditto+json') }}" | quote }}
@@ -51,7 +51,7 @@
         },
         {
           "addresses": [
-            "command_response/{{ .Values.demoDevice.tenant }}/replies"
+            "command_response/{{ .Values.tenant }}/replies"
           ],
           "authorizationContext": [
             "pre-authenticated:hono-connection"
@@ -72,7 +72,7 @@
       ],
       "targets": [
         {
-          "address": "command/{{ .Values.demoDevice.tenant }}",
+          "address": "command/{{ .Values.tenant }}",
           "authorizationContext": [
             "pre-authenticated:hono-connection"
           ],
@@ -81,15 +81,15 @@
             "_/_/things/live/messages"
           ],
           "headerMapping": {
-            "to": {{ printf "command/%s/{{ thing:id }}" .Values.demoDevice.tenant | quote }},
+            "to": {{ printf "command/%s/{{ thing:id }}" .Values.tenant | quote }},
             "subject": {{ "{{ header:subject | fn:default(topic:action-subject) }}" | quote }},
             "content-type": {{ "{{ header:content-type | fn:default('application/vnd.eclipse.ditto+json') }}" | quote }},
             "correlation-id": {{ "{{ header:correlation-id }}" | quote }},
-            "reply-to": {{ printf "{{ fn:default('command_response/%s/replies') | fn:filter(header:response-required,'ne','false') }}" .Values.demoDevice.tenant | quote }}
+            "reply-to": {{ printf "{{ fn:default('command_response/%s/replies') | fn:filter(header:response-required,'ne','false') }}" .Values.tenant | quote }}
           }
         },
         {
-          "address": "command/{{ .Values.demoDevice.tenant }}",
+          "address": "command/{{ .Values.tenant }}",
           "authorizationContext": [
             "pre-authenticated:hono-connection"
           ],
@@ -98,7 +98,7 @@
             "_/_/things/live/events"
           ],
           "headerMapping": {
-            "to": {{ printf "command/%s/{{ thing:id }}" .Values.demoDevice.tenant | quote }},
+            "to": {{ printf "command/%s/{{ thing:id }}" .Values.tenant | quote }},
             "subject": {{ "{{ header:subject | fn:default(topic:action-subject) }}" | quote }},
             "content-type": {{ "{{ header:content-type | fn:default('application/vnd.eclipse.ditto+json') }}" | quote }},
             "correlation-id": {{ "{{ header:correlation-id }}" | quote }}

--- a/packages/cloud2edge/post-install/hono-kafka-connection.json
+++ b/packages/cloud2edge/post-install/hono-kafka-connection.json
@@ -20,7 +20,7 @@
       "sources": [
         {
           "addresses": [
-            "hono.telemetry.{{ .Values.demoDevice.tenant }}"
+            "hono.telemetry.{{ .Values.tenant }}"
           ],
           "consumerCount": 1,
           "authorizationContext": [
@@ -37,7 +37,7 @@
           "payloadMapping": [],
           "replyTarget": {
             "enabled": true,
-            "address": {{ printf "hono.command.%s/{{ thing:id }}" .Values.demoDevice.tenant | quote }},
+            "address": {{ printf "hono.command.%s/{{ thing:id }}" .Values.tenant | quote }},
             "headerMapping": {
               "device_id": {{ "{{ thing:id }}" | quote }},
               "subject": {{ "{{ header:subject | fn:default(topic:action-subject) | fn:default(topic:criterion) }}-response" | quote }},
@@ -56,7 +56,7 @@
         },
         {
           "addresses": [
-            "hono.event.{{ .Values.demoDevice.tenant }}"
+            "hono.event.{{ .Values.tenant }}"
           ],
           "consumerCount": 1,
           "authorizationContext": [
@@ -73,7 +73,7 @@
           "payloadMapping": [],
           "replyTarget": {
             "enabled": true,
-            "address": {{ printf "hono.command.%s/{{ thing:id }}" .Values.demoDevice.tenant | quote }},
+            "address": {{ printf "hono.command.%s/{{ thing:id }}" .Values.tenant | quote }},
             "headerMapping": {
               "device_id": {{ "{{ thing:id }}" | quote }},
               "subject": {{ "{{ header:subject | fn:default(topic:action-subject) | fn:default(topic:criterion) }}-response" | quote }},
@@ -91,7 +91,7 @@
         },
         {
           "addresses": [
-            "hono.command_response.{{ .Values.demoDevice.tenant }}"
+            "hono.command_response.{{ .Values.tenant }}"
           ],
           "consumerCount": 1,
           "authorizationContext": [
@@ -125,7 +125,7 @@
       ],
       "targets": [
         {
-          "address": {{ printf "hono.command.%s/{{ thing:id }}" .Values.demoDevice.tenant | quote }},
+          "address": {{ printf "hono.command.%s/{{ thing:id }}" .Values.tenant | quote }},
           "authorizationContext": [
             "pre-authenticated:hono-connection"
           ],
@@ -141,7 +141,7 @@
           ]
         },
         {
-          "address": {{ printf "hono.command.%s/{{thing:id}}" .Values.demoDevice.tenant | quote }},
+          "address": {{ printf "hono.command.%s/{{thing:id}}" .Values.tenant | quote }},
           "authorizationContext": [
             "pre-authenticated:hono-connection"
           ],
@@ -165,7 +165,7 @@
         "saslMechanism": "{{ (or (index $kafka "sasl.mechanism") "PLAIN") | lower }}",
         "bootstrapServers": "{{ index $kafka "bootstrap.servers" }}",
         {{- end }}
-        "groupId": {{ printf "%s_{{ connection:id }}" .Values.demoDevice.tenant | quote }}
+        "groupId": {{ printf "%s_{{ connection:id }}" .Values.tenant | quote }}
       },
       "clientCount": 1,
       "failoverEnabled": true,

--- a/packages/cloud2edge/templates/post-install-job.yaml
+++ b/packages/cloud2edge/templates/post-install-job.yaml
@@ -45,11 +45,14 @@ spec:
         - "curlHome=/home/curl_user
           PWD=$(cat /var/run/c2e/ditto-gw-users/devops-password) &&
           curl -X POST -H 'Content-Type: application/json' --data '{}'
-          {{ printf "http://%s-service-device-registry-ext:28080/v1/tenants/%s" .Release.Name .Values.demoDevice.tenant }} &&
+          {{ printf "http://%s-service-device-registry-ext:28080/v1/tenants/%s" .Release.Name .Values.tenant }} &&
+
+          {{- if .Values.demoDevice.enabled }}
           curl -X POST -H 'Content-Type: application/json' --data '{}'
-          {{ printf "http://%s-service-device-registry-ext:28080/v1/devices/%s/%s:%s" .Release.Name .Values.demoDevice.tenant .Values.demoDevice.tenant .Values.demoDevice.deviceId }} &&
+          {{ printf "http://%s-service-device-registry-ext:28080/v1/devices/%s/%s:%s" .Release.Name .Values.tenant .Values.tenant .Values.demoDevice.deviceId }} &&
           curl -X PUT -H 'Content-Type: application/json' --data-binary @/var/run/c2e/post-install-data/demo-device-credentials.json
-          {{ printf "http://%s-service-device-registry-ext:28080/v1/credentials/%s/%s:%s" .Release.Name .Values.demoDevice.tenant .Values.demoDevice.tenant .Values.demoDevice.deviceId }} &&
+          {{ printf "http://%s-service-device-registry-ext:28080/v1/credentials/%s/%s:%s" .Release.Name .Values.tenant .Values.tenant .Values.demoDevice.deviceId }} &&
+          {{- end }}
 
           {{- if ( has "amqp" .Values.hono.messagingNetworkTypes ) }}
           curl -X POST -u devops:$PWD -H 'Content-Type: application/json' --data-binary @/var/run/c2e/post-install-data/hono-amqp-connection.json
@@ -65,8 +68,12 @@ spec:
           {{ printf "http://%s-ditto-nginx:8080/devops/piggyback/connectivity" .Release.Name }} &&
           {{- end }}
 
+          {{- if .Values.demoDevice.enabled }}
           curl -X PUT -u ditto:ditto -H 'Content-Type: application/json' --data-binary @/var/run/c2e/post-install-data/demo-device-thing.json
-          {{ printf "http://%s-ditto-nginx:8080/api/2/things/%s:%s" .Release.Name .Values.demoDevice.tenant .Values.demoDevice.deviceId }};"
+          {{ printf "http://%s-ditto-nginx:8080/api/2/things/%s:%s" .Release.Name .Values.tenant .Values.demoDevice.deviceId }} &&
+          {{- end }}
+
+          true;"
         volumeMounts:
         - name: post-install-data
           mountPath: "/var/run/c2e/post-install-data"

--- a/packages/cloud2edge/values.yaml
+++ b/packages/cloud2edge/values.yaml
@@ -11,8 +11,9 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
+tenant: "org.eclipse.packages.c2e"
 demoDevice:
-  tenant: "org.eclipse.packages.c2e"
+  enabled: true
   deviceId: "demo-device"
   password: "demo-secret"
 


### PR DESCRIPTION
This is useful for having a default tenant available for testing purposes without also having a demo device & credentials registered.

Signed-off-by: Ryan Gonzalez <ryan.gonzalez@collabora.com>