### PR TITLE
Create helm for hawkbit v0.8.0

### DIFF
--- a/charts/hawkbit/Chart.yaml
+++ b/charts/hawkbit/Chart.yaml
@@ -11,7 +11,7 @@
 ---
 apiVersion: v2
 version: 1.7.0
-appVersion: "0.5.0-mysql"
+appVersion: "0.8.0"
 description: |
    Eclipse hawkBit™ is a domain independent back-end framework for rolling out software updates
    to constrained edge devices as well as more powerful controllers and gateways connected to

--- a/charts/hawkbit/Chart.yaml
+++ b/charts/hawkbit/Chart.yaml
@@ -10,7 +10,7 @@
 # SPDX-License-Identifier: EPL-2.0
 ---
 apiVersion: v2
-version: 1.7.0
+version: 2.0.0
 appVersion: "0.8.0"
 description: |
    Eclipse hawkBit™ is a domain independent back-end framework for rolling out software updates

--- a/charts/hawkbit/templates/_helpers.tpl
+++ b/charts/hawkbit/templates/_helpers.tpl
@@ -54,3 +54,14 @@ Return the appropriate apiVersion for ingress.
 {{- print "networking.k8s.io/v1beta1" -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "hawkbit.ingressDefaultPaths" -}}
+- path: "/rest"
+  service: {{ include "hawkbit.fullname" . }}
+- path: "/swagger-ui"
+  service: {{ include "hawkbit.fullname" . }}
+- path: "/v3"
+  service: {{ include "hawkbit.fullname" . }}
+- path: "/"
+  service: {{ include "hawkbit.fullname" . }}-simple-ui
+{{- end -}}

--- a/charts/hawkbit/templates/deployment-simple-ui.yaml
+++ b/charts/hawkbit/templates/deployment-simple-ui.yaml
@@ -37,19 +37,19 @@ spec:
             - name: SPRING_APPLICATION_JSON
               value: {{ .Values.envSimpleUI.springAppJson | toJson | quote }}
           ports:
-            - name: http
+            - name: http-simple-ui
               containerPort: {{ .Values.serviceSimpleUI.port }}
               protocol: TCP
           livenessProbe:
             httpGet:
               path: /login
-              port: http
+              port: http-simple-ui
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
           readinessProbe:
             httpGet:
               path: /login
-              port: http
+              port: http-simple-ui
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
           resources:

--- a/charts/hawkbit/templates/deployment-simple-ui.yaml
+++ b/charts/hawkbit/templates/deployment-simple-ui.yaml
@@ -1,0 +1,126 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "{{ include "hawkbit.fullname" . }}-simple-ui-deployement"
+  labels:
+    app.kubernetes.io/name: "{{ include "hawkbit.name" . }}-simple-ui"
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    {{- with .Values.updateStrategy }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: "{{ include "hawkbit.name" . }}-simple-ui"
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: "{{ include "hawkbit.name" . }}-simple-ui"
+        app.kubernetes.io/instance: {{ .Release.Name }}
+      annotations:
+        checksum/config: {{ include (print .Template.BasePath "/secrets.yaml") . | sha256sum }}
+        {{- with .Values.podTemplate.annotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+    {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: "{{ .Values.spring.profiles }}"
+            - name: "SPRING_DATASOURCE_URL"
+              {{- if .Values.env.springDatasourceUrl }}
+              value: "{{ .Values.env.springDatasourceUrl }}"
+              {{- else }}
+              value: "jdbc:mariadb://{{ if .Values.mysql.enabled }}{{ .Release.Name }}-mysql{{ else }}{{ .Values.env.springDatasourceHost }}{{ end }}:3306/{{ .Values.env.springDatasourceDb }}"
+              {{- end }}
+            - name: "SPRING_APPLICATION_JSON"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "hawkbit.fullname" . }}
+                  key: "SPRING_APPLICATION_JSON"
+            - name: "SPRING_RABBITMQ_HOST"
+              value: "{{ if .Values.rabbitmq.enabled }}{{ .Release.Name }}-rabbitmq{{ else }}{{ .Values.env.springRabbitmqHost }}{{ end }}"
+            - name: "SPRING_RABBITMQ_USERNAME"
+              value: "{{ .Values.env.springRabbitmqUsername }}"
+            - name: "SPRING_RABBITMQ_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "hawkbit.fullname" . }}-rabbitmq-pass"
+                  key: "rabbitmq-pass"
+            {{- if .Values.fileStorage.enabled }}
+            - name: "org.eclipse.hawkbit.repository.file.path"
+              value: {{ .Values.fileStorage.mountPath }}
+            {{- end }}
+            {{- range $key, $value := .Values.extraEnv }}
+            - name: "{{ $key }}"
+              value: "{{ $value }}"
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /swagger-ui/index.html
+              port: http
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          readinessProbe:
+            httpGet:
+              path: /swagger-ui/index.html
+              port: http
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          volumeMounts:
+            - name: configmap
+              mountPath: {{ .Values.configMap.mountPath }}
+            {{- if .Values.fileStorage.enabled }}
+            - name: storage
+              mountPath: {{ .Values.fileStorage.mountPath }}
+            {{- end }}
+            {{- if .Values.extraVolumeMounts }}
+            {{ toYaml .Values.extraVolumeMounts | nindent 12 }}
+            {{- end }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      {{- if .Values.securityContext.enabled }}
+      securityContext:
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        {{- if .Values.securityContext.extra }}
+        {{- toYaml .Values.securityContext.extra | nindent 8 }}
+        {{- end }}   
+      {{- end }}
+      volumes:
+      - name: configmap
+        configMap:
+          name: {{ include "hawkbit.fullname" . }}
+      {{- if .Values.fileStorage.enabled }}
+      - name: storage
+        persistentVolumeClaim:
+          claimName: {{ include "hawkbit.fullname" . }}-data
+      {{- end}}
+      {{- if .Values.extraVolumes }}
+      {{ toYaml .Values.extraVolumes | nindent 6 }}
+      {{- end }}

--- a/charts/hawkbit/templates/deployment-simple-ui.yaml
+++ b/charts/hawkbit/templates/deployment-simple-ui.yaml
@@ -37,6 +37,11 @@ spec:
           env:
             - name: HAWKBIT_SERVER_MGMTURL
               value: {{ .Values.envSimpleUI.hawkbitServerMgmtUrl | default (printf "http://%s:%v" $hawkbit_service_name $.Values.service.port ) }}
+            - name: "SPRING_APPLICATION_JSON"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "hawkbit.fullname" . }}
+                  key: SIMPLE_UI_SPRING_APPLICATION_JSON
           ports:
             - name: http
               containerPort: 8088

--- a/charts/hawkbit/templates/deployment-simple-ui.yaml
+++ b/charts/hawkbit/templates/deployment-simple-ui.yaml
@@ -38,7 +38,7 @@ spec:
               value: {{ .Values.envSimpleUI.springAppJson | toJson | quote }}
           ports:
             - name: http
-              containerPort: 8080
+              containerPort: {{ .Values.serviceSimpleUI.port }}
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/charts/hawkbit/templates/deployment-simple-ui.yaml
+++ b/charts/hawkbit/templates/deployment-simple-ui.yaml
@@ -80,16 +80,6 @@ spec:
               port: http
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-          volumeMounts:
-            - name: configmap
-              mountPath: {{ .Values.configMap.mountPath }}
-            {{- if .Values.fileStorage.enabled }}
-            - name: storage
-              mountPath: {{ .Values.fileStorage.mountPath }}
-            {{- end }}
-            {{- if .Values.extraVolumeMounts }}
-            {{ toYaml .Values.extraVolumeMounts | nindent 12 }}
-            {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
       {{- with .Values.nodeSelector }}
@@ -111,16 +101,4 @@ spec:
         {{- if .Values.securityContext.extra }}
         {{- toYaml .Values.securityContext.extra | nindent 8 }}
         {{- end }}   
-      {{- end }}
-      volumes:
-      - name: configmap
-        configMap:
-          name: {{ include "hawkbit.fullname" . }}
-      {{- if .Values.fileStorage.enabled }}
-      - name: storage
-        persistentVolumeClaim:
-          claimName: {{ include "hawkbit.fullname" . }}-data
-      {{- end}}
-      {{- if .Values.extraVolumes }}
-      {{ toYaml .Values.extraVolumes | nindent 6 }}
       {{- end }}

--- a/charts/hawkbit/templates/deployment-simple-ui.yaml
+++ b/charts/hawkbit/templates/deployment-simple-ui.yaml
@@ -26,14 +26,14 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-    {{- with .Values.imageSimpleUI.pullSecrets }}
+    {{- with .Values.simpleUIImage.pullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       containers:
         - name: "{{ .Chart.Name }}-simple-ui"
-          image: "{{ .Values.imageSimpleUI.repository }}:{{ .Values.imageSimpleUI.tag }}"
-          imagePullPolicy: {{ .Values.imageSimpleUI.pullPolicy }}
+          image: "{{ .Values.simpleUIImage.repository }}:{{ .Values.simpleUIImage.tag }}"
+          imagePullPolicy: {{ .Values.simpleUIImage.pullPolicy }}
           env:
             - name: HAWKBIT_SERVER_MGMTURL
               value: {{ .Values.envSimpleUI.hawkbitServerMgmtUrl | default (printf "http://%s:%v" $hawkbit_service_name $.Values.service.port ) }}

--- a/charts/hawkbit/templates/deployment-simple-ui.yaml
+++ b/charts/hawkbit/templates/deployment-simple-ui.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: "{{ include "hawkbit.fullname" . }}-simple-ui-deployement"
+  name: "{{ include "hawkbit.fullname" . }}-simple-ui"
   labels:
     app.kubernetes.io/name: "{{ include "hawkbit.name" . }}-simple-ui"
 spec:
@@ -30,7 +30,7 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       containers:
-        - name: {{ .Chart.Name }}
+        - name: "{{ .Chart.Name }}-simple-ui"
           image: "{{ .Values.imageSimpleUI.repository }}:{{ .Values.imageSimpleUI.tag }}"
           imagePullPolicy: {{ .Values.imageSimpleUI.pullPolicy }}
           env:

--- a/charts/hawkbit/templates/deployment-simple-ui.yaml
+++ b/charts/hawkbit/templates/deployment-simple-ui.yaml
@@ -1,3 +1,4 @@
+{{- $hawkbit_service_name :=  include "hawkbit.fullname" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -5,9 +6,9 @@ metadata:
   labels:
     app.kubernetes.io/name: "{{ include "hawkbit.name" . }}-simple-ui"
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.serviceSimpleUI.replicaCount }}
   strategy:
-    {{- with .Values.updateStrategy }}
+    {{- with .Values.serviceSimpleUI.updateStrategy }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
   selector:
@@ -34,26 +35,26 @@ spec:
           image: "{{ .Values.imageSimpleUI.repository }}:{{ .Values.imageSimpleUI.tag }}"
           imagePullPolicy: {{ .Values.imageSimpleUI.pullPolicy }}
           env:
-            - name: SPRING_APPLICATION_JSON
-              value: {{ .Values.envSimpleUI.springAppJson | toJson | quote }}
+            - name: HAWKBIT_SERVER_MGMTURL
+              value: {{ .Values.envSimpleUI.hawkbitServerMgmtUrl | default (printf "http://%s:%v" $hawkbit_service_name $.Values.service.port ) }}
           ports:
-            - name: http-simple-ui
-              containerPort: {{ .Values.serviceSimpleUI.port }}
+            - name: http
+              containerPort: 8088
               protocol: TCP
           livenessProbe:
             httpGet:
               path: /login
-              port: http-simple-ui
+              port: http
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
           readinessProbe:
             httpGet:
               path: /login
-              port: http-simple-ui
+              port: http
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
           resources:
-{{ toYaml .Values.resources | indent 12 }}
+{{ toYaml .Values.serviceSimpleUI.resources | indent 12 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -72,5 +73,5 @@ spec:
         runAsUser: {{ .Values.securityContext.runAsUser }}
         {{- if .Values.securityContext.extra }}
         {{- toYaml .Values.securityContext.extra | nindent 8 }}
-        {{- end }}   
+        {{- end }}
       {{- end }}

--- a/charts/hawkbit/templates/deployment-simple-ui.yaml
+++ b/charts/hawkbit/templates/deployment-simple-ui.yaml
@@ -25,14 +25,14 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-    {{- with .Values.image.pullSecrets }}
+    {{- with .Values.imageSimpleUI.pullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ .Values.imageSimpleUI.repository }}:{{ .Values.imageSimpleUI.tag }}"
+          imagePullPolicy: {{ .Values.imageSimpleUI.pullPolicy }}
           env:
             - name: SPRING_PROFILES_ACTIVE
               value: "{{ .Values.spring.profiles }}"
@@ -70,13 +70,13 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /swagger-ui/index.html
+              path: /login
               port: http
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
           readinessProbe:
             httpGet:
-              path: /swagger-ui/index.html
+              path: /login
               port: http
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/charts/hawkbit/templates/deployment-simple-ui.yaml
+++ b/charts/hawkbit/templates/deployment-simple-ui.yaml
@@ -34,36 +34,8 @@ spec:
           image: "{{ .Values.imageSimpleUI.repository }}:{{ .Values.imageSimpleUI.tag }}"
           imagePullPolicy: {{ .Values.imageSimpleUI.pullPolicy }}
           env:
-            - name: SPRING_PROFILES_ACTIVE
-              value: "{{ .Values.spring.profiles }}"
-            - name: "SPRING_DATASOURCE_URL"
-              {{- if .Values.env.springDatasourceUrl }}
-              value: "{{ .Values.env.springDatasourceUrl }}"
-              {{- else }}
-              value: "jdbc:mariadb://{{ if .Values.mysql.enabled }}{{ .Release.Name }}-mysql{{ else }}{{ .Values.env.springDatasourceHost }}{{ end }}:3306/{{ .Values.env.springDatasourceDb }}"
-              {{- end }}
-            - name: "SPRING_APPLICATION_JSON"
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "hawkbit.fullname" . }}
-                  key: "SPRING_APPLICATION_JSON"
-            - name: "SPRING_RABBITMQ_HOST"
-              value: "{{ if .Values.rabbitmq.enabled }}{{ .Release.Name }}-rabbitmq{{ else }}{{ .Values.env.springRabbitmqHost }}{{ end }}"
-            - name: "SPRING_RABBITMQ_USERNAME"
-              value: "{{ .Values.env.springRabbitmqUsername }}"
-            - name: "SPRING_RABBITMQ_PASSWORD"
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ template "hawkbit.fullname" . }}-rabbitmq-pass"
-                  key: "rabbitmq-pass"
-            {{- if .Values.fileStorage.enabled }}
-            - name: "org.eclipse.hawkbit.repository.file.path"
-              value: {{ .Values.fileStorage.mountPath }}
-            {{- end }}
-            {{- range $key, $value := .Values.extraEnv }}
-            - name: "{{ $key }}"
-              value: "{{ $value }}"
-            {{- end }}
+            - name: SPRING_APPLICATION_JSON
+              value: {{ .Values.envSimpleUI.springAppJson | toJson | quote }}
           ports:
             - name: http
               containerPort: 8080

--- a/charts/hawkbit/templates/deployment.yaml
+++ b/charts/hawkbit/templates/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   replicas: {{ .Values.replicaCount }}
   strategy:
-    {{- with .Values.updateStrategy }}
+    {{- with .Values.service.updateStrategy }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
   selector:
@@ -42,7 +42,7 @@ spec:
               {{- else }}
               value: "jdbc:mariadb://{{ if .Values.mysql.enabled }}{{ .Release.Name }}-mysql{{ else }}{{ .Values.env.springDatasourceHost }}{{ end }}:3306/{{ .Values.env.springDatasourceDb }}"
               {{- end }}
-            - name: "SPRING_APPLICATION_JSON" ## secret incluing the env SPRING_DATASOURCE_USERNAME TO TEST
+            - name: "SPRING_APPLICATION_JSON"
               valueFrom:
                 secretKeyRef:
                   name: {{ include "hawkbit.fullname" . }}
@@ -66,7 +66,7 @@ spec:
             {{- end }}
           ports:
             - name: http
-              containerPort: {{ .Values.service.port }}
+              containerPort: 8080
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/charts/hawkbit/templates/deployment.yaml
+++ b/charts/hawkbit/templates/deployment.yaml
@@ -66,7 +66,7 @@ spec:
             {{- end }}
           ports:
             - name: http
-              containerPort: 8080
+              containerPort: {{ .Values.service.port }}
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/charts/hawkbit/templates/deployment.yaml
+++ b/charts/hawkbit/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
-            - name: SPRING_PROFILES_ACTIVE
+            - name: PROFILES
               value: "{{ .Values.spring.profiles }}"
             - name: "SPRING_DATASOURCE_URL"
               {{- if .Values.env.springDatasourceUrl }}
@@ -42,7 +42,7 @@ spec:
               {{- else }}
               value: "jdbc:mariadb://{{ if .Values.mysql.enabled }}{{ .Release.Name }}-mysql{{ else }}{{ .Values.env.springDatasourceHost }}{{ end }}:3306/{{ .Values.env.springDatasourceDb }}"
               {{- end }}
-            - name: "SPRING_APPLICATION_JSON"
+            - name: "SPRING_APPLICATION_JSON" ## secret incluing the env SPRING_DATASOURCE_USERNAME TO TEST
               valueFrom:
                 secretKeyRef:
                   name: {{ include "hawkbit.fullname" . }}

--- a/charts/hawkbit/templates/ingress.yaml
+++ b/charts/hawkbit/templates/ingress.yaml
@@ -1,6 +1,8 @@
 {{- if .Values.ingress.enabled -}}
 {{- $apiVersion := include "hawkbit.ingressAPIVersion" . -}}
 {{- $fullName := include "hawkbit.fullname" . -}}
+{{- $hostsHawkbitSimpleUIport  := .Values.ingress.hosts_hawkbit_simple_ui.port -}}
+{{- $hostsHawkbitPort  := .Values.ingress.hosts_hawkbit.port -}}
 apiVersion: {{ $apiVersion }}
 kind: Ingress
 metadata:
@@ -26,7 +28,7 @@ spec:
   ingressClassName: {{ .Values.ingress.ingressClassName  }}
   {{- end }}
   rules:
-  {{- range .Values.ingress.hosts_hawkbit }}
+  {{- range .Values.ingress.hosts_hawkbit.hosts }}
     - host: {{ .host | quote }}
       http:
         paths:
@@ -42,11 +44,11 @@ spec:
             {{- else }}
             backend:
               serviceName: hawkbit
-              servicePort: http
+              servicePort: {{  $hostsHawkbitPort }}
             {{- end }}
         {{- end }}
   {{- end }}
-  {{- range .Values.ingress.hosts_hawkbit_simple_ui }}
+  {{- range .Values.ingress.hosts_hawkbit_simple_ui.hosts }}
     - host: {{ .host | quote }}
       http:
         paths:
@@ -56,13 +58,13 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: hawkbit-simple-ui-deployement
+                name: hawkbit-simple-ui
                 port:
-                  name: http
+                  name: http-simple-ui
             {{- else }}
             backend:
-              serviceName: hawkbit-simple-ui-deployement
-              servicePort: http
+              serviceName: hawkbit-simple-ui
+              servicePort: {{ $hostsHawkbitSimpleUIport }}
             {{- end }}
         {{- end }}
   {{- end }}

--- a/charts/hawkbit/templates/ingress.yaml
+++ b/charts/hawkbit/templates/ingress.yaml
@@ -8,6 +8,7 @@ kind: Ingress
 metadata:
   name: {{ $fullName }}
   labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
 {{ include "hawkbit.labels" . | indent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:

--- a/charts/hawkbit/templates/ingress.yaml
+++ b/charts/hawkbit/templates/ingress.yaml
@@ -33,40 +33,18 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-        {{- range .paths }}
-          - path: {{ . }}
+          - path: {{ .paths }}
             {{- if eq $apiVersion "networking.k8s.io/v1" }}
             pathType: Prefix
             backend:
               service:
-                name: hawkbit
+                name: {{ .service }}
                 port:
-                  name: http
+                  number: {{ .port }}
             {{- else }}
             backend:
-              serviceName: hawkbit
+              serviceName: {{ include "hawkbit.fullname" . }}
               servicePort: {{  $hostsHawkbitPort }}
             {{- end }}
-        {{- end }}
-  {{- end }}
-  {{- range .Values.ingress.hosts_hawkbit_simple_ui.hosts }}
-    - host: {{ .host | quote }}
-      http:
-        paths:
-        {{- range .paths }}
-          - path: {{ . }}
-            {{- if eq $apiVersion "networking.k8s.io/v1" }}
-            pathType: Prefix
-            backend:
-              service:
-                name: hawkbit-simple-ui
-                port:
-                  name: http-simple-ui
-            {{- else }}
-            backend:
-              serviceName: hawkbit-simple-ui
-              servicePort: {{ $hostsHawkbitSimpleUIport }}
-            {{- end }}
-        {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/hawkbit/templates/ingress.yaml
+++ b/charts/hawkbit/templates/ingress.yaml
@@ -1,14 +1,12 @@
 {{- if .Values.ingress.enabled -}}
+{{- $ingressDefaultPaths := (include "hawkbit.ingressDefaultPaths" $ | fromYamlArray ) }}
 {{- $apiVersion := include "hawkbit.ingressAPIVersion" . -}}
 {{- $fullName := include "hawkbit.fullname" . -}}
-{{- $hostsHawkbitSimpleUIport  := .Values.ingress.hosts_hawkbit_simple_ui.port -}}
-{{- $hostsHawkbitPort  := .Values.ingress.hosts_hawkbit.port -}}
 apiVersion: {{ $apiVersion }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
   labels:
-    app.kubernetes.io/instance: {{ .Release.Name }}
 {{ include "hawkbit.labels" . | indent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
@@ -29,22 +27,24 @@ spec:
   ingressClassName: {{ .Values.ingress.ingressClassName  }}
   {{- end }}
   rules:
-  {{- range .Values.ingress.hosts_hawkbit.hosts }}
+  {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}
       http:
         paths:
-          - path: {{ .paths }}
+        {{- range default .paths $ingressDefaultPaths }}
+          - path: {{ .path }}
             {{- if eq $apiVersion "networking.k8s.io/v1" }}
             pathType: Prefix
             backend:
               service:
                 name: {{ .service }}
                 port:
-                  number: {{ .port }}
+                  name: http
             {{- else }}
             backend:
-              serviceName: {{ include "hawkbit.fullname" . }}
-              servicePort: {{  $hostsHawkbitPort }}
+              serviceName: {{ .service }}
+              servicePort: http
             {{- end }}
+        {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/hawkbit/templates/ingress.yaml
+++ b/charts/hawkbit/templates/ingress.yaml
@@ -26,7 +26,7 @@ spec:
   ingressClassName: {{ .Values.ingress.ingressClassName  }}
   {{- end }}
   rules:
-  {{- range .Values.ingress.hosts }}
+  {{- range .Values.ingress.hosts_hawkbit }}
     - host: {{ .host | quote }}
       http:
         paths:
@@ -36,12 +36,32 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: {{ $fullName }}
+                name: hawkbit
                 port:
                   name: http
             {{- else }}
             backend:
-              serviceName: {{ $fullName }}
+              serviceName: hawkbit
+              servicePort: http
+            {{- end }}
+        {{- end }}
+  {{- end }}
+  {{- range .Values.ingress.hosts_hawkbit_simple_ui }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ . }}
+            {{- if eq $apiVersion "networking.k8s.io/v1" }}
+            pathType: Prefix
+            backend:
+              service:
+                name: hawkbit-simple-ui-deployement
+                port:
+                  name: http
+            {{- else }}
+            backend:
+              serviceName: hawkbit-simple-ui-deployement
               servicePort: http
             {{- end }}
         {{- end }}

--- a/charts/hawkbit/templates/secrets.yaml
+++ b/charts/hawkbit/templates/secrets.yaml
@@ -7,6 +7,7 @@ metadata:
 type: Opaque
 data:
   SPRING_APPLICATION_JSON: {{ .Values.config.secrets | toJson | b64enc }}
+  SIMPLE_UI_SPRING_APPLICATION_JSON: {{ .Values.config.simpleUI | toJson | b64enc }}
 ---
 apiVersion: v1
 kind: Secret

--- a/charts/hawkbit/templates/service.yaml
+++ b/charts/hawkbit/templates/service.yaml
@@ -11,8 +11,8 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.ingress.hosts_hawkbit.port }} #port expose pour ingress
-      targetPort: {{ .Values.service.port }} ## port of the pod/deployement
+    - port: {{ .Values.service.port }}
+      targetPort: http
       protocol: TCP
       name: http
   selector:

--- a/charts/hawkbit/templates/service.yaml
+++ b/charts/hawkbit/templates/service.yaml
@@ -11,8 +11,8 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.service.port }}
-      targetPort: http
+    - port: {{ .Values.ingress.hosts_hawkbit.port }} #port expose pour ingress
+      targetPort: {{ .Values.service.port }} ## port of the pod/deployement
       protocol: TCP
       name: http
   selector:

--- a/charts/hawkbit/templates/servicesimpleui.yaml
+++ b/charts/hawkbit/templates/servicesimpleui.yaml
@@ -12,9 +12,9 @@ spec:
   type: {{ .Values.serviceSimpleUI.type }}
   ports:
     - port: {{ .Values.serviceSimpleUI.port }}
-      targetPort: {{ .Values.serviceSimpleUI.port }}
+      targetPort: http-simple-ui
       protocol: TCP
-      name: http
+      name: http-simple-ui
   selector:
     app.kubernetes.io/name: "{{ include "hawkbit.name" . }}-simple-ui"
     app.kubernetes.io/instance: "{{ .Release.Name }}-simple-ui"

--- a/charts/hawkbit/templates/servicesimpleui.yaml
+++ b/charts/hawkbit/templates/servicesimpleui.yaml
@@ -12,7 +12,7 @@ spec:
   type: {{ .Values.serviceSimpleUI.type }}
   ports:
     - port: {{ .Values.serviceSimpleUI.port }}
-      targetPort: http
+      targetPort: {{ .Values.serviceSimpleUI.port }}
       protocol: TCP
       name: http
   selector:

--- a/charts/hawkbit/templates/servicesimpleui.yaml
+++ b/charts/hawkbit/templates/servicesimpleui.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ include "hawkbit.fullname" . }}-simple-ui"
+  name: "{{ include "hawkbit.fullname" . }}-simple-ui-service"
   labels:
-{{ include "hawkbit.labels" . | indent 4 }}
+    app.kubernetes.io/name: "{{ include "hawkbit.name" . }}-simple-ui"
   {{- with .Values.serviceSimpleUI.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/hawkbit/templates/servicesimpleui.yaml
+++ b/charts/hawkbit/templates/servicesimpleui.yaml
@@ -11,8 +11,8 @@ metadata:
 spec:
   type: {{ .Values.serviceSimpleUI.type }}
   ports:
-    - port: {{ .Values.serviceSimpleUI.port }}
-      targetPort: http-simple-ui
+    - port: {{ .Values.ingress.hosts_hawkbit_simple_ui.port }} #port expose pour ingress
+      targetPort: {{ .Values.serviceSimpleUI.port }} ## port of the pod/deployement
       protocol: TCP
       name: http-simple-ui
   selector:

--- a/charts/hawkbit/templates/servicesimpleui.yaml
+++ b/charts/hawkbit/templates/servicesimpleui.yaml
@@ -4,6 +4,7 @@ metadata:
   name: "{{ include "hawkbit.fullname" . }}-simple-ui"
   labels:
     app.kubernetes.io/name: "{{ include "hawkbit.name" . }}-simple-ui"
+    app.kubernetes.io/instance: {{ .Release.Name }}
   {{- with .Values.serviceSimpleUI.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -17,4 +18,4 @@ spec:
       name: http-simple-ui
   selector:
     app.kubernetes.io/name: "{{ include "hawkbit.name" . }}-simple-ui"
-    app.kubernetes.io/instance: "{{ .Release.Name }}-simple-ui"
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/hawkbit/templates/servicesimpleui.yaml
+++ b/charts/hawkbit/templates/servicesimpleui.yaml
@@ -12,10 +12,10 @@ metadata:
 spec:
   type: {{ .Values.serviceSimpleUI.type }}
   ports:
-    - port: {{ .Values.ingress.hosts_hawkbit_simple_ui.port }} #port expose pour ingress
-      targetPort: {{ .Values.serviceSimpleUI.port }} ## port of the pod/deployement
+    - port: {{ .Values.serviceSimpleUI.port }}
+      targetPort: http
       protocol: TCP
-      name: http-simple-ui
+      name: http
   selector:
     app.kubernetes.io/name: "{{ include "hawkbit.name" . }}-simple-ui"
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/hawkbit/templates/servicesimpleui.yaml
+++ b/charts/hawkbit/templates/servicesimpleui.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ include "hawkbit.fullname" . }}-simple-ui-service"
+  name: "{{ include "hawkbit.fullname" . }}-simple-ui"
   labels:
     app.kubernetes.io/name: "{{ include "hawkbit.name" . }}-simple-ui"
   {{- with .Values.serviceSimpleUI.annotations }}

--- a/charts/hawkbit/templates/servicesimpleui.yaml
+++ b/charts/hawkbit/templates/servicesimpleui.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ include "hawkbit.fullname" . }}-simple-ui"
+  labels:
+{{ include "hawkbit.labels" . | indent 4 }}
+  {{- with .Values.serviceSimpleUI.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.serviceSimpleUI.type }}
+  ports:
+    - port: {{ .Values.serviceSimpleUI.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: "{{ include "hawkbit.name" . }}-simple-ui"
+    app.kubernetes.io/instance: "{{ .Release.Name }}-simple-ui"

--- a/charts/hawkbit/values.yaml
+++ b/charts/hawkbit/values.yaml
@@ -74,9 +74,7 @@ ingress:
     # kubernetes.io/tls-acme: "true"
   hosts:
     - host: hawkbit.local
-      paths: []
-    - host: hawkbit.simpleui
-      paths: []
+      paths: [hawkbit, "hawkbit-simple-ui"]
   tls: []
   #  - secretName: hawkbit-tls
   #    hosts:

--- a/charts/hawkbit/values.yaml
+++ b/charts/hawkbit/values.yaml
@@ -15,7 +15,12 @@
 
 image:
   repository: "hawkbit/hawkbit-update-server"
-  tag: 0.5.0-mysql
+  tag: "0.8.0"
+  pullPolicy: IfNotPresent
+
+imageSimpleUI:
+  repository: "hawkbit/hawkbit-simple-ui"
+  tag: "0.8.0"
   pullPolicy: IfNotPresent
 
 replicaCount: 1
@@ -45,9 +50,14 @@ fullnameOverride: ""
 
 service:
   type: ClusterIP
-  port: 80
+  port: 8080
   annotations: {}
     # traefik.ingress.kubernetes.io/affinity: "true"
+
+serviceSimpleUI:
+  type: ClusterIP
+  port: 8088
+  annotations: {}
 
 livenessProbe:
   initialDelaySeconds: 240

--- a/charts/hawkbit/values.yaml
+++ b/charts/hawkbit/values.yaml
@@ -50,13 +50,13 @@ fullnameOverride: ""
 
 service:
   type: ClusterIP
-  port: 8080
+  port: 8080 ## port of the container
   annotations: {}
     # traefik.ingress.kubernetes.io/affinity: "true"
 
 serviceSimpleUI:
   type: ClusterIP
-  port: 8088
+  port: 8088 ## port of the container
   annotations: {}
 
 livenessProbe:
@@ -74,9 +74,13 @@ ingress:
     # kubernetes.io/tls-acme: "true"
     ## ingress service multiple host so has to have api on https://hawkbit.sbx.agreg.io/ and ui on https://hawkbit-simple-ui.sbx.agreg.io/
   hosts_hawkbit:
+    port : 8080 ## port exposed by ingress or internal
+    hosts:
     - host: hawkbit
       paths: [ / ]
   hosts_hawkbit_simple_ui:
+    port : 8088 ## port exposed by ingress or internal
+    hosts :
     - host: hawkbit-simple-ui
       paths: [ / ]
   tls: []

--- a/charts/hawkbit/values.yaml
+++ b/charts/hawkbit/values.yaml
@@ -67,22 +67,22 @@ readinessProbe:
   timeoutSeconds: 5
 
 ingress:
-  enabled: true
+  enabled: false
   ingressClassName:
   annotations: {}
     # ingress.kubernetes.io/ssl-redirect: "true"
     # kubernetes.io/tls-acme: "true"
     ## ingress service multiple host so has to have api on https://hawkbit.sbx.agreg.io/ and ui on https://hawkbit-simple-ui.sbx.agreg.io/
   hosts_hawkbit:
-    port : 8080 ## port exposed by ingress or internal
     hosts:
     - host: hawkbit
-      paths: [ / ]
-  hosts_hawkbit_simple_ui:
-    port : 8088 ## port exposed by ingress or internal
-    hosts :
+      path: "/"
+      port : 8080 ## port exposed by ingress or internal
+      service: hawkbit
     - host: hawkbit-simple-ui
-      paths: [ / ]
+      path: "/"
+      port : 8088 ## port exposed by ingress or internal
+      service: hawkbit-simple-ui
   tls: []
   #  - secretName: hawkbit-tls
   #    hosts:

--- a/charts/hawkbit/values.yaml
+++ b/charts/hawkbit/values.yaml
@@ -23,7 +23,6 @@ imageSimpleUI:
   tag: "0.8.0"
   pullPolicy: IfNotPresent
 
-replicaCount: 1
 
 ## podDisruptionBudget configuration
 podDisruptionBudget:
@@ -39,25 +38,30 @@ securityContext:
   runAsUser: 65534
   extra: {}
 
-## strategy used to replace old Pods by new ones
-## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
-updateStrategy:
-  ## default is re-create, because of possible database migrations
-  type: Recreate
 
 nameOverride: ""
 fullnameOverride: ""
 
 service:
   type: ClusterIP
-  port: 8080 ## port of the container
+  port: 8080
   annotations: {}
+  replicaCount: 1
+  ## strategy used to replace old Pods by new ones
+  ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+  updateStrategy:
+    ## default is re-create, because of possible database migrations
+    type: Recreate
     # traefik.ingress.kubernetes.io/affinity: "true"
 
 serviceSimpleUI:
   type: ClusterIP
-  port: 8088 ## port of the container
+  port: 8088
   annotations: {}
+  replicaCount: 1
+  updateStrategy:
+    type: RollingUpdate
+  resources: {}
 
 livenessProbe:
   initialDelaySeconds: 240
@@ -72,17 +76,11 @@ ingress:
   annotations: {}
     # ingress.kubernetes.io/ssl-redirect: "true"
     # kubernetes.io/tls-acme: "true"
-    ## ingress service multiple host so has to have api on https://hawkbit.sbx.agreg.io/ and ui on https://hawkbit-simple-ui.sbx.agreg.io/
-  hosts_hawkbit:
-    hosts:
-    - host: hawkbit
-      path: "/"
-      port : 8080 ## port exposed by ingress or internal
-      service: hawkbit
-    - host: hawkbit-simple-ui
-      path: "/"
-      port : 8088 ## port exposed by ingress or internal
-      service: hawkbit-simple-ui
+  hosts:
+    - host: hawkbit.local
+  #   paths:
+  #      - path: "/"
+  #        service: "hawkbit"
   tls: []
   #  - secretName: hawkbit-tls
   #    hosts:
@@ -103,13 +101,13 @@ env:
   springDatasourceHost: "hawkbit-mysql"
   springDatasourceDb: "hawkbit"
   # if springDatasourceUrl is set override default mysql db url
-  springDatasourceUrl: "jdbc:mariadb://mysql:3306/hawkbit"
-  springRabbitmqHost: "rabbitmq"
-  springRabbitmqUsername: "guest"
-  springRabbitmqPassword: "guest"
+  springDatasourceUrl: ""
+  springRabbitmqHost: "hawkbit-rabbitmq"
+  springRabbitmqUsername: "hawkbit"
+  springRabbitmqPassword: "hawkbit"
 
 envSimpleUI:
-  springAppJson: {"hawkbit.server.mgmtUrl": "http://hawkbit-server:8080"}
+  hawkbitServerMgmtUrl: ""
 
 # optional env vars
 extraEnv: {}
@@ -189,7 +187,7 @@ config:
           # the "{noop}" prefix is needed!
           password: "{noop}admin"
       datasource:
-        username: root
+        username: hawkbit
         password: hawkbit
 
 

--- a/charts/hawkbit/values.yaml
+++ b/charts/hawkbit/values.yaml
@@ -67,17 +67,18 @@ readinessProbe:
   timeoutSeconds: 5
 
 ingress:
-  enabled: false
+  enabled: true
   ingressClassName:
   annotations: {}
     # ingress.kubernetes.io/ssl-redirect: "true"
     # kubernetes.io/tls-acme: "true"
     ## ingress service multiple host so has to have api on https://hawkbit.sbx.agreg.io/ and ui on https://hawkbit-simple-ui.sbx.agreg.io/
-  hosts:
-    - host: hawkbit.local
-      paths: []
+  hosts_hawkbit:
+    - host: hawkbit
+      paths: [ / ]
+  hosts_hawkbit_simple_ui:
     - host: hawkbit-simple-ui
-      paths: []
+      paths: [ / ]
   tls: []
   #  - secretName: hawkbit-tls
   #    hosts:

--- a/charts/hawkbit/values.yaml
+++ b/charts/hawkbit/values.yaml
@@ -67,8 +67,9 @@ livenessProbe:
   initialDelaySeconds: 240
   timeoutSeconds: 5
 readinessProbe:
-  initialDelaySeconds: 120
+  failureThreshold: 24
   timeoutSeconds: 5
+  periodSeconds: 5
 
 ingress:
   enabled: false

--- a/charts/hawkbit/values.yaml
+++ b/charts/hawkbit/values.yaml
@@ -103,6 +103,9 @@ env:
   springRabbitmqUsername: "hawkbit"
   springRabbitmqPassword: "hawkbit"
 
+envSimpleUI:
+  springAppJson: {"hawkbit.server.mgmtUrl": "http://hawkbit:8080"}
+
 # optional env vars
 extraEnv: {}
   # JAVA_TOOL_OPTIONS: "-Xms1024m -Xmx1024m"

--- a/charts/hawkbit/values.yaml
+++ b/charts/hawkbit/values.yaml
@@ -196,6 +196,7 @@ config:
       datasource:
         username: hawkbit
         password: hawkbit
+  simpleUI: {}
 
 
 ## dependency charts config

--- a/charts/hawkbit/values.yaml
+++ b/charts/hawkbit/values.yaml
@@ -98,10 +98,10 @@ env:
   springDatasourceHost: "hawkbit-mysql"
   springDatasourceDb: "hawkbit"
   # if springDatasourceUrl is set override default mysql db url
-  springDatasourceUrl: ""
-  springRabbitmqHost: "hawkbit-rabbitmq"
-  springRabbitmqUsername: "hawkbit"
-  springRabbitmqPassword: "hawkbit"
+  springDatasourceUrl: "jdbc:mariadb://mysql:3306/hawkbit"
+  springRabbitmqHost: "rabbitmq"
+  springRabbitmqUsername: "guest"
+  springRabbitmqPassword: "guest"
 
 envSimpleUI:
   springAppJson: {"hawkbit.server.mgmtUrl": "http://hawkbit:8080"}
@@ -184,7 +184,7 @@ config:
           # the "{noop}" prefix is needed!
           password: "{noop}admin"
       datasource:
-        username: hawkbit
+        username: root
         password: hawkbit
 
 

--- a/charts/hawkbit/values.yaml
+++ b/charts/hawkbit/values.yaml
@@ -109,7 +109,7 @@ env:
   springRabbitmqPassword: "guest"
 
 envSimpleUI:
-  springAppJson: {"hawkbit.server.mgmtUrl": "http://hawkbit:8080"}
+  springAppJson: {"hawkbit.server.mgmtUrl": "http://hawkbit-server:8080"}
 
 # optional env vars
 extraEnv: {}

--- a/charts/hawkbit/values.yaml
+++ b/charts/hawkbit/values.yaml
@@ -75,6 +75,8 @@ ingress:
   hosts:
     - host: hawkbit.local
       paths: []
+    - host: hawkbit.simpleui
+      paths: []
   tls: []
   #  - secretName: hawkbit-tls
   #    hosts:

--- a/charts/hawkbit/values.yaml
+++ b/charts/hawkbit/values.yaml
@@ -78,9 +78,16 @@ ingress:
     # kubernetes.io/tls-acme: "true"
   hosts:
     - host: hawkbit.local
-  #   paths:
-  #      - path: "/"
-  #        service: "hawkbit"
+      paths:
+    # default value:
+    #  - path: "/rest"
+    #    service: {{ include "hawkbit.fullname" . }}
+    #  - path: "/swagger-ui"
+    #    service: {{ include "hawkbit.fullname" . }}
+    #  - path: "/v3"
+    #    service: {{ include "hawkbit.fullname" . }}
+    #²  - path: "/"
+    #    service: {{ include "hawkbit.fullname" . }}-simple-ui
   tls: []
   #  - secretName: hawkbit-tls
   #    hosts:

--- a/charts/hawkbit/values.yaml
+++ b/charts/hawkbit/values.yaml
@@ -18,7 +18,7 @@ image:
   tag: "0.8.0"
   pullPolicy: IfNotPresent
 
-imageSimpleUI:
+simpleUIImage:
   repository: "hawkbit/hawkbit-simple-ui"
   tag: "0.8.0"
   pullPolicy: IfNotPresent

--- a/charts/hawkbit/values.yaml
+++ b/charts/hawkbit/values.yaml
@@ -72,9 +72,12 @@ ingress:
   annotations: {}
     # ingress.kubernetes.io/ssl-redirect: "true"
     # kubernetes.io/tls-acme: "true"
+    ## ingress service multiple host so has to have api on https://hawkbit.sbx.agreg.io/ and ui on https://hawkbit-simple-ui.sbx.agreg.io/
   hosts:
     - host: hawkbit.local
-      paths: [hawkbit, "hawkbit-simple-ui"]
+      paths: []
+    - host: hawkbit-simple-ui
+      paths: []
   tls: []
   #  - secretName: hawkbit-tls
   #    hosts:


### PR DESCRIPTION
# Create helm for hawkbit v0.8.0

for security purpose we needed to upgrade Hawkbit (v0.4.1) to a newer version. We upgraded to the last hawkbit version available v0.8.0.

## done 

with a lot of help from @flobz (since i'm a newby to helm/kube)  we integrated simple ui into the helm chart for hawkbit. 

## tested
tested/deployed with :
- hawbit v0.8.0
- db: postgres
