### PR TITLE
[#478] Invalid PVC Size

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 2.5.0
+version: 2.5.1
 # Version of Hono being deployed by the chart
 appVersion: 2.4.0
 keywords:

--- a/charts/hono/README.md
+++ b/charts/hono/README.md
@@ -102,6 +102,10 @@ helm uninstall eclipse-hono -n hono
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 
 ## Release Notes
+### 2.5.1
+
+* Allow customizing the PVC storage size for the Device Registry service.
+
 ### 2.5.0
 
 * Allow customizing the pod/service names irrespective of .Release.Name.

--- a/charts/hono/templates/hono-service-device-registry-embedded/hono-service-device-registry-pvc.yaml
+++ b/charts/hono/templates/hono-service-device-registry-embedded/hono-service-device-registry-pvc.yaml
@@ -24,5 +24,5 @@ spec:
   {{- end }}
   resources:
     requests:
-      storage: 1Mi
+      storage: {{ .Values.deviceRegistryExample.embeddedJdbcDeviceRegistry.storageSize | quote }}
 {{- end }}

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -1144,6 +1144,10 @@ deviceRegistryExample:
     # should be used for the example registry's persistent volume claim.
     # If not set, the cluster's default storage class is used.
     storageClass:
+    # storageSize contains the size of the storage that will be created using the
+    # storageClass or the cluster's default configuration.
+    # If no value is specified, the default value will be assumed.
+    storageSize: 1Mi
     # cmdLineArgs contains additional arguments to be passed to the container's CMD.
     cmdLineArgs: []
     # quarkusConfigLocations contains resources that the Quarkus based variant of the component should read


### PR DESCRIPTION
Related to https://github.com/eclipse/packages/issues/478. 

Created a new parameter - storageSize - that allows any user to define the size of the storage created by the Service Device Registry pod. This allows the installation of the Hono in a Cloud Provider that have policies who restrict the size of the storage.