### PR TITLE
Update commit requirements in Contributing page.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,18 +5,18 @@ We welcome your additions to this project.
 
 ## Eclipse Contributor Agreement
 
-Before your contribution can be accepted by the project team contributors must
+In order to be able to contribute to Eclipse Foundation projects you must
 electronically sign the Eclipse Contributor Agreement (ECA).
 
-* https://accounts.eclipse.org/user/eca
+* https://www.eclipse.org/legal/ECA.php
 
-Commits that are provided by non-committers must have a Signed-off-by field in
-the footer indicating that the author is aware of the terms by which the
-contribution has been provided to the project. The non-committer must
-additionally have an Eclipse Foundation account and must have a signed Eclipse
-Contributor Agreement (ECA) on file.
+The ECA provides the Eclipse Foundation with a permanent record that you agree
+that each of your contributions will comply with the commitments documented in
+the Developer Certificate of Origin (DCO). Having an ECA on file associated with
+the email address matching the "Author" field of your contribution's Git commits
+fulfills the DCO's requirement that you sign-off on your contributions.
 
-For more information, please see the Eclipse Committer Handbook:
+For more information, please see the Eclipse Project Handbook:
 https://www.eclipse.org/projects/handbook/#resources-commit
 
 ## Making your Changes

--- a/homepage/contribute.md
+++ b/homepage/contribute.md
@@ -146,5 +146,5 @@ If you plan on contributing code, you will need to
 and [sign the Eclipse Contributor Agreement](https://accounts.eclipse.org/user/eca).
 
 Is this required? Yes! Is there a way around it? No! Why is this necessary? Because legal
-issues are as though as software engineering issues, and this is the way to solve them.
+issues are as tough as software engineering issues, and this is the way to solve them.
 


### PR DESCRIPTION
Removing the 'Signed-off-by' requirement as it isn't listed in the [Eclipse Project Handbook](https://www.eclipse.org/projects/handbook/#resources-commit) anymore.

See the corresponding change in the `org.eclipse.dash.handbook` repo [here](https://gitlab.eclipse.org/eclipse/technology/dash/org.eclipse.dash.handbook/-/commit/ba80975702f666de587e9cd0003d821cb8f95d9a#13e7b2e3a22176dcc2d2d157775b7732dff45899_91_88).