### PR TITLE
[#543] Update Hono/Ditto versions in c2e chart.

### DIFF
--- a/packages/cloud2edge/Chart.yaml
+++ b/packages/cloud2edge/Chart.yaml
@@ -11,8 +11,8 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 apiVersion: v2
-version: 0.9.0
-appVersion: 0.9.0
+version: 0.9.1
+appVersion: 0.9.1
 name: cloud2edge
 description: |
   Eclipse IoT Cloud2Edge (C2E) is an integrated suite of services developers can use to build IoT applications
@@ -33,8 +33,8 @@ maintainers:
     email: thomas.jaeckle@bosch.io
 dependencies:
   - name: hono
-    version: ~2.6.1
+    version: ~2.6.3
     repository: "https://eclipse.org/packages/charts/"
   - name: ditto
-    version: ~3.5.6
+    version: ~3.5.10
     repository: "oci://registry-1.docker.io/eclipse"

--- a/packages/cloud2edge/README.md
+++ b/packages/cloud2edge/README.md
@@ -28,6 +28,11 @@ These profiles can be applied using the `-f` parameter when installing the packa
 
 ## Release Notes
 
+### 0.9.1
+
+- Use Hono 2.6.3 chart version (including updated example certificates).
+- Use Ditto 3.5.10 chart version.
+
 ### 0.9.0
 
 - Use Ditto 3.5.6 chart version.

--- a/packages/cloud2edge/templates/NOTES.txt
+++ b/packages/cloud2edge/templates/NOTES.txt
@@ -14,6 +14,7 @@ Once all services are up and running, the output should look similar to this:
 
 NAME                                            {{ "READY   STATUS    RESTARTS   AGE" | indent ( len .Release.Name ) }}
 {{ include "c2e.ditto.fullname" . }}-connectivity-779fc6f574-gd5gq            1/1     Running   0          3m15s
+{{ include "c2e.ditto.fullname" . }}-dittoui-59b5b47bc7-4dt9m                 1/1     Running   0          3m15s
 {{ include "c2e.ditto.fullname" . }}-gateway-5cfdc9f9fc-kl6mh                 1/1     Running   0          3m15s
 {{ include "c2e.ditto.fullname" . }}-nginx-864cffd948-mvcdg                   1/1     Running   0          3m15s
 {{ include "c2e.ditto.fullname" . }}-policies-86748888d6-g2xs7                1/1     Running   0          3m15s
@@ -37,12 +38,9 @@ NAME                                            {{ "READY   STATUS    RESTARTS  
 {{ include "c2e.hono.fullname" . }}-service-command-router-8d6bcc664-5xfz8    1/1     Running   0          3m15s
 {{ include "c2e.hono.fullname" . }}-service-device-registry-975dfcdb7-d6d6h   1/1     Running   0          3m15s
 {{- if ( has "kafka" .Values.hono.messagingNetworkTypes ) }}
-{{ .Release.Name }}-kafka-0                                        1/1     Running   0          3m15s
+{{ .Release.Name }}-kafka-controller-0                             1/1     Running   0          3m15s
 {{- end }}
 {{ .Release.Name }}-mongodb-8ff6bb7cf-r7hh5                        1/1     Running   0          3m15s
-{{- if ( has "kafka" .Values.hono.messagingNetworkTypes ) }}
-{{ .Release.Name }}-zookeeper-0                                    1/1     Running   0          3m15s
-{{- end }}
 
 Once all pods have status 'Running', the Cloud2Edge package is ready to be used.
 


### PR DESCRIPTION
Updates the cloud2edge chart with the new Hono chart, including the updated example certificates (#543). Ditto version is updated as well.