### PR TITLE
Fixed Grafana dashboards to work with new metrics

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 2.3.0
+version: 2.3.1
 # Version of Hono being deployed by the chart
 appVersion: 2.3.0
 keywords:

--- a/charts/hono/README.md
+++ b/charts/hono/README.md
@@ -103,6 +103,10 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Release Notes
 
+### 2.3.1
+
+* Update to Grafana Dashboard to work with the new metrics
+
 ### 2.3.0
 
 * Use Hono 2.3.0 container images.

--- a/charts/hono/config/grafana/dashboard-definitions/message-details.json
+++ b/charts/hono/config/grafana/dashboard-definitions/message-details.json
@@ -57,7 +57,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(hono_messages_received_seconds_count{status=\"forwarded\",component_name=~\"$componentname\",type=~\"$type\",tenant=~\"$tenant\",host=~\"$instance\"}[$__range]))",
+          "expr": "sum(irate(hono_telemetry_processing_duration_seconds_count{status=\"forwarded\",component_name=~\"$componentname\",type=~\"$type\",tenant=~\"$tenant\",host=~\"$instance\"}[$__range]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -166,7 +166,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(rate(hono_messages_received_seconds_count{status=\"forwarded\",component_name=~\"$componentname\",type=~\"$type\",tenant=~\"$tenant\",host=~\"$instance\"}[$__rate_interval]))",
+          "expr": "sum(rate(hono_telemetry_processing_duration_seconds_count{status=\"forwarded\",component_name=~\"$componentname\",type=~\"$type\",tenant=~\"$tenant\",host=~\"$instance\"}[$__rate_interval]))",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -247,7 +247,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(rate(hono_messages_received_seconds_count{status=\"forwarded\",component_name=~\"$componentname\",type=~\"$type\",tenant=~\"$tenant\",host=~\"$instance\"}[$__rate_interval]))",
+          "expr": "sum(rate(hono_telemetry_processing_duration_seconds_count{status=\"forwarded\",component_name=~\"$componentname\",type=~\"$type\",tenant=~\"$tenant\",host=~\"$instance\"}[$__rate_interval]))",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -328,7 +328,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(rate(hono_messages_received_seconds_count{status=\"forwarded\",component_name=~\"$componentname\",type=~\"$type\",tenant=~\"$tenant\",host=~\"$instance\"}[$__rate_interval]))",
+          "expr": "sum(rate(hono_telemetry_processing_duration_seconds_count{status=\"forwarded\",component_name=~\"$componentname\",type=~\"$type\",tenant=~\"$tenant\",host=~\"$instance\"}[$__rate_interval]))",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -387,21 +387,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(hono_messages_payload_bytes_sum{component_name=~\"$componentname\",type=~\"$type\",status=\"forwarded\",tenant=~\"$tenant\",host=~\"$instance\"}[$__range]))",
+          "expr": "sum(irate(hono_telemetry_payload_bytes_sum{component_name=~\"$componentname\",type=~\"$type\",status=\"forwarded\",tenant=~\"$tenant\",host=~\"$instance\"}[$__range]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "forwarded",
           "refId": "A"
         },
         {
-          "expr": "sum(irate(hono_messages_payload_bytes_sum{component_name=~\"$componentname\",type=~\"$type\",status=\"undeliverable\",tenant=~\"$tenant\",host=~\"$instance\"}[$__range]))",
+          "expr": "sum(irate(hono_telemetry_payload_bytes_sum{component_name=~\"$componentname\",type=~\"$type\",status=\"undeliverable\",tenant=~\"$tenant\",host=~\"$instance\"}[$__range]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "undeliverable",
           "refId": "B"
         },
         {
-          "expr": "sum(irate(hono_messages_payload_bytes_sum{component_name=~\"$componentname\",type=~\"$type\",status=\"unprocessable\",tenant=~\"$tenant\",host=~\"$instance\"}[$__range]))",
+          "expr": "sum(irate(hono_telemetry_payload_bytes_sum{component_name=~\"$componentname\",type=~\"$type\",status=\"unprocessable\",tenant=~\"$tenant\",host=~\"$instance\"}[$__range]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "unprocessable",
@@ -509,7 +509,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(rate(hono_messages_payload_bytes_sum{component_name=~\"$componentname\",type=~\"$type\",tenant=~\"$tenant\",host=~\"$instance\"}[$__rate_interval]))",
+          "expr": "sum(rate(hono_telemetry_payload_bytes_sum{component_name=~\"$componentname\",type=~\"$type\",tenant=~\"$tenant\",host=~\"$instance\"}[$__rate_interval]))",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -590,7 +590,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(rate(hono_messages_payload_bytes_sum{component_name=~\"$componentname\",type=~\"$type\",tenant=~\"$tenant\",host=~\"$instance\"}[$__rate_interval]))",
+          "expr": "sum(rate(hono_telemetry_payload_bytes_sum{component_name=~\"$componentname\",type=~\"$type\",tenant=~\"$tenant\",host=~\"$instance\"}[$__rate_interval]))",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -671,7 +671,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(rate(hono_messages_payload_bytes_sum{component_name=~\"$componentname\",type=~\"$type\",tenant=~\"$tenant\",host=~\"$instance\"}[$__rate_interval]))",
+          "expr": "sum(rate(hono_telemetry_payload_bytes_sum{component_name=~\"$componentname\",type=~\"$type\",tenant=~\"$tenant\",host=~\"$instance\"}[$__rate_interval]))",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -730,14 +730,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(hono_messages_received_seconds_count{component_name=~\"$componentname\",type=~\"$type\",status=\"undeliverable\",tenant=~\"$tenant\",host=~\"$instance\"}[$__range]))",
+          "expr": "sum(irate(hono_telemetry_processing_duration_seconds_count{component_name=~\"$componentname\",type=~\"$type\",status=\"undeliverable\",tenant=~\"$tenant\",host=~\"$instance\"}[$__range]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "undeliverable",
           "refId": "A"
         },
         {
-          "expr": "sum(irate(hono_messages_received_seconds_count{component_name=~\"$componentname\",type=~\"$type\",status=\"unprocessable\",tenant=~\"$tenant\",host=~\"$instance\"}[$__range]))",
+          "expr": "sum(irate(hono_telemetry_processing_duration_seconds_count{component_name=~\"$componentname\",type=~\"$type\",status=\"unprocessable\",tenant=~\"$tenant\",host=~\"$instance\"}[$__range]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "unprocessable",
@@ -846,7 +846,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "(sum(rate(hono_messages_received_seconds_count{component_name=~\"$componentname\",type=~\"$type\",status!=\"forwarded\",tenant=~\"$tenant\",host=~\"$instance\"}[$__rate_interval]))\n/\n sum(rate(hono_messages_received_seconds_count{component_name=~\"$componentname\",type=~\"$type\",tenant=~\"$tenant\",host=~\"$instance\"}[$__rate_interval])))\n* 100\n",
+          "expr": "(sum(rate(hono_telemetry_processing_duration_seconds_count{component_name=~\"$componentname\",type=~\"$type\",status!=\"forwarded\",tenant=~\"$tenant\",host=~\"$instance\"}[$__rate_interval]))\n/\n sum(rate(hono_telemetry_processing_duration_seconds_count{component_name=~\"$componentname\",type=~\"$type\",tenant=~\"$tenant\",host=~\"$instance\"}[$__rate_interval])))\n* 100\n",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -889,7 +889,7 @@
         "multi": true,
         "name": "componentname",
         "options": [],
-        "query": "label_values(hono_messages_received_seconds_count,component_name)",
+        "query": "label_values(hono_telemetry_processing_duration_seconds_count,component_name)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -934,7 +934,7 @@
         "multi": true,
         "name": "type",
         "options": [],
-        "query": "label_values(hono_messages_received_seconds_count,type)",
+        "query": "label_values(hono_telemetry_processing_duration_seconds_count,type)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -960,7 +960,7 @@
         "multi": true,
         "name": "instance",
         "options": [],
-        "query": "label_values(hono_messages_received_seconds_count,host)",
+        "query": "label_values(hono_telemetry_processing_duration_seconds_count,host)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,

--- a/charts/hono/config/grafana/dashboard-definitions/overview.json
+++ b/charts/hono/config/grafana/dashboard-definitions/overview.json
@@ -139,21 +139,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(hono_messages_received_seconds_count{type=\"telemetry\",status=\"unprocessable\"}[$__rate_interval]))",
+          "expr": "sum(irate(hono_telemetry_processing_duration_seconds_count{type=\"telemetry\",status=\"unprocessable\"}[$__rate_interval]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "unprocessable",
           "refId": "C"
         },
         {
-          "expr": "sum(irate(hono_messages_received_seconds_count{type=\"telemetry\",status=\"undeliverable\"}[$__rate_interval]))",
+          "expr": "sum(irate(hono_telemetry_processing_duration_seconds_count{type=\"telemetry\",status=\"undeliverable\"}[$__rate_interval]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "undeliverable",
           "refId": "B"
         },
         {
-          "expr": "sum(irate(hono_messages_received_seconds_count{type=\"telemetry\",status=\"forwarded\"}[$__rate_interval]))",
+          "expr": "sum(irate(hono_telemetry_processing_duration_seconds_count{type=\"telemetry\",status=\"forwarded\"}[$__rate_interval]))",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -263,21 +263,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(hono_messages_received_seconds_count{type=\"event\",status=\"unprocessable\"}[$__rate_interval]))",
+          "expr": "sum(irate(hono_telemetry_processing_duration_seconds_count{type=\"event\",status=\"unprocessable\"}[$__rate_interval]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "unprocessable",
           "refId": "C"
         },
         {
-          "expr": "sum(irate(hono_messages_received_seconds_count{type=\"event\",status=\"undeliverable\"}[$__rate_interval]))",
+          "expr": "sum(irate(hono_telemetry_processing_duration_seconds_count{type=\"event\",status=\"undeliverable\"}[$__rate_interval]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "undeliverable",
           "refId": "B"
         },
         {
-          "expr": "sum(irate(hono_messages_received_seconds_count{type=\"event\",status=\"forwarded\"}[$__rate_interval]))",
+          "expr": "sum(irate(hono_telemetry_processing_duration_seconds_count{type=\"event\",status=\"forwarded\"}[$__rate_interval]))",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -367,7 +367,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(hono_commands_received_seconds_count{direction=~\"one-way|request\",status=\"unprocessable\"}[$__rate_interval]))",
+          "expr": "sum(irate(hono_command_processing_duration_seconds_count{direction=~\"one-way|request\",status=\"unprocessable\"}[$__rate_interval]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -375,7 +375,7 @@
           "refId": "C"
         },
         {
-          "expr": "sum(irate(hono_commands_received_seconds_count{direction=~\"one-way|request\",status=\"undeliverable\"}[$__rate_interval]))",
+          "expr": "sum(irate(hono_command_processing_duration_seconds_count{direction=~\"one-way|request\",status=\"undeliverable\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -384,7 +384,7 @@
           "refId": "B"
         },
         {
-          "expr": "sum(irate(hono_commands_received_seconds_count{direction=~\"one-way|request\",status=\"forwarded\"}[$__rate_interval]))",
+          "expr": "sum(irate(hono_command_processing_duration_seconds_count{direction=~\"one-way|request\",status=\"forwarded\"}[$__rate_interval]))",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -473,21 +473,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(hono_messages_payload_bytes_sum{type=\"telemetry\",status=\"unprocessable\"}[$__rate_interval]))",
+          "expr": "sum(irate(hono_telemetry_payload_bytes_sum{type=\"telemetry\",status=\"unprocessable\"}[$__rate_interval]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "unprocessable",
           "refId": "C"
         },
         {
-          "expr": "sum(irate(hono_messages_payload_bytes_sum{type=\"telemetry\",status=\"undeliverable\"}[$__rate_interval]))",
+          "expr": "sum(irate(hono_telemetry_payload_bytes_sum{type=\"telemetry\",status=\"undeliverable\"}[$__rate_interval]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "undeliverable",
           "refId": "B"
         },
         {
-          "expr": "sum(irate(hono_messages_payload_bytes_sum{type=\"telemetry\",status=\"forwarded\"}[$__rate_interval]))",
+          "expr": "sum(irate(hono_telemetry_payload_bytes_sum{type=\"telemetry\",status=\"forwarded\"}[$__rate_interval]))",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -575,21 +575,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(hono_messages_payload_bytes_sum{type=\"event\",status=\"unprocessable\"}[$__rate_interval]))",
+          "expr": "sum(irate(hono_telemetry_payload_bytes_sum{type=\"event\",status=\"unprocessable\"}[$__rate_interval]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "unprocessable",
           "refId": "C"
         },
         {
-          "expr": "sum(irate(hono_messages_payload_bytes_sum{type=\"event\",status=\"undeliverable\"}[$__rate_interval]))",
+          "expr": "sum(irate(hono_telemetry_payload_bytes_sum{type=\"event\",status=\"undeliverable\"}[$__rate_interval]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "undeliverable",
           "refId": "B"
         },
         {
-          "expr": "sum(irate(hono_messages_payload_bytes_sum{type=\"event\",status=\"forwarded\"}[$__rate_interval]))",
+          "expr": "sum(irate(hono_telemetry_payload_bytes_sum{type=\"event\",status=\"forwarded\"}[$__rate_interval]))",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -679,21 +679,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(hono_commands_payload_bytes_sum{direction=~\"one-way|request\",status=\"unprocessable\"}[$__rate_interval]))",
+          "expr": "sum(irate(hono_command_payload_bytes_sum{direction=~\"one-way|request\",status=\"unprocessable\"}[$__rate_interval]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "unprocessable",
           "refId": "C"
         },
         {
-          "expr": "sum(irate(hono_commands_payload_bytes_sum{direction=~\"one-way|request\",status=\"undeliverable\"}[$__rate_interval]))",
+          "expr": "sum(irate(hono_command_payload_bytes_sum{direction=~\"one-way|request\",status=\"undeliverable\"}[$__rate_interval]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "undeliverable",
           "refId": "B"
         },
         {
-          "expr": "sum(irate(hono_commands_payload_bytes_sum{direction=~\"one-way|request\",status=\"forwarded\"}[$__rate_interval]))",
+          "expr": "sum(irate(hono_command_payload_bytes_sum{direction=~\"one-way|request\",status=\"forwarded\"}[$__rate_interval]))",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -781,14 +781,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "(100 * sum(irate(hono_messages_received_seconds_count{type=\"telemetry\",qos=\"0\",status=\"undeliverable\"}[$__rate_interval])))\n/\nsum(irate(hono_messages_received_seconds_count{type=\"telemetry\",qos=\"0\"}[$__rate_interval]))",
+          "expr": "(100 * sum(irate(hono_telemetry_processing_duration_seconds_count{type=\"telemetry\",qos=\"0\",status=\"undeliverable\"}[$__rate_interval])))\n/\nsum(irate(hono_telemetry_processing_duration_seconds_count{type=\"telemetry\",qos=\"0\"}[$__rate_interval]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "QoS 0",
           "refId": "C"
         },
         {
-          "expr": "(100 * sum(irate(hono_messages_received_seconds_count{type=\"telemetry\",qos=\"1\",status=\"undeliverable\"}[$__rate_interval])))\n/\nsum(irate(hono_messages_received_seconds_count{type=\"telemetry\",qos=\"1\"}[$__rate_interval]))",
+          "expr": "(100 * sum(irate(hono_telemetry_processing_duration_seconds_count{type=\"telemetry\",qos=\"1\",status=\"undeliverable\"}[$__rate_interval])))\n/\nsum(irate(hono_telemetry_processing_duration_seconds_count{type=\"telemetry\",qos=\"1\"}[$__rate_interval]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "QoS 1",
@@ -892,7 +892,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "(100 * sum(irate(hono_messages_received_seconds_count{type=\"event\",status=\"undeliverable\"}[$__rate_interval])))\n/\nsum(irate(hono_messages_received_seconds_count{type=\"event\"}[$__rate_interval]))",
+          "expr": "(100 * sum(irate(hono_telemetry_processing_duration_seconds_count{type=\"event\",status=\"undeliverable\"}[$__rate_interval])))\n/\nsum(irate(hono_telemetry_processing_duration_seconds_count{type=\"event\"}[$__rate_interval]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "not forwarded",
@@ -996,7 +996,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "(100 * sum(irate(hono_commands_received_seconds_count{direction=~\"one-way|request\",status=\"undeliverable\"}[$__rate_interval])))\n/\nsum(irate(hono_commands_received_seconds_count{direction=~\"one-way|request\"}[$__rate_interval]))",
+          "expr": "(100 * sum(irate(hono_command_processing_duration_seconds_count{direction=~\"one-way|request\",status=\"undeliverable\"}[$__rate_interval])))\n/\nsum(irate(hono_command_processing_duration_seconds_count{direction=~\"one-way|request\"}[$__rate_interval]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "not forwarded",


### PR DESCRIPTION
Dashboards on grafana are not working because old metrics are used. This PR will fix it.

Mostly it was replacement of
_hono_messages_received_seconds_count_ =>
_hono_telemetry_processing_duration_seconds_count_

_hono_messages_payload_bytes_sum_ =>
_hono_telemetry_payload_bytes_sum_

_hono_commands_received_seconds_count_ =>
_hono_command_processing_duration_seconds_count_

_hono_commands_payload_bytes_sum_ =>
_hono_command_payload_bytes_sum_

<img width="2472" alt="Screenshot 2023-03-03 at 08 53 21" src="https://user-images.githubusercontent.com/46897537/222663320-6278e566-c07e-45ef-893a-b629340e5a30.png">
<img width="2493" alt="Screenshot 2023-03-03 at 08 53 41" src="https://user-images.githubusercontent.com/46897537/222663327-99d185e0-2d92-4f04-af82-43e2a24b81c2.png">
