### PR TITLE
Align secretKeyRef.name with gateway-deployment

### DIFF
--- a/charts/ditto/Chart.yaml
+++ b/charts/ditto/Chart.yaml
@@ -17,7 +17,7 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 3.2.0
+version: 3.2.1
 appVersion: 3.2.0
 keywords:
 - iot-chart

--- a/charts/ditto/templates/connectivity-deployment.yaml
+++ b/charts/ditto/templates/connectivity-deployment.yaml
@@ -107,7 +107,7 @@ spec:
             - name: MONGO_DB_URI
               valueFrom:
                 secretKeyRef:
-                  name: {{ if .Values.dbconfig.uriSecret }}{{ .Values.dbconfig.uriSecret }}{{ else }}{{ include "ditto.fullname" . }}-mongodb-secret{{ end }}
+                  name: {{ .Values.dbconfig.uriSecret | default ( printf "%s-mongodb-secret" ( include "ditto.fullname" . )) }}
                   key: connectivity-uri
             {{- if .Values.global.prometheus.enabled }}
             - name: PROMETHEUS_PORT

--- a/charts/ditto/templates/policies-deployment.yaml
+++ b/charts/ditto/templates/policies-deployment.yaml
@@ -107,7 +107,7 @@ spec:
             - name: MONGO_DB_URI
               valueFrom:
                 secretKeyRef:
-                  name: {{ if .Values.dbconfig.uriSecret }}{{ .Values.dbconfig.uriSecret }}{{ else }}{{ include "ditto.fullname" . }}-mongodb-secret{{ end }}
+                  name: {{ .Values.dbconfig.uriSecret | default ( printf "%s-mongodb-secret" ( include "ditto.fullname" . )) }}
                   key: policies-uri
             {{- if .Values.global.prometheus.enabled }}
             - name: PROMETHEUS_PORT

--- a/charts/ditto/templates/things-deployment.yaml
+++ b/charts/ditto/templates/things-deployment.yaml
@@ -107,7 +107,7 @@ spec:
             - name: MONGO_DB_URI
               valueFrom:
                 secretKeyRef:
-                  name: {{ if .Values.dbconfig.uriSecret }}{{ .Values.dbconfig.uriSecret }}{{ else }}{{ include "ditto.fullname" . }}-mongodb-secret{{ end }}
+                  name: {{ .Values.dbconfig.uriSecret | default ( printf "%s-mongodb-secret" ( include "ditto.fullname" . )) }}
                   key: things-uri
             {{- if .Values.global.prometheus.enabled }}
             - name: PROMETHEUS_PORT

--- a/charts/ditto/templates/thingssearch-deployment.yaml
+++ b/charts/ditto/templates/thingssearch-deployment.yaml
@@ -107,7 +107,7 @@ spec:
             - name: MONGO_DB_URI
               valueFrom:
                 secretKeyRef:
-                  name: {{ if .Values.dbconfig.uriSecret }}{{ .Values.dbconfig.uriSecret }}{{ else }}{{ include "ditto.fullname" . }}-mongodb-secret{{ end }}
+                  name: {{ .Values.dbconfig.uriSecret | default ( printf "%s-mongodb-secret" ( include "ditto.fullname" . )) }}
                   key: searchDB-uri
             {{- if .Values.global.prometheus.enabled }}
             - name: PROMETHEUS_PORT


### PR DESCRIPTION
The secretKeyRef.name entry was composed differently in various deployments. It has been aligned for greater readability.