### PR TITLE
update cloud2edge chart with ditto 3.0.0

### DIFF
--- a/packages/cloud2edge/Chart.yaml
+++ b/packages/cloud2edge/Chart.yaml
@@ -11,8 +11,8 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 apiVersion: v1
-version: 0.3.0
-appVersion: 0.3.0
+version: 0.4.0
+appVersion: 0.4.0
 name: cloud2edge
 description: |
   Eclipse IoT Cloud2Edge (C2E) is an integrated suite of services developers can use to build IoT applications

--- a/packages/cloud2edge/requirements.yaml
+++ b/packages/cloud2edge/requirements.yaml
@@ -15,5 +15,5 @@ dependencies:
     version: ^2.1.0
     repository: "https://eclipse.org/packages/charts/"
   - name: ditto
-    version: ~2.5.8
+    version: ~3.0.0
     repository: "https://eclipse.org/packages/charts/"

--- a/packages/cloud2edge/templates/NOTES.txt
+++ b/packages/cloud2edge/templates/NOTES.txt
@@ -2,7 +2,7 @@ Thank you for installing the Cloud2Edge Eclipse IoT Package.
 
 Your release is named '{{ .Release.Name }}'.
 
-It might take some time for all of the package's services to start up.
+It might take some time for all the package's services to start up.
 You can check the current status by issuing the following command:
 {{ if ( eq .Release.Namespace "default" ) }}
   $ kubectl get pods
@@ -18,7 +18,6 @@ NAME                                         {{ "READY   STATUS    RESTARTS   AG
 {{ .Release.Name }}-adapter-mqtt-765fcd578b-5rl7n               1/1     Running   0          3m15s
 {{ .Release.Name }}-artemis-f8f7dc7f4-864cj                     1/1     Running   0          3m15s
 {{ .Release.Name }}-dispatch-router-6c77dc78bd-hjn4l            1/1     Running   0          3m15s
-{{ .Release.Name }}-ditto-concierge-5949cb449d-46vp5            1/1     Running   0          3m15s
 {{ .Release.Name }}-ditto-connectivity-779fc6f574-gd5gq         1/1     Running   0          3m15s
 {{ .Release.Name }}-ditto-gateway-5cfdc9f9fc-kl6mh              1/1     Running   0          3m15s
 {{ .Release.Name }}-ditto-nginx-864cffd948-mvcdg                1/1     Running   0          3m15s

--- a/packages/cloud2edge/values.yaml
+++ b/packages/cloud2edge/values.yaml
@@ -110,13 +110,6 @@ hono:
 ditto:
   # do not set cpu limits for Ditto to avoid CFS scheduler limits
   # ref: https://doc.akka.io/docs/akka/snapshot/additional/deploy.html#in-kubernetes
-  concierge:
-    resources:
-      requests:
-        cpu: 200m
-      limits:
-        memory: "768Mi"
-
   connectivity:
     resources:
       requests:

--- a/packages/telemetry-e2e/values.yaml
+++ b/packages/telemetry-e2e/values.yaml
@@ -116,14 +116,6 @@ drogueCloud:
 ditto:
   fullnameOverride: ditto
 
-  concierge:
-    resources:
-      requests:
-        cpu: "100m"
-        memory: 256Mi
-      limits:
-        cpu: "1"
-        memory: 384Mi
   connectivity:
     resources:
       requests:


### PR DESCRIPTION
 - removed all concierge mentions as per the ditto 3.0.0 introduction
 - increased the respective versions in Chart.yaml and requirements.yaml

Signed-off-by: Kalin Kostashki <kalin.kostashki@bosch.io>