### PR TITLE
Wrong (misspelled) variable used for a host

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 2.3.0
+version: 2.3.2
 # Version of Hono being deployed by the chart
 appVersion: 2.3.0
 keywords:

--- a/charts/hono/README.md
+++ b/charts/hono/README.md
@@ -102,6 +102,9 @@ helm uninstall eclipse-hono -n hono
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 
 ## Release Notes
+### 2.3.2
+
+* Fix using custom host with amqp Messaging Network Example
 
 ### 2.3.0
 

--- a/charts/hono/config/router/qdrouterd.json
+++ b/charts/hono/config/router/qdrouterd.json
@@ -87,7 +87,7 @@
     "saslUsername": "{{ .Values.amqpMessagingNetworkExample.broker.saslUsername }}",
     "saslPassword": "file:/opt/hono/config/broker-password",
     {{- if .Values.amqpMessagingNetworkExample.broker.servicebus.host }}
-    "host": "{{ .Values.amqpMessagingNetworkExample.broker.serviceBus.host }}",
+    "host": "{{ .Values.amqpMessagingNetworkExample.broker.servicebus.host }}",
     "idleTimeoutSeconds": 120
     {{- else }}
     "host": "{{ .Release.Name }}-artemis",


### PR DESCRIPTION
This bug will cause that Hono chart will not start for this type of configuration of amqpMessagingNetworkExample