### PR TITLE
Align secretKeyRef with gateway-deployment.yaml

### DIFF
--- a/charts/ditto/templates/connectivity-deployment.yaml
+++ b/charts/ditto/templates/connectivity-deployment.yaml
@@ -107,7 +107,7 @@ spec:
             - name: MONGO_DB_URI
               valueFrom:
                 secretKeyRef:
-                  name: {{ if .Values.dbconfig.uriSecret }}{{ .Values.dbconfig.uriSecret }}{{ else }}{{ include "ditto.fullname" . }}-mongodb-secret{{ end }}
+                  name: {{ .Values.dbconfig.uriSecret | default ( printf "%s-mongodb-secret" (include "ditto.fullname" . )) }}
                   key: connectivity-uri
             {{- if .Values.global.prometheus.enabled }}
             - name: PROMETHEUS_PORT

--- a/charts/ditto/templates/policies-deployment.yaml
+++ b/charts/ditto/templates/policies-deployment.yaml
@@ -107,7 +107,7 @@ spec:
             - name: MONGO_DB_URI
               valueFrom:
                 secretKeyRef:
-                  name: {{ if .Values.dbconfig.uriSecret }}{{ .Values.dbconfig.uriSecret }}{{ else }}{{ include "ditto.fullname" . }}-mongodb-secret{{ end }}
+                  name: {{ .Values.dbconfig.uriSecret | default ( printf "%s-mongodb-secret" (include "ditto.fullname" . )) }}
                   key: policies-uri
             {{- if .Values.global.prometheus.enabled }}
             - name: PROMETHEUS_PORT

--- a/charts/ditto/templates/things-deployment.yaml
+++ b/charts/ditto/templates/things-deployment.yaml
@@ -107,7 +107,7 @@ spec:
             - name: MONGO_DB_URI
               valueFrom:
                 secretKeyRef:
-                  name: {{ if .Values.dbconfig.uriSecret }}{{ .Values.dbconfig.uriSecret }}{{ else }}{{ include "ditto.fullname" . }}-mongodb-secret{{ end }}
+                  name: {{ .Values.dbconfig.uriSecret | default ( printf "%s-mongodb-secret" (include "ditto.fullname" . )) }}
                   key: things-uri
             {{- if .Values.global.prometheus.enabled }}
             - name: PROMETHEUS_PORT

--- a/charts/ditto/templates/thingssearch-deployment.yaml
+++ b/charts/ditto/templates/thingssearch-deployment.yaml
@@ -107,7 +107,7 @@ spec:
             - name: MONGO_DB_URI
               valueFrom:
                 secretKeyRef:
-                  name: {{ if .Values.dbconfig.uriSecret }}{{ .Values.dbconfig.uriSecret }}{{ else }}{{ include "ditto.fullname" . }}-mongodb-secret{{ end }}
+                  name: {{ .Values.dbconfig.uriSecret | default ( printf "%s-mongodb-secret" (include "ditto.fullname" . )) }}
                   key: searchDB-uri
             {{- if .Values.global.prometheus.enabled }}
             - name: PROMETHEUS_PORT


### PR DESCRIPTION
secretKeyRef.name entry was composed differently in various deployments. It has been aligned for greater readability.