### PR TITLE
Update hawkBit to Application Version 0.5.0

### DIFF
--- a/charts/hawkbit/Chart.yaml
+++ b/charts/hawkbit/Chart.yaml
@@ -10,8 +10,8 @@
 # SPDX-License-Identifier: EPL-2.0
 ---
 apiVersion: v2
-version: 1.6.0
-appVersion: "0.3.0M6-mysql"
+version: 1.7.0
+appVersion: "0.5.0-mysql"
 description: |
    Eclipse hawkBit™ is a domain independent back-end framework for rolling out software updates
    to constrained edge devices as well as more powerful controllers and gateways connected to

--- a/charts/hawkbit/templates/deployment.yaml
+++ b/charts/hawkbit/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
               {{- if .Values.env.springDatasourceUrl }}
               value: "{{ .Values.env.springDatasourceUrl }}"
               {{- else }}
-              value: "jdbc:mysql://{{ if .Values.mysql.enabled }}{{ .Release.Name }}-mysql{{ else }}{{ .Values.env.springDatasourceHost }}{{ end }}:3306/{{ .Values.env.springDatasourceDb }}"
+              value: "jdbc:mariadb://{{ if .Values.mysql.enabled }}{{ .Release.Name }}-mysql{{ else }}{{ .Values.env.springDatasourceHost }}{{ end }}:3306/{{ .Values.env.springDatasourceDb }}"
               {{- end }}
             - name: "SPRING_APPLICATION_JSON"
               valueFrom:
@@ -70,13 +70,13 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /VAADIN/themes/hawkbit/favicon.ico
+              path: /swagger-ui/index.html
               port: http
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
           readinessProbe:
             httpGet:
-              path: /VAADIN/themes/hawkbit/favicon.ico
+              path: /swagger-ui/index.html
               port: http
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/charts/hawkbit/templates/tests/test-connection.yaml
+++ b/charts/hawkbit/templates/tests/test-connection.yaml
@@ -16,7 +16,7 @@ spec:
       command: ['curl']
       args: [
         "-X 'GET'",
-        "-u admin:admin",
+        "-u 'admin:admin'",
         "'http://{{ include "hawkbit.fullname" . }}:{{ .Values.service.port }}/rest/v1/userinfo'"
       ]
   restartPolicy: Never

--- a/charts/hawkbit/templates/tests/test-connection.yaml
+++ b/charts/hawkbit/templates/tests/test-connection.yaml
@@ -15,8 +15,8 @@ spec:
       image: curlimages/curl
       command: ['curl']
       args: [
-        "-X 'GET'",
-        "-u 'admin:admin'",
-        "'http://{{ include "hawkbit.fullname" . }}:{{ .Values.service.port }}/rest/v1/userinfo'"
+        "-X", "GET",
+        "-u", "admin:admin",
+        "http://{{ include "hawkbit.fullname" . }}:{{ .Values.service.port }}/rest/v1/userinfo"
       ]
   restartPolicy: Never

--- a/charts/hawkbit/templates/tests/test-connection.yaml
+++ b/charts/hawkbit/templates/tests/test-connection.yaml
@@ -16,7 +16,7 @@ spec:
       command: ['curl']
       args: [
         "-X", "GET",
-        "-u", "admin:admin",
+        "-u", "{{ .Values.config.application.spring.security.user.name }}:{{ trimPrefix "{noop}" .Values.config.secrets.spring.security.user.password }}",
         "http://{{ include "hawkbit.fullname" . }}:{{ .Values.service.port }}/rest/v1/userinfo"
       ]
   restartPolicy: Never

--- a/charts/hawkbit/templates/tests/test-connection.yaml
+++ b/charts/hawkbit/templates/tests/test-connection.yaml
@@ -11,8 +11,12 @@ metadata:
     "helm.sh/hook": test-success
 spec:
   containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args:  ['--user', 'admin', '--password', 'admin', '{{ include "hawkbit.fullname" . }}:{{ .Values.service.port }}/rest/v1/userinfo']
+    - name: curl
+      image: curlimages/curl
+      command: ['curl']
+      args: [
+        "-X 'GET'",
+        "-u admin:admin",
+        "'{{ include "hawkbit.fullname" . }}:{{ .Values.service.port }}/rest/v1/userinfo'"
+      ]
   restartPolicy: Never

--- a/charts/hawkbit/templates/tests/test-connection.yaml
+++ b/charts/hawkbit/templates/tests/test-connection.yaml
@@ -14,5 +14,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args:  ['{{ include "hawkbit.fullname" . }}:{{ .Values.service.port }}']
+      args:  ['--user', 'admin', '--password', 'admin', '{{ include "hawkbit.fullname" . }}:{{ .Values.service.port }}/rest/v1/userinfo']
   restartPolicy: Never

--- a/charts/hawkbit/templates/tests/test-connection.yaml
+++ b/charts/hawkbit/templates/tests/test-connection.yaml
@@ -17,6 +17,6 @@ spec:
       args: [
         "-X 'GET'",
         "-u admin:admin",
-        "'{{ include "hawkbit.fullname" . }}:{{ .Values.service.port }}/rest/v1/userinfo'"
+        "'http://{{ include "hawkbit.fullname" . }}:{{ .Values.service.port }}/rest/v1/userinfo'"
       ]
   restartPolicy: Never

--- a/charts/hawkbit/values.yaml
+++ b/charts/hawkbit/values.yaml
@@ -41,7 +41,7 @@ updateStrategy:
   type: Recreate
 
 nameOverride: ""
-fullnameOverride: "eclipse-hawkbit"
+fullnameOverride: ""
 
 service:
   type: ClusterIP

--- a/charts/hawkbit/values.yaml
+++ b/charts/hawkbit/values.yaml
@@ -41,7 +41,7 @@ updateStrategy:
   type: Recreate
 
 nameOverride: ""
-fullnameOverride: ""
+fullnameOverride: "eclipse-hawkbit"
 
 service:
   type: ClusterIP

--- a/charts/hawkbit/values.yaml
+++ b/charts/hawkbit/values.yaml
@@ -15,7 +15,7 @@
 
 image:
   repository: "hawkbit/hawkbit-update-server"
-  tag: 0.3.0M6-mysql
+  tag: 0.5.0-mysql
   pullPolicy: IfNotPresent
 
 replicaCount: 1


### PR DESCRIPTION
In the current version, the helm chart does not support the latest version of hawkBit that is [0.5.0].

Because of the removal of the vaadin UI, the readyness and liveness probes are broken.
Additionally, by default, the version [0.5.0] uses the [MariaDB Connector][MariaDB-j] instead of the [MySQL Connector][mysql-j].

Thus, I updated the readiness and liveness probes to use the Swagger-UI and the MariaDB connection string by default.

  [0.5.0]: https://github.com/eclipse/hawkbit/releases/tag/0.5.0 
  [MariaDB-j]: https://mariadb.com/kb/en/about-mariadb-connector-j/
  [mysql-j]: https://mvnrepository.com/artifact/com.mysql/mysql-connector-j