### PR TITLE
Hawkbit: Use networking.k8s.io/v1 for Ingress if available (2)

### DIFF
--- a/charts/hawkbit/Chart.yaml
+++ b/charts/hawkbit/Chart.yaml
@@ -10,7 +10,7 @@
 # SPDX-License-Identifier: EPL-2.0
 ---
 apiVersion: v2
-version: 1.6.0
+version: 1.6.1
 appVersion: "0.3.0M6-mysql"
 description: |
    Eclipse hawkBit™ is a domain independent back-end framework for rolling out software updates

--- a/charts/hawkbit/templates/_helpers.tpl
+++ b/charts/hawkbit/templates/_helpers.tpl
@@ -43,3 +43,14 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for ingress.
+*/}}
+{{- define "hawkbit.ingressAPIVersion" -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" -}}
+{{- print "networking.k8s.io/v1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/hawkbit/templates/ingress.yaml
+++ b/charts/hawkbit/templates/ingress.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.ingress.enabled -}}
+{{- $apiVersion := include "hawkbit.ingressAPIVersion" . -}}
 {{- $fullName := include "hawkbit.fullname" . -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: {{ $apiVersion }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -21,6 +22,9 @@ spec:
       secretName: {{ .secretName }}
   {{- end }}
 {{- end }}
+  {{- if eq $apiVersion "networking.k8s.io/v1" }}
+  ingressClassName: {{ .Values.ingress.ingressClassName  }}
+  {{- end }}
   rules:
   {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}
@@ -28,9 +32,18 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ . }}
+            {{- if eq $apiVersion "networking.k8s.io/v1" }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
+            {{- else }}
             backend:
               serviceName: {{ $fullName }}
               servicePort: http
+            {{- end }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/hawkbit/values.yaml
+++ b/charts/hawkbit/values.yaml
@@ -58,6 +58,7 @@ readinessProbe:
 
 ingress:
   enabled: false
+  ingressClassName:
   annotations: {}
     # ingress.kubernetes.io/ssl-redirect: "true"
     # kubernetes.io/tls-acme: "true"


### PR DESCRIPTION
Cherrypicked the commit from #314 and added a commit to update the chart version.