### PR TITLE
[#522] Hono 2.5.0: Add useLegacyTraceContextFormat property in values.yaml.

### DIFF
--- a/charts/hono/README.md
+++ b/charts/hono/README.md
@@ -106,6 +106,8 @@ The command removes all the Kubernetes components associated with the chart and 
 * Use Hono 2.5.0 container images.
 * Update bitnami/kafka chart to version 26.8.x which uses Kafka 3.6 in Kraft mode.
 * Update to latest MongoDB chart version 13.x.
+* Add a `useLegacyAmqpTraceContextFormat` configuration property, allowing usage of a more generic format
+  for storing OpenTelemetry trace context information in messages exchanged with an AMQP messaging network.
 
 ### 2.5.6
 

--- a/charts/hono/templates/_helpers.tpl
+++ b/charts/hono/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2019 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -266,6 +266,7 @@ messaging:
   certPath: {{ .dot.Values.adapters.amqpMessagingNetworkSpec.certPath | quote }}
   trustStorePath: {{ .dot.Values.adapters.amqpMessagingNetworkSpec.trustStorePath | quote }}
   hostnameVerificationRequired: {{ .dot.Values.adapters.amqpMessagingNetworkSpec.hostnameVerificationRequired }}
+  useLegacyTraceContextFormat: {{ .dot.Values.useLegacyAmqpTraceContextFormat }}
 {{- else }}
   {{- required ".Values.adapters.amqpMessagingNetworkSpec MUST be set if example AMQP Messaging Network is disabled" .dot.Values.adapters.amqpMessagingNetworkSpec | toYaml | nindent 2 }}
 {{- end }}
@@ -372,6 +373,7 @@ command:
   certPath: {{ .dot.Values.adapters.commandAndControlSpec.certPath | quote }}
   trustStorePath: {{ .dot.Values.adapters.commandAndControlSpec.trustStorePath | quote }}
   hostnameVerificationRequired: {{ .dot.Values.adapters.commandAndControlSpec.hostnameVerificationRequired }}
+  useLegacyTraceContextFormat: {{ .dot.Values.useLegacyAmqpTraceContextFormat }}
 {{- else }}
   {{- required ".Values.adapters.commandAndControlSpec MUST be set if example AMQP Messaging Network is disabled" .dot.Values.adapters.commandAndControlSpec | toYaml | nindent 2 }}
 {{- end -}}

--- a/charts/hono/templates/hono-service-command-router/hono-service-command-router-secret.yaml
+++ b/charts/hono/templates/hono-service-command-router/hono-service-command-router-secret.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+# Copyright (c) 2021 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -88,6 +88,7 @@ stringData:
         certPath: {{ .Values.adapters.commandAndControlSpec.certPath }}
         trustStorePath: {{ .Values.adapters.commandAndControlSpec.trustStorePath }}
         hostnameVerificationRequired: {{ .Values.adapters.commandAndControlSpec.hostnameVerificationRequired }}
+        useLegacyTraceContextFormat: {{ .Values.useLegacyAmqpTraceContextFormat }}
       {{- else }}
         {{- required ".Values.adapters.commandAndControlSpec MUST be set if example AMQP Messaging Network is disabled" .Values.adapters.commandAndControlSpec | toYaml | nindent 8 }}
       {{- end }}

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2019 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -104,6 +104,14 @@ serviceType:
 #     sections "amqpMessagingNetworkExample" and "adapters.amqpMessagingNetworkSpec".
 messagingNetworkTypes:
 - "kafka"
+
+# useLegacyAmqpTraceContextFormat determines how OpenTelemetry trace context information
+# is stored in an AMQP 1.0 message sent to the AMQP Messaging Network. A "true" value here
+# configures the format used in previous Hono versions, while setting "false" chooses a more
+# generic format (compatible with e.g. Eclipse Ditto). Refer to
+# https://www.eclipse.org/hono/docs/admin-guide/hono-client-configuration/
+# for the documentation of the corresponding "useLegacyTraceContextFormat" Hono client property.
+useLegacyAmqpTraceContextFormat: true
 
 # Configuration properties for protocol adapters.
 adapters:


### PR DESCRIPTION
This is for #522, to be included in PR #523:
Adds support for the `useLegacyTraceContextFormat` property introduced in Hono 2.5.0 (https://github.com/eclipse-hono/hono/issues/3597).