### PR TITLE
[#433] Use consistent LB/NodePort setting in c2e chart, fix c2e docs.

### DIFF
--- a/homepage/_packages/cloud2edge/installation.md
+++ b/homepage/_packages/cloud2edge/installation.md
@@ -30,7 +30,7 @@ This should print out the version of the client, but must also print out the ver
 
 The Cloud2Edge package consists of multiple components. In order to keep them together and separate
 from other components running in your Kubernetes cluster, it is feasible to install them into
-their own name space. The following command creates the `cloud2edge` name space but you can select any
+their own namespace. The following command creates the `cloud2edge` namespace, but you can select any
 other name as well.
 
 {% clipboard %}
@@ -38,27 +38,35 @@ NS=cloud2edge
 kubectl create namespace $NS
 {% endclipboard %}
 
-Next, install the package to the name space using Helm.
+Next, install the package to the namespace using Helm.
 
 {% variants %}
 
 {% variant NodePort %}
-Kubernetes variants like *kind* or *Minikube* do not support exposing service endpoints via load balancers
-out of the box. Instead, services are exposed via *NodePorts*.
+For a single-node Kubernetes cluster, the most basic and universally supported way to direct traffic to the
+Kubernetes services is done via *NodePorts*.
+
+To install the Cloud2Edge package using NodePort services, run the following command:
 
 {% clipboard %}
 RELEASE=c2e
-helm install -n $NS --wait --timeout 15m $RELEASE eclipse-iot/cloud2edge
+helm install -n $NS --wait --timeout 20m $RELEASE eclipse-iot/cloud2edge
 {% endclipboard %}
 {% endvariant %}
 
 {% variant LoadBalancer %}
 Managed Kubernetes variants usually support exposing service endpoints via load balancers on public
-IP addresses. To install the Cloud2Edge package using load balancers, run the following command:
+IP addresses. On a local Kubernetes cluster, load balancer support requires additional preparation
+(e.g. running [minikube tunnel](https://minikube.sigs.k8s.io/docs/handbook/accessing/#loadbalancer-access) on Minikube, 
+or setting up [MetalLB](https://metallb.universe.tf/) on [Kind](https://kind.sigs.k8s.io/docs/user/loadbalancer/) or [MicroK8s](https://microk8s.io/docs/addon-metallb)).
+
+To install the Cloud2Edge package using load balancers, run the following command:
 
 {% clipboard %}
 RELEASE=c2e
-helm install -n $NS --wait --timeout 20m --set hono.useLoadBalancer=true --set ditto.nginx.service.type=LoadBalancer $RELEASE eclipse-iot/cloud2edge
+helm install -n $NS --wait --timeout 20m --set hono.useLoadBalancer=true \
+ --set hono.kafka.externalAccess.service.type=LoadBalancer \
+ --set ditto.nginx.service.type=LoadBalancer $RELEASE eclipse-iot/cloud2edge
 {% endclipboard %}
 {% endvariant %}
 

--- a/homepage/prereqs.md
+++ b/homepage/prereqs.md
@@ -27,11 +27,11 @@ Generally, you can either use a cloud provider, such as Azure (AKS) or AWS (EKS)
 As the Kubernetes API is standardized both ways will work.
 However, setting up Kubernetes yourself is not trivial and requires some more effort.
 As part of this tutorial, we present two different K8s distributions (and how to deploy Eclipse IoT Packages with them),
-namely [MicroK8s](microk8s) and [Minikube](minikube).
+namely [MicroK8s](#microk8s) and [Minikube](#minikube).
 
 Packages are encouraged to give you an estimate of what resources they require. The following is
 an example of what this may look like. You will need to translate this into the specific
-Kubernetes environment you have. Also may the package declare on which Kubernetes platform
+Kubernetes environment you have. Also, the package may declare on which Kubernetes platform
 it was tested. This doesn't mean that other Kubernetes versions don't work, but sets some
 expectations of what was tested at some point.
 
@@ -43,11 +43,10 @@ expectations of what was tested at some point.
 
 </div>
 
-For each documentation Kubernetes environment on this page, you will find a section that explains how to do this.
 
 ### MicroK8s
 
-[MicroK8s](https://microk8s.io/) is a Kubernetes distribution, maintained by Canonical and enables developers to run a
+[MicroK8s](https://microk8s.io/) is a Kubernetes distribution, maintained by Canonical, that enables developers to run a
 fully-fledged Kubernetes cluster on their own infrastructure. In contrast to *minikube* it is not only intended for testing
 purposes but also for production scenarios, e.g. in cases where a cloud setup is not possible or desirable.
 
@@ -55,7 +54,11 @@ All you need is a virtual or physical machine with root access and the [snap pac
 
 Install MicroK8s, executing `sudo snap install microk8s --classic`
 
-Check the cluster status, by running `microk8s status --wait-ready`
+For Windows or macOS, or a Linux system without snap, consult the [alternative install methods for MicroK8s](https://microk8s.io/docs/install-alternatives). 
+When installing on [Windows](https://microk8s.io/docs/install-windows) or using [Multipass](https://microk8s.io/docs/install-multipass), 
+make sure the CPU, memory and disk configuration corresponds to what is required by the package.
+
+After the installation, check the cluster status, by running `microk8s status --wait-ready`
 
 Once the cluster is up and running you will need to enable a few modules that are required for installing an
 Eclipse IoT Packages package such as Cloud2Edge.
@@ -74,172 +77,61 @@ These commands enable
 - the cluster dns server
 - and the load balancing module, which enables external access to your cluster
 
-In order to control the cluster using the Kubernetes CLI (`kubectl`) you can either use integrated option which ships
-with MicroK8s. Alternatively, e.g. if you want to control your cluster from another machine you can extract the cluster
-config file and use it with a native install of `kubectl`.
+In order to control the cluster using the Kubernetes CLI (`kubectl`) you can use the integrated `microk8s kubectl <command>` 
+option which ships with MicroK8s.
 
-#### Integrated option
+In order to use the host's `kubectl` command, consult the [Working with kubectl](https://microk8s.io/docs/working-with-kubectl) documentation chapter.
 
-Use `microk8s kubectl <command>`
-
-#### Native option
-
-Execute `microk8s kubectl config view --raw > $HOME/.kube/config`
-
-Now, use `kubectl <command>`
-
-In case you are not running the cluster on a your local machine you can also enable remote access by following these steps:
-- stop your cluster by running `microk8s stop`
-- edit the file `/var/snap/microk8s/current/certs/csr.conf.template` and add your domain/ip address:
-
-```
-DNS.6 = <domain_of_microk8s_host>
-IP.7 = <public_ip_of_microk8s_host>
-```
-Restart your cluster by running `microk8s start` and extract the new Kubernetes configuration by executing
-`microk8s kubectl config view --raw`.
-Now copy the configuration description to your local machine under `~/.kube/config`.
-
-#### Loadbalancing and Ingress
-
-Once you have a Kubernetes cluster available and installed the Kubernetes and Helm CLI (see below), you are now ready
-to setup an Eclipse IoT Packages deployment such as Cloud2Edge. By default the containers can communicate within the
-cluster. But to access a container and its respective services from outside the cluster (e.g. from another machine)
-you need to perform some extra steps.
-Depending on your setup, you have 3 options available how to make your services externally available.
-
-##### NodePort
-
-The simplest way to expose your services is by using a Kubernetes Service with type
-[NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport). The Cloud2Edge Helm chart uses
-this option by default.
-Using this in production mode has some drawbacks and is not recommended as it is very static, enables just one Service
-per port and only allows you to use ports in the range 30000–32767.
-
-##### LoadBalancer
-
-Another option is the [LoadBalancer](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer)
-Service type, which requires your Kubernetes provider to supply an external load balancing module. The provider is
-also responsible for provisioning external IP addresses.
-The Cloud2Edge enables this option by setting the flags `hono.useLoadBalancer` to `true` and `ditto.nginx.service.type`
-to `LoadBalancer`.
-The downside of this approach is that each of your Services requires its own publicly available IP address, which
-might either not be desirable (due to higher costs) or possible at all e.g. in case you are running your deployment
-on a custom Kubernetes setup (such as MicroK8s).
-
-##### Ingress Loadbalancing
-
-Ingress controllers employ a single LoadBalancer service, which then routes all incoming traffic to the actual
-controller in charge of distributing it to the right endpoints.
-This allows not only differentiating by port, but also routing by path (HTTP) or subdomain.
-We are using the [Ambassador](https://www.getambassador.io/) controller, as it is capable of routing not only HTTP
-ingress but also on the TCP level.
-
-1. Deploy the Cloud2Edge Helm chart setting the aforementioned flags to **not** use the LoadBalancer type
-2. Create a namespace for Ambassador: `kubectl create namespace ambassador`
-3. Add the Helm repository: `helm repo add datawire https://www.getambassador.io`
-4. Create a file named `override.yaml`, that contains all necessary Ambassador configurations:
-   ```yaml
-   enableAES: false
-   image:
-     repository: docker.io/datawire/ambassador
-   replicaCount: 1
-   service:
-     ports:
-       - name: mqtt-adapter
-         port: 1883
-         targetPort: 1883
-       - name: http-adapter
-         port: 18080
-         targetPort: 18080
-       - name: device-registry
-         port: 28080
-         targetPort: 28080
-       - name: dispatch-router
-         port: 5671
-         targetPort: 15671
-       - name: ditto
-         port: 38080
-         targetPort: 38080
-   ```
-5. Start Ambassador by running `helm install ambassador -n ambassador -f override.yaml datawire/ambassador`
-6. Then we create the necessary mappings, such that the controller knows where to route incoming traffic.
-   These mappings are specifically adjusted to the Cloud2Edge deployment, so you will have to create your own
-   mappings for other packages. Create a new file named `ambassador-mappings.yaml` and replace the release name and
-   the namespace of your deployment:
-   ```yaml
-   apiVersion: getambassador.io/v2
-   kind:  TCPMapping
-   metadata:
-     name: ambassador-http-adapter
-     namespace: ambassador
-   spec:
-     port: 18080
-     service: {name-of-helm-release}-adapter-http.{kubernetes-namespace}:8080
-   ---
-   apiVersion: getambassador.io/v2
-   kind:  TCPMapping
-   metadata:
-     name: ambassador-mqtt-adapter
-     namespace: ambassador
-   spec:
-     port: 1883
-     service: {name-of-helm-release}-adapter-mqtt.{kubernetes-namespace}:1883
-   ---
-   apiVersion: getambassador.io/v2
-   kind:  TCPMapping
-   metadata:
-     name: ambassador-device-registry
-     namespace: ambassador
-   spec:
-     port: 28080
-     service: {name-of-helm-release}-service-device-registry-ext.{kubernetes-namespace}:28080
-   ---
-   apiVersion: getambassador.io/v2
-   kind:  TCPMapping
-   metadata:
-     name: ambassador-dispatch-router
-     namespace: ambassador
-   spec:
-     port: 15671
-     service: {name-of-helm-release}-service-device-registry-ext.{kubernetes-namespace}:15671
-   ---
-   apiVersion: getambassador.io/v2
-   kind:  TCPMapping
-   metadata:
-     name: ambassador-ditto
-     namespace: ambassador
-   spec:
-     port: 38080
-     service: {name-of-helm-release}-ditto-nginx.{kubernetes-namespace}:8080
-   ```
-7. Now add the mappings to your cluster: `kubectl apply -f ambassador-mappings.yaml`
-
-You are now able to access the deployed Cloud2Edge services externally. Check what IP address you are using by
-running `kubectl get service -n ambassador`.
-
-Navigate to http://<your_ip>:38080 and check whether Ditto is running.
+In case you are installing MicroK8s on a remote machine that is accessible via a real domain name, you can follow the
+[Authentication and authorization](https://microk8s.io/docs/services-and-ports#heading--auth) documentation section on how
+to allow access via that domain name.
 
 ### Minikube
 
-[Minikube](https://kubernetes.io/docs/setup/learning-environment/minikube/) is Kubernetes in a bottle.
+[Minikube](https://minikube.sigs.k8s.io/docs/) is Kubernetes in a bottle.
 
-Instead of provisioning a full-blown cluster, it will create a virtual machine on your local system, and
-provision a small, single-node cluster inside it. As it puts the operating system in a VM, Minikube itself
-can run on all major operating systems, including Windows and macOS.
+Instead of provisioning a full-blown cluster, it will create a Docker (or similarly compatible) container
+or a virtual machine on your local system, and provision a small, single-node cluster inside it. 
+Minikube can run on all major operating systems, including Windows and macOS.
 
 Instead of duplicating the effort, documenting how to get Minikube up and running, we leave this to the
-excellent [documentation of Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/) itself.
+excellent [documentation of Minikube](https://minikube.sigs.k8s.io/docs/start/) itself.
 
 #### Getting started
 
-Once you have everything installed, you should be able to start a new cluster by executing:
+Once you have everything installed, you should be able to start a new cluster via `minikube start`, specifying the
+resources you want to allocate for the cluster:
 
 {%clipboard%}
-minikube start
+minikube start --cpus <cpus> --disk-size <size> --memory <memory> --kubernetes-version <version>
 {%endclipboard%}
 
-And you can switch `kubectl` to the context `minikube`, and interact with your cluster:
+You can translate the package resources requirements into these arguments:
+
+<dl class="row">
+
+<dt class="col-sm-2">cpus</dt>
+<dd class="col-sm-10">The number of CPUs you allocate for Minikube (e.g. <code>--cpus 2</code>).</dd>
+
+<dt class="col-sm-2">size</dt>
+<dd class="col-sm-10">
+The size of the disk available for the cluster and persistent volumes. In the format <code>&lt;number&gt;&lt;unit&gt;</code>,
+where unit can be either <code>k</code>, <code>m</code>, or <code>g</code> (e.g. 20GiB means <code>--disk-size 20g</code>).
+</dd>
+
+<dt class="col-sm-2">memory</dt>
+<dd class="col-sm-10">
+The amount of RAM allocated to the virtual machine. This is the amount in MiB (e.g. for 8GiB means <code>--memory 8192</code>.
+</dd>
+
+<dt class="col-sm-2">version</dt>
+<dd class="col-sm-10">
+The Kubernetes version deployed into the virtual machine (e.g. <code>--kubernetes-version v1.20.2</code>). 
+</dd>
+
+</dl>
+
+After Minikube got started, you can switch `kubectl` to the context `minikube` and interact with your cluster:
 
 {%clipboard%}
 kubectl config use-context minikube
@@ -279,38 +171,16 @@ Or delete it using:
 minikube delete
 {%endclipboard%}
 
-#### Resources
 
-You can translate the package resources requirements into arguments for the `start` command like this:
+#### Load Balancer Support
 
-```sh
-minikube start --cpus <cpus> --disk-size <size> --memory <memory> --kubernetes-version <version>
-```
+To enable support for load balancer services, run
 
-Using the following arguments:
+{%clipboard%}
+minikube tunnel
+{%endclipboard%}
 
-<dl class="row">
-
-<dt class="col-sm-2">cpus</dt>
-<dd class="col-sm-10">The number of CPUs you allocate for Minikube (e.g. <code>--cpus 2</code>).</dd>
-
-<dt class="col-sm-2">size</dt>
-<dd class="col-sm-10">
-The size of the disk available for the cluster and persistent volumes. In the format <code>&lt;number&gt;&lt;unit&gt;</code>,
-where unit can be either <code>k</code>, <code>m</code>, or <code>g</code> (e.g. 20GiB means <code>--disk-size 20g</code>).
-</dd>
-
-<dt class="col-sm-2">memory</dt>
-<dd class="col-sm-10">
-The amount of RAM allocated to the virtual machine. This is the amount in MiB (e.g. for 8GiB means <code>--memory 8192</code>.
-</dd>
-
-<dt class="col-sm-2">version</dt>
-<dd class="col-sm-10">
-The Kubernetes version deployed into the virtual machine (e.g. <code>--kubernetes-version v1.20.2</code>). 
-</dd>
-
-</dl>
+in a separate terminal (keeping it running) before installing a package.
 
 #### Addons
 
@@ -325,7 +195,7 @@ minikube start ... --addons ingress
 ## Helm
 
 You will need an installation of Helm on the machine which is used to deploy the packages. You can find
-installation instructions for Helm in the Helm documentation under [Installing Helm](https://helm.sh/docs/using_helm/#installing-helm).
+installation instructions for Helm in the Helm documentation under [Installing Helm](https://helm.sh/docs/intro/install/).
 
 The required Helm version is 3.9 or later.
 

--- a/packages/cloud2edge/Chart.yaml
+++ b/packages/cloud2edge/Chart.yaml
@@ -11,8 +11,8 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 apiVersion: v1
-version: 0.5.1
-appVersion: 0.5.1
+version: 0.6.0
+appVersion: 0.6.0
 name: cloud2edge
 description: |
   Eclipse IoT Cloud2Edge (C2E) is an integrated suite of services developers can use to build IoT applications

--- a/packages/cloud2edge/values.yaml
+++ b/packages/cloud2edge/values.yaml
@@ -33,10 +33,13 @@ hono:
           clientPasswords:
             - "hono-secret"
             - "verysecret"
+    externalAccess:
+      service:
+        type: NodePort
 
   livenessProbeInitialDelaySeconds: 900
   readinessProbeInitialDelaySeconds: 45
-  useLoadBalancer: true
+  useLoadBalancer: false
 
   prometheus:
     createInstance: false


### PR DESCRIPTION
This fixes #433.

I've restored the original service-type NodePort as default for the cloud2edge chart and adapted the "helm install" command for using service-type LoadBalancer.

I've also revised the "Prerequisites" page, replacing outdated links there and changing the MicroK8s chapter. The general "Loadbalancing and Ingress" in that chapter seemed out-of-place there to me. It also contained specific cloud2edge package information, which should rather go in the cloud2edge package installation instructions. The "Ingress LoadBalancing" section contained outdated information regarding the Ambassador component. I've therefore removed the "Loadbalancing and Ingress" chapter there.