### PR TITLE
[BUG] wrong (misspelled) variable used for a host

### DIFF
--- a/charts/hono/config/router/qdrouterd.json
+++ b/charts/hono/config/router/qdrouterd.json
@@ -87,7 +87,7 @@
     "saslUsername": "{{ .Values.amqpMessagingNetworkExample.broker.saslUsername }}",
     "saslPassword": "file:/opt/hono/config/broker-password",
     {{- if .Values.amqpMessagingNetworkExample.broker.servicebus.host }}
-    "host": "{{ .Values.amqpMessagingNetworkExample.broker.serviceBus.host }}",
+    "host": "{{ .Values.amqpMessagingNetworkExample.broker.servicebus.host }}",
     "idleTimeoutSeconds": 120
     {{- else }}
     "host": "{{ .Release.Name }}-artemis",


### PR DESCRIPTION
This bug will cause that Hono chart will not start for this type of configuration of amqpMessagingNetworkExample