### PR TITLE
remove @ctron as code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*                                     @calohmn @ctron
+*                                     @calohmn


### PR DESCRIPTION
As I am currenlty not really involve in the project I think it makes sense to remove me as one of the code owners, in order to set the right expectations.

Being listed a code owner automatically assigns me as a reviewer to new PRs, however, I can't really review much and so people might wonder why I don't react.

So, removing me from the code owners file seems to be right way forward.