### PR TITLE
[#486] Use newer Helm version in Jenkinsfile.

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -8,7 +8,7 @@ properties([
 ])
 
 def label = "packages-${UUID.randomUUID().toString()}"
-def HELM_VERSION = "3.5.4"
+def HELM_VERSION = "3.9.2"
 
 def needToDeploy() {
     return BRANCH_NAME == 'master' || BRANCH_NAME == 'develop'


### PR DESCRIPTION
Helm >= 3.8 needed to install cloud2edge chart now.