### PR TITLE
Update the Hawkbit chart to be compatible with external secrets 

### DIFF
--- a/charts/hawkbit/Chart.yaml
+++ b/charts/hawkbit/Chart.yaml
@@ -11,7 +11,7 @@
 ---
 apiVersion: v2
 version: 1.7.0
-appVersion: "0.5.0-mysql"
+appVersion: "0.9.0"
 description: |
    Eclipse hawkBit™ is a domain independent back-end framework for rolling out software updates
    to constrained edge devices as well as more powerful controllers and gateways connected to

--- a/charts/hawkbit/templates/_helpers.tpl
+++ b/charts/hawkbit/templates/_helpers.tpl
@@ -54,3 +54,14 @@ Return the appropriate apiVersion for ingress.
 {{- print "networking.k8s.io/v1beta1" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the secret with the Hawkbit credentials.
+*/}}
+{{- define "hawkbit.secretName" -}}
+  {{- if .Values.auth.existingSecret -}}
+    {{ print (tpl .Values.auth.existingSecret $) -}}
+  {{- else -}}
+    {{ printf "%s" (include "hawkbit.fullname" .) -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/hawkbit/templates/deployment.yaml
+++ b/charts/hawkbit/templates/deployment.yaml
@@ -113,13 +113,13 @@ spec:
         {{- end }}
       {{- end }}
       volumes:
-      - name: configmap
-        configMap:
-          name: {{ include "hawkbit.fullname" . }}
+        - name: configmap
+          configMap:
+            name: {{ include "hawkbit.fullname" . }}
       {{- if .Values.fileStorage.enabled }}
-      - name: storage
-        persistentVolumeClaim:
-          claimName: {{ include "hawkbit.fullname" . }}-data
+        - name: storage
+          persistentVolumeClaim:
+            claimName: {{ include "hawkbit.fullname" . }}-data
       {{- end}}
       {{- if .Values.extraVolumes }}
       {{ toYaml .Values.extraVolumes | nindent 6 }}

--- a/charts/hawkbit/templates/deployment.yaml
+++ b/charts/hawkbit/templates/deployment.yaml
@@ -36,26 +36,35 @@ spec:
           env:
             - name: PROFILES
               value: "{{ .Values.spring.profiles }}"
-            - name: "SPRING_DATASOURCE_URL"
-              {{- if .Values.env.springDatasourceUrl }}
-              value: "{{ .Values.env.springDatasourceUrl }}"
-              {{- else }}
-              value: "jdbc:mariadb://{{ if .Values.mysql.enabled }}{{ .Release.Name }}-mysql{{ else }}{{ .Values.env.springDatasourceHost }}{{ end }}:3306/{{ .Values.env.springDatasourceDb }}"
-              {{- end }}
-            - name: "SPRING_APPLICATION_JSON"
+            - name: SPRING_DATASOURCE_USERNAME
+              value: "{{ .Values.mysql.auth.username }}"
+            - name: SPRING_DATASOURCE_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "hawkbit.fullname" . }}
-                  key: "SPRING_APPLICATION_JSON"
+                  name: {{ include "mysql.secretName" .Subcharts.mysql }}
+                  key: mysql-password
+            - name: "SPRING_DATASOURCE_URL"
+              {{- if and .Values.env .Values.env.springDatasourceUrl }}
+              value: "{{ .Values.env.springDatasourceUrl }}"
+              {{- else }}
+              value: "jdbc:mariadb://{{ .Release.Name }}-mysql:3306/{{ .Values.mysql.auth.database }}"
+              {{- end }}
             - name: "SPRING_RABBITMQ_HOST"
-              value: "{{ if .Values.rabbitmq.enabled }}{{ .Release.Name }}-rabbitmq{{ else }}{{ .Values.env.springRabbitmqHost }}{{ end }}"
+              value: "{{ .Release.Name }}-rabbitmq"
             - name: "SPRING_RABBITMQ_USERNAME"
-              value: "{{ .Values.env.springRabbitmqUsername }}"
+              value: "{{ .Values.rabbitmq.auth.username }}"
             - name: "SPRING_RABBITMQ_PASSWORD"
               valueFrom:
                 secretKeyRef:
-                  name: "{{ template "hawkbit.fullname" . }}-rabbitmq-pass"
-                  key: "rabbitmq-pass"
+                  name: {{ include "rabbitmq.secretPasswordName" .Subcharts.rabbitmq }}
+                  key: rabbitmq-password
+            - name: SPRING_SECURITY_USER_NAME
+              value: "{{ .Values.auth.username }}"
+            - name: SPRING_SECURITY_USER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "hawkbit.secretName" . }}
+                  key: hawkbit-password
             {{- if .Values.fileStorage.enabled }}
             - name: "org.eclipse.hawkbit.repository.file.path"
               value: {{ .Values.fileStorage.mountPath }}

--- a/charts/hawkbit/templates/deployment.yaml
+++ b/charts/hawkbit/templates/deployment.yaml
@@ -25,6 +25,28 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      initContainers:
+        - name: hawkbit-init
+          image: "{{ .Values.image.initContainer }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: HAWKBIT_DB_MODE
+              value: "migrate"
+            - name: "SPRING_DATASOURCE_URL"
+              {{- if and .Values.env .Values.env.springDatasourceUrl }}
+              value: "{{ .Values.env.springDatasourceUrl }}"
+              {{- else }}
+              value: "jdbc:mariadb://{{ .Release.Name }}-mysql:3306/{{ .Values.mysql.auth.database }}"
+              {{- end }}
+            - name: SPRING_DATASOURCE_USERNAME
+              value: "{{ .Values.mysql.auth.username }}"
+            - name: SPRING_DATASOURCE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mysql.secretName" .Subcharts.mysql }}
+                  key: mysql-password
+            - name: AND_THEN
+              value: "true"
     {{- with .Values.image.pullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -36,6 +58,8 @@ spec:
           env:
             - name: PROFILES
               value: "{{ .Values.spring.profiles }}"
+            - name: SPRING_FLYWAY_ENABLED
+              value: "false"
             - name: SPRING_DATASOURCE_USERNAME
               value: "{{ .Values.mysql.auth.username }}"
             - name: SPRING_DATASOURCE_PASSWORD

--- a/charts/hawkbit/templates/deployment.yaml
+++ b/charts/hawkbit/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
-            - name: SPRING_PROFILES_ACTIVE
+            - name: PROFILES
               value: "{{ .Values.spring.profiles }}"
             - name: "SPRING_DATASOURCE_URL"
               {{- if .Values.env.springDatasourceUrl }}

--- a/charts/hawkbit/templates/deployment.yaml
+++ b/charts/hawkbit/templates/deployment.yaml
@@ -69,9 +69,17 @@ spec:
             - name: "org.eclipse.hawkbit.repository.file.path"
               value: {{ .Values.fileStorage.mountPath }}
             {{- end }}
+            {{- if .Values.extraEnv }}
+            {{- if kindIs "slice" .Values.extraEnv }}
+            {{- toYaml .Values.extraEnv | nindent 12 }}
+            {{- else if kindIs "map" .Values.extraEnv }}
             {{- range $key, $value := .Values.extraEnv }}
             - name: "{{ $key }}"
               value: "{{ $value }}"
+            {{- end }}
+            {{- else }}
+            # .Values.extraEnv of type {{kindOf .Values.extraEnv}} is ignored
+            {{- end }}
             {{- end }}
           ports:
             - name: http

--- a/charts/hawkbit/templates/pvc.yaml
+++ b/charts/hawkbit/templates/pvc.yaml
@@ -11,9 +11,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
- accessModes:
- - ReadWriteOnce
- resources:
-   requests:
-     storage: {{ .Values.fileStorage.pvcSize }}
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.fileStorage.pvcSize }}
 {{- end }}

--- a/charts/hawkbit/templates/secrets.yaml
+++ b/charts/hawkbit/templates/secrets.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.auth.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,17 +7,11 @@ metadata:
 {{ include "hawkbit.labels" . | indent 4 }}
 type: Opaque
 data:
-  SPRING_APPLICATION_JSON: {{ .Values.config.secrets | toJson | b64enc }}
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ template "hawkbit.fullname" . }}-rabbitmq-pass
-  labels:
-    app.kubernetes.io/name: {{ include "hawkbit.name" . }}
-    helm.sh/chart: {{ include "hawkbit.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-type: Opaque
-data:
-  rabbitmq-pass: {{ .Values.env.springRabbitmqPassword | b64enc | quote }}
+{{- if .Values.config.secrets }}
+  hawkbit-dmf-password: {{ .Values.config.secrets.hawkbit.dmf.hono.password | b64enc | quote }}
+  hawkbit-password: {{ .Values.config.secrets.spring.securinty.user.password | b64enc | quote }}
+{{- else }}
+  hawkbit-dmf-password: {{ .Values.auth.dmfPassword | b64enc | quote }}
+  hawkbit-password: {{ .Values.auth.password | b64enc | quote }}
+{{- end }}
+{{- end }}

--- a/charts/hawkbit/templates/tests/test-connection.yaml
+++ b/charts/hawkbit/templates/tests/test-connection.yaml
@@ -16,7 +16,7 @@ spec:
       command: ['curl']
       args: [
         "-X", "GET",
-        "-u", "{{ .Values.config.application.spring.security.user.name }}:{{ trimPrefix "{noop}" .Values.config.secrets.spring.security.user.password }}",
+        "-u", "{{ .Values.auth.username }}:{{ trimPrefix "{noop}" .Values.auth.password }}",
         "http://{{ include "hawkbit.fullname" . }}:{{ .Values.service.port }}/rest/v1/userinfo"
       ]
   restartPolicy: Never

--- a/charts/hawkbit/values.yaml
+++ b/charts/hawkbit/values.yaml
@@ -17,6 +17,7 @@ image:
   repository: "hawkbit/hawkbit-update-server"
   tag: '0.9.0'
   pullPolicy: IfNotPresent
+  initContainer: "hawkbit/hawkbit-repository-jpa-init"
 
 # auth configuration
 auth:

--- a/charts/hawkbit/values.yaml
+++ b/charts/hawkbit/values.yaml
@@ -18,6 +18,14 @@ image:
   tag: '0.9.0'
   pullPolicy: IfNotPresent
 
+# auth configuration
+auth:
+  # if set, the secret will be used to set the hawkbit user password
+  existingSecret: ""
+  username: "admin"
+  password: "{noop}admin"
+  dmfPassword: "[KEYCLOAK_HAWKBIT_USER_PASSWORD]"
+
 replicaCount: 1
 
 ## podDisruptionBudget configuration
@@ -82,8 +90,6 @@ fileStorage:
 
 # env vars for configuration
 env:
-  springDatasourceHost: "hawkbit-mysql"
-  springDatasourceDb: "hawkbit"
   # if springDatasourceUrl is set override default mysql db url
   springDatasourceUrl: ""
   springRabbitmqHost: "hawkbit-rabbitmq"
@@ -141,23 +147,6 @@ config:
               destination: "device-registry.device-updated"
             device-deleted:
               destination: "device-registry.device-deleted"
-      security:
-        user:
-          name: admin
-  secrets:
-    hawkbit:
-      dmf:
-        hono:
-          password: "[KEYCLOAK_HAWKBIT_USER_PASSWORD]"
-    spring:
-      security:
-        user:
-          # the "{noop}" prefix is needed!
-          password: "{noop}admin"
-      datasource:
-        username: hawkbit
-        password: hawkbit
-
 
 ## dependency charts config
 ## ref: https://github.com/bitnami/charts/blob/master/bitnami/mysql/values.yaml
@@ -170,6 +159,8 @@ mysql:
     enabled: true
   architecture: standalone
   auth:
+    # The secret has to contain the keys mysql-root-password, mysql-replication-password and mysql-password
+    existingSecret: ""
     username: hawkbit
     password: hawkbit
     database: hawkbit
@@ -184,6 +175,8 @@ rabbitmq:
   volumePermissions:
     enabled: true
   auth:
+    existingPasswordSecret: ""
+    existingSecretPasswordKey: rabbitmq-password
     username: hawkbit
     password: hawkbit
   metrics:

--- a/charts/hawkbit/values.yaml
+++ b/charts/hawkbit/values.yaml
@@ -129,19 +129,6 @@ config:
     server:
       useForwardHeaders: true
     hawkbit:
-      ## Configuration for the device management federation
-      ## ref: https://www.eclipse.org/hawkbit/apis/dmf_api/
-      ## These configuration will become available once https://github.com/eclipse/hawkbit/pull/890 is merged
-      # dmf:
-      #   hono:
-      #     enabled: false
-      #     tenant-list-uri: "http://[DEVICE_REGISTRY_HOST]:8080/admin/tenants"
-      #     device-list-uri: "http://[DEVICE_REGISTRY_HOST]:8080/admin/$$tenantId/devices"
-      #     credentials-list-uri: "http://[DEVICE_REGISTRY_HOST]:8080/v1/credentials/$$tenantId/$$deviceId"
-      #     authentication-method: "oidc"
-      #     username: "[KEYCLOAK_HAWKBIT_USERNAME]"
-      #     oidc-token-uri: "http://[KEYCLOAK_HOST]:8080/auth/realms/master/protocol/openid-connect/token"
-      #     oidc-client-id: "[KEYCLOAK_DEVICE_REGISTRY_CLIENT_ID]"
     spring:
       cloud:
         stream:

--- a/charts/hawkbit/values.yaml
+++ b/charts/hawkbit/values.yaml
@@ -88,17 +88,10 @@ fileStorage:
   pvcSize: "1Gi"
   mountPath: "/artifactrepo"
 
-# env vars for configuration
-env:
-  # if springDatasourceUrl is set override default mysql db url
-  springDatasourceUrl: ""
-  springRabbitmqHost: "hawkbit-rabbitmq"
-  springRabbitmqUsername: "hawkbit"
-  springRabbitmqPassword: "hawkbit"
-
 # optional env vars
-extraEnv: {}
-  # JAVA_TOOL_OPTIONS: "-Xms1024m -Xmx1024m"
+extraEnv: []
+# - name: JAVA_TOOL_OPTIONS:
+#   value: "-Xms1024m -Xmx1024m"
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/hawkbit/values.yaml
+++ b/charts/hawkbit/values.yaml
@@ -78,7 +78,7 @@ routes:
 fileStorage:
   enabled: true
   pvcSize: "1Gi"
-  mountPath: "/var/lib/hawkbit-storage"
+  mountPath: "/artifactrepo"
 
 # env vars for configuration
 env:
@@ -119,7 +119,7 @@ extraVolumes: []
 extraVolumeMounts: []
 
 configMap:
-  mountPath: "/opt/hawkbit/config"
+  mountPath: "/config"
 
 spring:
   profiles: "mysql"

--- a/charts/hawkbit/values.yaml
+++ b/charts/hawkbit/values.yaml
@@ -15,7 +15,7 @@
 
 image:
   repository: "hawkbit/hawkbit-update-server"
-  tag: 0.5.0-mysql
+  tag: '0.9.0'
   pullPolicy: IfNotPresent
 
 replicaCount: 1


### PR DESCRIPTION
I found that the Hawkbit chart was not compatible with 'existingSecret', and
also that I couldn't even inject a secret via extraEnv,

I ended up replacing SPRING_APPLICATION_JSON with several individual environment variables, 
in order to have more fine grained control.
Where possible I've kept it backwards compatible, though I'm not sure if that is the best way forward,
I either need to do more work to be perfectly backward compatible, or provide a migration guide, and 
explain how the values.yaml needs to change to move to this version.

I'm just. starting to test this updated chart, so there may be bugs. I also hope to update to the latest version of hawkbit, 
but my first attempt to do that didn't go well.

It is not my desire to permanently fork the chart, 
I'm pushing this as a draft PR to see if I get any feedback. I'm happy to make changes to better suit the project.