### PR TITLE
Support disabling insecure ports

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 2.3.2
+version: 2.4.0
 # Version of Hono being deployed by the chart
 appVersion: 2.3.0
 keywords:

--- a/charts/hono/README.md
+++ b/charts/hono/README.md
@@ -106,6 +106,12 @@ The command removes all the Kubernetes components associated with the chart and 
 
 * Fix using custom host with amqp Messaging Network Example
 
+### 2.4.0
+
+* Do not expose insecure service port if insecure port is disabled for a component.
+  Support disabling the insecure port of the Dispatch Router of the AMQP 1.0 based
+  example messaging infrastructure.
+
 ### 2.3.1
 
 * Update to Grafana Dashboard to work with the new metrics

--- a/charts/hono/config/router/qdrouterd.json
+++ b/charts/hono/config/router/qdrouterd.json
@@ -36,6 +36,7 @@
     "saslPlugin": "Hono Auth"
   }],
 
+{{- if .Values.amqpMessagingNetworkExample.insecurePortEnabled }}
   ["listener", {
     "host": "0.0.0.0",
     "port": 5672,
@@ -44,6 +45,7 @@
     "saslMechanisms": "PLAIN",
     "saslPlugin": "Hono Auth"
   }],
+{{- end }}
 
   ["sslProfile", {
     "name": "internal",

--- a/charts/hono/templates/dispatch-router/dispatch-router-deployment.yaml
+++ b/charts/hono/templates/dispatch-router/dispatch-router-deployment.yaml
@@ -47,9 +47,11 @@ spec:
         - name: amqps
           containerPort: 5671
           protocol: TCP
+        {{- if .Values.amqpMessagingNetworkExample.insecurePortEnabled }}
         - name: amqp
           containerPort: 5672
           protocol: TCP
+        {{- end }}
         - name: internal
           containerPort: 5673
           protocol: TCP

--- a/charts/hono/templates/dispatch-router/dispatch-router-ext-svc.yaml
+++ b/charts/hono/templates/dispatch-router/dispatch-router-ext-svc.yaml
@@ -29,12 +29,14 @@ spec:
     targetPort: amqps
     {{- $amqpsArgs := dict "dot" . "port" 30671 }}
     {{- include "hono.nodePort" $amqpsArgs | nindent 4 }}
+  {{- if .Values.amqpMessagingNetworkExample.insecurePortEnabled }}
   - name: amqp
     port: 15672
     protocol: TCP
     targetPort: amqp
     {{- $amqpArgs := dict "dot" . "port" 30672 }}
     {{- include "hono.nodePort" $amqpArgs | nindent 4 }}
+  {{- end }}
   {{- if .Values.adapters.externalAdaptersEnabled }}
   - name: internal
     port: 15673

--- a/charts/hono/templates/hono-adapter-amqp/hono-adapter-amqp-secret.yaml
+++ b/charts/hono/templates/hono-adapter-amqp/hono-adapter-amqp-secret.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.adapters.amqp.enabled }}
 #
-# Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -23,7 +23,7 @@ stringData:
       app:
         maxInstances: {{ .Values.adapters.amqp.hono.app.maxInstances }}
       amqp:
-        {{- if .Values.adapters.amqp.hono.amqp }}
+        {{- if not ( empty .Values.adapters.amqp.hono.amqp  ) }}
         {{- .Values.adapters.amqp.hono.amqp | toYaml | nindent 8 }}
         {{- else }}
         bindAddress: "0.0.0.0"

--- a/charts/hono/templates/hono-adapter-amqp/hono-adapter-amqp-svc.yaml
+++ b/charts/hono/templates/hono-adapter-amqp/hono-adapter-amqp-svc.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.adapters.amqp.enabled }}
 #
-# Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -22,12 +22,14 @@ metadata:
   {{- end }}
 spec:
   ports:
+  {{- if ( eq .Values.adapters.amqp.hono.amqp.insecurePortEnabled true ) }}
   - name: amqp
     port: 5672
     protocol: TCP
     targetPort: amqp
     {{- $amqpArgs := dict "dot" . "port" 32672 }}
     {{- include "hono.nodePort" $amqpArgs | nindent 4 }}
+  {{- end }}
   - name: amqps
     port: 5671
     protocol: TCP

--- a/charts/hono/templates/hono-adapter-coap/hono-adapter-coap-secret.yaml
+++ b/charts/hono/templates/hono-adapter-coap/hono-adapter-coap-secret.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.adapters.coap.enabled }}
 #
-# Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -23,9 +23,10 @@ stringData:
       app:
         maxInstances: {{ .Values.adapters.coap.hono.app.maxInstances }}
       coap:
-        {{- if .Values.adapters.coap.hono.coap }}
+        {{- if not ( empty .Values.adapters.coap.hono.coap  ) }}
         {{- .Values.adapters.coap.hono.coap | toYaml | nindent 8 }}
         {{- else }}
+        insecurePortEnabled: false
         bindAddress: "0.0.0.0"
         port: 5684
         keyPath: "/opt/hono/tls/tls.key"

--- a/charts/hono/templates/hono-adapter-coap/hono-adapter-coap-svc.yaml
+++ b/charts/hono/templates/hono-adapter-coap/hono-adapter-coap-svc.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.adapters.coap.enabled }}
 #
-# Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -23,12 +23,14 @@ metadata:
 
 spec:
   ports:
+  {{- if ( eq .Values.adapters.coap.hono.coap.insecurePortEnabled true ) }}
   - name: coap
     port: 5683
     protocol: UDP
     targetPort: coap
     {{- $coapArgs := dict "dot" . "port" 30683 }}
     {{- include "hono.nodePort" $coapArgs | nindent 4 }}
+  {{- end }}
   - name: coaps
     port: 5684
     protocol: UDP

--- a/charts/hono/templates/hono-adapter-http/hono-adapter-http-secret.yaml
+++ b/charts/hono/templates/hono-adapter-http/hono-adapter-http-secret.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.adapters.http.enabled }}
 #
-# Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -23,7 +23,7 @@ stringData:
       app:
         maxInstances: {{ .Values.adapters.http.hono.app.maxInstances }}
       http:
-        {{- if .Values.adapters.http.hono.http }}
+        {{- if not ( empty .Values.adapters.http.hono.http  ) }}
         {{- .Values.adapters.http.hono.http | toYaml | nindent 8 }}
         {{- else }}
         bindAddress: "0.0.0.0"

--- a/charts/hono/templates/hono-adapter-http/hono-adapter-http-svc.yaml
+++ b/charts/hono/templates/hono-adapter-http/hono-adapter-http-svc.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.adapters.http.enabled }}
 #
-# Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -22,12 +22,14 @@ metadata:
   {{- end }}
 spec:
   ports:
+  {{- if ( eq .Values.adapters.http.hono.http.insecurePortEnabled true ) }}
   - name: http
     port: 8080
     protocol: TCP
     targetPort: http
     {{- $httpArgs := dict "dot" . "port" 30080 }}
     {{- include "hono.nodePort" $httpArgs | nindent 4 }}
+  {{- end }}
   - name: https
     port: 8443
     protocol: TCP

--- a/charts/hono/templates/hono-adapter-lora/hono-adapter-lora-secret.yaml
+++ b/charts/hono/templates/hono-adapter-lora/hono-adapter-lora-secret.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.adapters.lora.enabled }}
 #
-# Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -23,7 +23,7 @@ stringData:
       app:
         maxInstances: {{ .Values.adapters.lora.hono.app.maxInstances }}
       lora:
-        {{- if .Values.adapters.lora.hono.lora }}
+        {{- if not ( empty .Values.adapters.lora.hono.lora  ) }}
         {{- .Values.adapters.lora.hono.lora | toYaml | nindent 8 }}
         {{- else }}
         bindAddress: "0.0.0.0"

--- a/charts/hono/templates/hono-adapter-lora/hono-adapter-lora-svc.yaml
+++ b/charts/hono/templates/hono-adapter-lora/hono-adapter-lora-svc.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.adapters.lora.enabled }}
 #
-# Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -22,12 +22,14 @@ metadata:
   {{- end }}
 spec:
   ports:
+  {{- if ( eq .Values.adapters.lora.hono.lora.insecurePortEnabled true ) }}
   - name: http
     port: 8080
     protocol: TCP
     targetPort: http
     {{- $httpArgs := dict "dot" . "port" 32080 }}
     {{- include "hono.nodePort" $httpArgs | nindent 4 }}
+  {{- end }}
   - name: https
     port: 8443
     protocol: TCP

--- a/charts/hono/templates/hono-adapter-mqtt/hono-adapter-mqtt-secret.yaml
+++ b/charts/hono/templates/hono-adapter-mqtt/hono-adapter-mqtt-secret.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.adapters.mqtt.enabled }}
 #
-# Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -23,7 +23,7 @@ stringData:
       app:
         maxInstances: {{ .Values.adapters.mqtt.hono.app.maxInstances }}
       mqtt:
-        {{- if .Values.adapters.mqtt.hono.mqtt }}
+        {{- if not ( empty .Values.adapters.mqtt.hono.mqtt  ) }}
         {{- .Values.adapters.mqtt.hono.mqtt | toYaml | nindent 8 }}
         {{- else }}
         bindAddress: "0.0.0.0"

--- a/charts/hono/templates/hono-adapter-mqtt/hono-adapter-mqtt-svc.yaml
+++ b/charts/hono/templates/hono-adapter-mqtt/hono-adapter-mqtt-svc.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.adapters.mqtt.enabled }}
 #
-# Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -22,12 +22,14 @@ metadata:
   {{- end }}
 spec:
   ports:
+  {{- if ( eq .Values.adapters.mqtt.hono.mqtt.insecurePortEnabled true ) }}
   - name: mqtt
     port: 1883
     protocol: TCP
     targetPort: mqtt
     {{- $mqttArgs := dict "dot" . "port" 31883 }}
     {{- include "hono.nodePort" $mqttArgs | nindent 4 }}
+  {{- end }}
   - name: secure-mqtt
     port: 8883
     protocol: TCP

--- a/charts/hono/templates/hono-service-auth/hono-service-auth-secret.yaml
+++ b/charts/hono/templates/hono-service-auth/hono-service-auth-secret.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -23,7 +23,7 @@ stringData:
         maxInstances: {{ .Values.authServer.hono.app.maxInstances }}
       auth:
         amqp:
-          {{- if .Values.authServer.hono.auth.amqp }}
+          {{- if not ( empty .Values.authServer.hono.auth.amqp ) }}
           {{- .Values.authServer.hono.auth.amqp | toYaml | nindent 10 }}
           {{- else }}
           bindAddress: "0.0.0.0"

--- a/charts/hono/templates/hono-service-device-registry-base/hono-service-device-registry-ext-svc.yaml
+++ b/charts/hono/templates/hono-service-device-registry-base/hono-service-device-registry-ext-svc.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.deviceRegistryExample.enabled }}
 #
-# Copyright (c) 2019 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -22,12 +22,14 @@ metadata:
   {{- end }}
 spec:
   ports:
+  {{- if ( eq .Values.deviceRegistryExample.hono.registry.http.insecurePortEnabled true ) }}
   - name: http
     port: 28080
     protocol: TCP
     targetPort: http
     {{- $httpArgs := dict "dot" . "port" 31080 }}
     {{- include "hono.nodePort" $httpArgs | nindent 4 }}
+  {{- end }}
   - name: https
     port: 28443
     protocol: TCP

--- a/charts/hono/templates/hono-service-device-registry-embedded/hono-service-device-registry-secret.yaml
+++ b/charts/hono/templates/hono-service-device-registry-embedded/hono-service-device-registry-secret.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.deviceRegistryExample.enabled ( eq .Values.deviceRegistryExample.type "embedded" ) }}
 #
-# Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+# Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -36,7 +36,7 @@ stringData:
         {{- end }}
       registry:
         amqp:
-          {{- if .Values.deviceRegistryExample.hono.registry.amqp }}
+          {{- if not ( empty .Values.deviceRegistryExample.hono.registry.amqp  ) }}
           {{- .Values.deviceRegistryExample.hono.registry.amqp | toYaml | nindent 10 }}
           {{- else }}
           bindAddress: "0.0.0.0"
@@ -44,7 +44,7 @@ stringData:
           certPath: "/opt/hono/tls/tls.crt"
           {{- end }}
         http:
-          {{- if .Values.deviceRegistryExample.hono.registry.http }}
+          {{- if not ( empty .Values.deviceRegistryExample.hono.registry.http  ) }}
           {{- .Values.deviceRegistryExample.hono.registry.http | toYaml | nindent 10 }}
           {{- else }}
           authenticationRequired: false
@@ -55,7 +55,7 @@ stringData:
           insecurePortBindAddress: "0.0.0.0"
           {{- end }}
           deviceIdPattern: "^[a-zA-Z0-9-_\\.\\:]+$"
-        {{- if .Values.deviceRegistryExample.hono.registry.svc }}
+        {{- if not ( empty .Values.deviceRegistryExample.hono.registry.svc  ) }}
         svc:
           {{- .Values.deviceRegistryExample.hono.registry.svc | toYaml | nindent 10 }}
         {{- end }}

--- a/charts/hono/templates/hono-service-device-registry-jdbc/hono-service-device-registry-secret.yaml
+++ b/charts/hono/templates/hono-service-device-registry-jdbc/hono-service-device-registry-secret.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.deviceRegistryExample.enabled ( eq .Values.deviceRegistryExample.type "jdbc" ) }}
 #
-# Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
+# Copyright (c) 2020, 2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -36,7 +36,7 @@ stringData:
         {{- end }}
       registry:
         amqp:
-          {{- if .Values.deviceRegistryExample.hono.registry.amqp }}
+          {{- if not ( empty .Values.deviceRegistryExample.hono.registry.amqp  ) }}
           {{- .Values.deviceRegistryExample.hono.registry.amqp | toYaml | nindent 10 }}
           {{- else }}
           bindAddress: "0.0.0.0"
@@ -44,7 +44,7 @@ stringData:
           certPath: "/opt/hono/tls/tls.crt"
           {{- end }}
         http:
-          {{- if .Values.deviceRegistryExample.hono.registry.http }}
+          {{- if not ( empty .Values.deviceRegistryExample.hono.registry.http  ) }}
           {{- .Values.deviceRegistryExample.hono.registry.http | toYaml | nindent 10 }}
           {{- else }}
           authenticationRequired: false
@@ -55,7 +55,7 @@ stringData:
           insecurePortBindAddress: "0.0.0.0"
           {{- end }}
           deviceIdPattern: "^[a-zA-Z0-9-_\\.\\:]+$"
-        {{- if .Values.deviceRegistryExample.hono.registry.svc }}
+        {{- if not ( empty .Values.deviceRegistryExample.hono.registry.svc  ) }}
         svc:
           {{- .Values.deviceRegistryExample.hono.registry.svc | toYaml | nindent 10 }}
         {{- end }}

--- a/charts/hono/templates/hono-service-device-registry-mongodb/hono-service-device-registry-secret.yaml
+++ b/charts/hono/templates/hono-service-device-registry-mongodb/hono-service-device-registry-secret.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.deviceRegistryExample.enabled ( eq .Values.deviceRegistryExample.type "mongodb" ) }}
 #
-# Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
+# Copyright (c) 2020, 2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -36,7 +36,7 @@ stringData:
         {{- end }}
       registry:
         amqp:
-          {{- if .Values.deviceRegistryExample.hono.registry.amqp }}
+          {{- if not ( empty .Values.deviceRegistryExample.hono.registry.amqp  ) }}
           {{- .Values.deviceRegistryExample.hono.registry.amqp | toYaml | nindent 10 }}
           {{- else }}
           bindAddress: "0.0.0.0"
@@ -44,7 +44,7 @@ stringData:
           certPath: "/opt/hono/tls/tls.crt"
           {{- end }}
         http:
-          {{- if .Values.deviceRegistryExample.hono.registry.http }}
+          {{- if not ( empty .Values.deviceRegistryExample.hono.registry.http  ) }}
           {{- .Values.deviceRegistryExample.hono.registry.http | toYaml | nindent 10 }}
           {{- else }}
           authenticationRequired: false
@@ -55,12 +55,12 @@ stringData:
           insecurePortBindAddress: "0.0.0.0"
           {{- end }}
           deviceIdPattern: "^[a-zA-Z0-9-_\\.\\:]+$"
-        {{- if .Values.deviceRegistryExample.hono.registry.svc }}
+        {{- if not ( empty .Values.deviceRegistryExample.hono.registry.svc  ) }}
         svc:
           {{- .Values.deviceRegistryExample.hono.registry.svc | toYaml | nindent 10 }}
         {{- end }}
       mongodb:
-        {{- if .Values.deviceRegistryExample.mongoDBBasedDeviceRegistry.mongodb}}
+        {{- if not ( empty .Values.deviceRegistryExample.mongoDBBasedDeviceRegistry.mongodb ) }}
         {{- .Values.deviceRegistryExample.mongoDBBasedDeviceRegistry.mongodb | toYaml | nindent 8 }}
         {{- else }}
         host: {{ printf "%s-%s" .Release.Name .Values.mongodb.nameOverride | quote }}

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -350,7 +350,7 @@ adapters:
       # exposed AMQP endpoints.
       # If not set, the adapter by default exposes the secure and insecure ports
       # using an example key and certificate.
-      amqp:
+      amqp: {}
       #  insecurePortEnabled: true
       #  insecurePortBindAddress: "0.0.0.0"
 
@@ -469,6 +469,13 @@ adapters:
         # maxInstances defines the number of adapter Verticle instances to deploy
         # to the vert.x runtime during start-up.
         maxInstances: 1
+      # coap contains configuration properties for the adapter's
+      # exposed CoAP endpoints.
+      # If not set, the adapter by default exposes the secure port
+      # using an example key and certificate.
+      coap: {}
+      #  insecurePortEnabled: true
+      #  insecurePortBindAddress: "0.0.0.0"
 
   http:
     # enabled indicates if Hono's HTTP adapter should be deployed.
@@ -591,7 +598,7 @@ adapters:
       # exposed HTTP endpoints.
       # If not set, the adapter by default exposes the secure and insecure ports
       # using an example key and certificate.
-      http:
+      http: {}
       #  insecurePortEnabled: true
       #  insecurePortBindAddress: "0.0.0.0"
 
@@ -715,7 +722,7 @@ adapters:
       # exposed HTTP endpoints.
       # If not set, the adapter by default exposes the secure and insecure ports
       # using an example key and certificate.
-      lora:
+      lora: {}
       #  insecurePortEnabled: true
       #  insecurePortBindAddress: "0.0.0.0"
 
@@ -840,7 +847,7 @@ adapters:
       # exposed MQTT endpoints.
       # If not set, the adapter by default exposes the secure and insecure ports
       # using an example key and certificate.
-      mqtt:
+      mqtt: {}
       #  insecurePortEnabled: true
       #  insecurePortBindAddress: "0.0.0.0"
 
@@ -959,7 +966,7 @@ authServer:
       # exposed AMQP endpoints.
       # If not set, the sever by default exposes the secure and insecure ports
       # using an example key and certificate.
-      amqp:
+      amqp: {}
       #  insecurePortEnabled: true
       #  insecurePortBindAddress: "0.0.0.0"
 
@@ -1064,7 +1071,7 @@ deviceRegistryExample:
       # exposed AMQP endpoints.
       # If not set, the registry by default exposes the secure port
       # using an example key and certificate.
-      amqp:
+      amqp: {}
       #  insecurePortEnabled: true
       #  insecurePortBindAddress: "0.0.0.0"
 
@@ -1073,12 +1080,12 @@ deviceRegistryExample:
       # If not set, the registry by default exposes the insecure and secure ports
       # using an example key and certificate.
       # NOTE: For the file based device registry use "rest" instead of "http".
-      http:
+      http: {}
       #  insecurePortEnabled: true
       #  insecurePortBindAddress: "0.0.0.0"
 
       # svc contains configuration properties for the registry's service implementation.
-      svc:
+      svc: {}
       #  maxDevicesPerTenant: 100
 
     # kafka contains the configuration used by the device registry
@@ -1222,7 +1229,7 @@ deviceRegistryExample:
     # mongodb contains the configuration properties to connect to the MongoDB database instance.
     # If you would like to use an already existing MongoDB database instance, then configure
     # the below section accordingly.
-    mongodb:
+    mongodb: {}
     # The host name or IP address of the MongoDB instance.
     # host:
     # The port that the MongoDB instance is listening on.
@@ -1749,6 +1756,9 @@ amqpMessagingNetworkExample:
   # deployed and used. By default an internal Broker is deployed.
   # As alternative an external Broker can be configured as well.
   enabled: false
+  # insecurePortEnabled indicates if the non-TLS secured API endpoint of the Dispatch Router
+  # should be enabled or not.
+  insecurePortEnabled: true
 
   # dispatchRouter contains properties for configuring the Qpid Dispatch Router
   dispatchRouter:


### PR DESCRIPTION
This addresses #457

Do not expose insecure service port if insecure port is disabled for a component. Support disabling the insecure port of the Dispatch Router of the AMQP 1.0 based example messaging infrastructure.