### PR TITLE
[#482] Fix wrong MongoDB hostname; fix MongoDB health checks.

### DIFF
--- a/packages/cloud2edge/Chart.yaml
+++ b/packages/cloud2edge/Chart.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
+# Copyright (c) 2020, 2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -11,8 +11,8 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 apiVersion: v1
-version: 0.4.0
-appVersion: 0.4.0
+version: 0.4.1
+appVersion: 0.4.1
 name: cloud2edge
 description: |
   Eclipse IoT Cloud2Edge (C2E) is an integrated suite of services developers can use to build IoT applications

--- a/packages/cloud2edge/requirements.yaml
+++ b/packages/cloud2edge/requirements.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
+# Copyright (c) 2020, 2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -12,7 +12,7 @@
 #
 dependencies:
   - name: hono
-    version: ^2.1.0
+    version: ~2.4.0
     repository: "https://eclipse.org/packages/charts/"
   - name: ditto
     version: ~3.1.0

--- a/packages/cloud2edge/values.yaml
+++ b/packages/cloud2edge/values.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+# Copyright (c) 2020, 2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -164,6 +164,9 @@ ditto:
         memory: "768Mi"
 
   mongodb:
+    # usage of default name (including release name) not supported in hono.deviceRegistryExample.mongoDBBasedDeviceRegistry.mongodb for now
+    # - therefore using fixed name here
+    fullnameOverride: ditto-mongodb
     resources:
       requests:
         cpu: 150m
@@ -171,3 +174,33 @@ ditto:
       limits:
         cpu: 250m
         memory: "512Mi"
+    # apply workaround for high CPU/memory usage of liveness/readiness check - see https://github.com/bitnami/charts/issues/10264
+    # using deprecated 'mongo' executable (still available in mongodb chart 12.x) showing much lower CPU/memory usage;
+    # needs to be adapted if TLS is enabled - see https://github.com/bitnami/charts/blob/2246e0540e621cd529e32ea2c7c2724c0fbc066a/bitnami/mongodb/templates/standalone/dep-sts.yaml#L285
+    livenessProbe:
+      enabled: false
+    customLivenessProbe:
+      exec:
+        command:
+          - mongo
+          - --disableImplicitSessions
+          - --eval
+          - "db.adminCommand('ping')"
+      failureThreshold: 6
+      initialDelaySeconds: 30
+      periodSeconds: 20
+      successThreshold: 1
+      timeoutSeconds: 10
+    readinessProbe:
+      enabled: false
+    customReadinessProbe:
+      exec:
+        command:
+          - sh
+          - '-c'
+          - mongo --disableImplicitSessions --eval 'db.hello().isWritablePrimary || db.hello().secondary' | grep -q 'true'
+      failureThreshold: 6
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      successThreshold: 1
+      timeoutSeconds: 5


### PR DESCRIPTION
Fix for #482 .
Fixes Hono devices registry not being able to connect to the MongoDB instance because it used the wrong hostname. Also fixes MongoDB not getting ready because the health checks took too long and caused OOM errors.
Also restrict Hono chart dependency version range (needed for upcoming changes addressing #430).