### PR TITLE
[#512] Add service account for Hono adapter pods; update tracing image versions.

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -27,7 +27,7 @@ keywords:
 home: https://www.eclipse.org/hono/
 sources:
 - https://github.com/eclipse-hono/hono
-icon: https://eclipse.dev/hono/img/favicon.ico
+icon: https://eclipse.dev/hono/img/hono-logo_image.svg
 maintainers:
 - name: dejanb
   email: dbosanac@redhat.com

--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 2.5.4
+version: 2.5.5
 # Version of Hono being deployed by the chart
 appVersion: 2.4.0
 keywords:

--- a/charts/hono/README.md
+++ b/charts/hono/README.md
@@ -102,6 +102,12 @@ helm uninstall eclipse-hono -n hono
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 
 ## Release Notes
+### 2.5.5
+
+* Add service account for protocol-adapter pods. Needed to query the container id via the K8s API, as it is
+  done in upcoming Hono releases in case cgroups v2 is used.
+* Update jaegertracing/all-in-one and opentelemetry-collector image versions.
+
 ### 2.5.4
 
 * Fix Grafana dashboard being empty in case a release name is used that doesn't contain 'hono'.

--- a/charts/hono/templates/hono-adapter-amqp/hono-adapter-amqp-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-amqp/hono-adapter-amqp-deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.adapters.amqp.enabled }}
 #
-# Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -36,6 +36,7 @@ spec:
       {{- end }}
       {{- include "hono.pod.priorityClassName" $args | nindent 6 }}
       {{- include "hono.pod.affinity" $args | nindent 6 }}
+      serviceAccountName: {{ printf "%s-%s" ( include "hono.fullname" . ) "adapter" | quote }}
       containers:
       {{- include "hono.otel.agent" . | indent 6 }}
       {{- include "hono.container" $args | indent 6 }}

--- a/charts/hono/templates/hono-adapter-base/hono-adapter-role.yaml
+++ b/charts/hono/templates/hono-adapter-base/hono-adapter-role.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+{{- $args := dict "dot" . "name" "adapter" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  {{- include "hono.metadata" $args | nindent 2 }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get"]

--- a/charts/hono/templates/hono-adapter-base/hono-adapter-rolebinding.yaml
+++ b/charts/hono/templates/hono-adapter-base/hono-adapter-rolebinding.yaml
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+{{- $args := dict "dot" . "name" "adapter" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  {{- include "hono.metadata" $args | nindent 2 }}
+roleRef:
+  kind: Role
+  name: {{ printf "%s-%s" ( include "hono.fullname" . ) $args.name | quote }}
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: {{ printf "%s-%s" ( include "hono.fullname" . ) $args.name | quote }}
+    namespace: {{ .Release.Namespace }}

--- a/charts/hono/templates/hono-adapter-base/hono-adapter-sa.yaml
+++ b/charts/hono/templates/hono-adapter-base/hono-adapter-sa.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+{{- $args := dict "dot" . "name" "adapter" }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  {{- include "hono.metadata" $args | nindent 2 }}

--- a/charts/hono/templates/hono-adapter-coap/hono-adapter-coap-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-coap/hono-adapter-coap-deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.adapters.coap.enabled }}
 #
-# Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -36,6 +36,7 @@ spec:
       {{- end }}
       {{- include "hono.pod.priorityClassName" $args | nindent 6 }}
       {{- include "hono.pod.affinity" $args | nindent 6 }}
+      serviceAccountName: {{ printf "%s-%s" ( include "hono.fullname" . ) "adapter" | quote }}
       containers:
       {{- include "hono.otel.agent" . | indent 6 }}
       {{- include "hono.container" $args | indent 6 }}

--- a/charts/hono/templates/hono-adapter-http/hono-adapter-http-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-http/hono-adapter-http-deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.adapters.http.enabled }}
 #
-# Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -36,6 +36,7 @@ spec:
       {{- end }}
       {{- include "hono.pod.priorityClassName" $args | nindent 6 }}
       {{- include "hono.pod.affinity" $args | nindent 6 }}
+      serviceAccountName: {{ printf "%s-%s" ( include "hono.fullname" . ) "adapter" | quote }}
       containers:
       {{- include "hono.otel.agent" . | indent 6 }}
       {{- include "hono.container" $args | indent 6 }}

--- a/charts/hono/templates/hono-adapter-lora/hono-adapter-lora-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-lora/hono-adapter-lora-deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.adapters.lora.enabled }}
 #
-# Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -36,6 +36,7 @@ spec:
       {{- end }}
       {{- include "hono.pod.priorityClassName" $args | nindent 6 }}
       {{- include "hono.pod.affinity" $args | nindent 6 }}
+      serviceAccountName: {{ printf "%s-%s" ( include "hono.fullname" . ) "adapter" | quote }}
       containers:
       {{- include "hono.otel.agent" . | indent 6 }}
       {{- include "hono.container" $args | indent 6 }}

--- a/charts/hono/templates/hono-adapter-mqtt/hono-adapter-mqtt-deployment.yaml
+++ b/charts/hono/templates/hono-adapter-mqtt/hono-adapter-mqtt-deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.adapters.mqtt.enabled }}
 #
-# Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
+# Copyright (c) 2019, 2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -36,6 +36,7 @@ spec:
       {{- end }}
       {{- include "hono.pod.priorityClassName" $args | nindent 6 }}
       {{- include "hono.pod.affinity" $args | nindent 6 }}
+      serviceAccountName: {{ printf "%s-%s" ( include "hono.fullname" . ) "adapter" | quote }}
       containers:
       {{- include "hono.otel.agent" . | indent 6 }}
       {{- include "hono.container" $args | indent 6 }}

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -2066,7 +2066,7 @@ jaegerBackendExample:
   enabled: false
   # allInOneImage contains the name (including tag)
   # of the container image to use for the example Jaeger back end.
-  allInOneImage: "jaegertracing/all-in-one:1.37"
+  allInOneImage: "jaegertracing/all-in-one:1.50"
   # [DEPRECATED: use probes instead] livenessProbeInitialDelaySeconds contains the value to use for the "initialDelaySeconds"
   # configuration property of the component's liveness probe.
   # The value of the top level "livenessProbeInitialDelaySeconds" property will be used if not set.
@@ -2135,7 +2135,7 @@ jaegerBackendExample:
 # to use for the OpenTelemetry collector agent sidecar containers.
 # These containers are deployed with Hono's components if the example Jaeger all-in-one
 # deployment is disabled and "otelCollectorAgentConfigMap" is not null.
-otelCollectorAgentImage: "otel/opentelemetry-collector:0.53.0"
+otelCollectorAgentImage: "otel/opentelemetry-collector:0.86.0"
 # otelCollectorAgentConfigMap can be used to specify the name of an existing ConfigMap
 # from which an OpenTelemetry collector configuration should be read.
 # If a ConfigMap name is given, an OpenTelemetry collector agent sidecar container will


### PR DESCRIPTION
This fixes #512.
Apply changes needed for https://github.com/eclipse-hono/hono/pull/3546, adding corresponding service accounts.

Also update jaegertracing/all-in-one and opentelemetry-collector image versions and fix Hono chart icon URL.