### PR TITLE
[#560] Update links to point to eclipse.dev/packages.

### DIFF
--- a/.github/ct.yaml
+++ b/.github/ct.yaml
@@ -18,7 +18,7 @@ chart-dirs:
   - packages
 chart-repos:
   - stable=https://charts.helm.sh/stable
-  - packages=https://eclipse.org/packages/charts
+  - packages=https://eclipse.dev/packages/charts
   - bitnami=https://charts.bitnami.com/bitnami
   - prometheus-community=https://prometheus-community.github.io/helm-charts
   - grafana=https://grafana.github.io/helm-charts

--- a/.github/kubeval.sh
+++ b/.github/kubeval.sh
@@ -27,7 +27,7 @@ sudo tar -C /usr/local/bin -xf /tmp/kubeval.tar.gz kubeval
 
 # add helm repos to resolve dependencies
 helm repo add stable https://charts.helm.sh/stable
-helm repo add packages https://eclipse.org/packages/charts
+helm repo add packages https://eclipse.dev/packages/charts
 helm repo add bitnami https://charts.bitnami.com/bitnami
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm repo add grafana https://grafana.github.io/helm-charts

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -186,7 +186,7 @@ podTemplate(
                         if ( isStaging() ) {
                             sh '${WORKSPACE}/helm repo index --merge www/charts/index.yaml build/helm-add --url https://staging.eclipse.org/packages/charts'
                         } else {
-                            sh '${WORKSPACE}/helm repo index --merge www/charts/index.yaml build/helm-add --url https://eclipse.org/packages/charts'
+                            sh '${WORKSPACE}/helm repo index --merge www/charts/index.yaml build/helm-add --url https://eclipse.dev/packages/charts'
                         }
                         // copy new content and index to www-repo
                         sh 'cp -v build/helm-add/* www/charts/'

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -11,11 +11,7 @@ def label = "packages-${UUID.randomUUID().toString()}"
 def HELM_VERSION = "3.9.2"
 
 def needToDeploy() {
-    return BRANCH_NAME == 'master' || BRANCH_NAME == 'develop'
-}
-
-def isStaging() {
-    return BRANCH_NAME == 'develop'
+    return BRANCH_NAME == 'master'
 }
 
 podTemplate(
@@ -115,11 +111,7 @@ podTemplate(
 
                 stage ('Jekyll Build') {
                     dir ("build/homepage") {
-                        if ( isStaging() ) {
-                            sh 'bundle exec ruby /usr/gem/bin/jekyll build --config _config.yml,_config_staging.yml'
-                        } else {
-                            sh 'bundle exec ruby /usr/gem/bin/jekyll build'
-                        }
+                        sh 'bundle exec ruby /usr/gem/bin/jekyll build'
                     }
                 }
 
@@ -145,9 +137,6 @@ podTemplate(
                         dir ("www") {
                             sshagent(['github-bot-ssh']) {
                                 sh '''
-                                    if [ ${BRANCH_NAME} == "develop" ]; then
-                                      BRANCH_NAME="staging"
-                                    fi
                                     git config --global user.email "${PROJECT_NAME}-bot@eclipse.org"
                                     git config --global user.name "${PROJECT_BOT_NAME}"
                                     git clone git@github.com:eclipse/${PROJECT_NAME}-website.git .
@@ -183,11 +172,7 @@ podTemplate(
                     if (fileExists('build/perform-merge')) {
                     stage ('Rebuild helm Index') {
                         // merge added content with existing index
-                        if ( isStaging() ) {
-                            sh '${WORKSPACE}/helm repo index --merge www/charts/index.yaml build/helm-add --url https://staging.eclipse.org/packages/charts'
-                        } else {
-                            sh '${WORKSPACE}/helm repo index --merge www/charts/index.yaml build/helm-add --url https://eclipse.dev/packages/charts'
-                        }
+                        sh '${WORKSPACE}/helm repo index --merge www/charts/index.yaml build/helm-add --url https://eclipse.dev/packages/charts'
                         // copy new content and index to www-repo
                         sh 'cp -v build/helm-add/* www/charts/'
                     }
@@ -197,10 +182,6 @@ podTemplate(
                         dir("www") {
                             sshagent(['github-bot-ssh']) {
                                 sh '''
-                                if [ ${BRANCH_NAME} == "develop" ]; then
-                                  BRANCH_NAME="staging"
-                                fi
-
                                 git add -A
                                 if ! git diff --cached --exit-code; then
                                   echo "Changes have been detected, publishing to repo 'www.eclipse.org/${PROJECT_NAME}'"

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -2,7 +2,7 @@
 
 This content is produced and maintained by the Eclipse IoT Packages project.
 
-* Project home: https://eclipse.org/packages
+* Project home: https://eclipse.dev/packages
 
 ## Trademarks
 

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 IoT Packages is an effort by the [Eclipse IoT working group](https://iot.eclipse.org/), to create easy to deploy Eclipse IoT based, end-to-end scenarios, on top of Kubernetes and Helm.
 
-See: https://eclipse.org/packages
+See: https://eclipse.dev/packages

--- a/homepage/_config_staging.yml
+++ b/homepage/_config_staging.yml
@@ -1,1 +1,0 @@
-url: https://staging.eclipse.org

--- a/homepage/contribute.md
+++ b/homepage/contribute.md
@@ -122,7 +122,7 @@ Helm charts
 All pull requests will be verified by a CI job which runs the linter and tries to install the chart to at least the three most recent minor releases of kubernetes.
 At least one maintainer needs to explicitly approve the PR before it can be merged.
 
-Once the Chart has been merged, a CI job will automatically package and release the Chart in the [Eclipse IoT Packages repository](https://eclipse.org/packages/repository/).
+Once the Chart has been merged, a CI job will automatically package and release the Chart in the [Eclipse IoT Packages repository](https://eclipse.dev/packages/repository/).
 
 ## When to increase a chart's version number?
 

--- a/homepage/prereqs.md
+++ b/homepage/prereqs.md
@@ -205,7 +205,7 @@ The Eclipse IoT Packages project hosts a Helm chart repository for Eclipse IoT p
 Adding the repository can be done on your local machine be executing:
 
 {% clipboard %}
-    helm repo add eclipse-iot https://eclipse.org/packages/charts
+    helm repo add eclipse-iot https://eclipse.dev/packages/charts
 {% endclipboard %} 
 
 Read more: [Helm chart repository]({{"/repository" | relative_url }} "title").

--- a/homepage/repository.md
+++ b/homepage/repository.md
@@ -18,7 +18,7 @@ are labeled explicitly.
 You can add the repository with a simple command:
 
 {% clipboard %}
-    helm repo add eclipse-iot https://eclipse.org/packages/charts
+    helm repo add eclipse-iot https://eclipse.dev/packages/charts
 {% endclipboard %}
 
 This will add the repository, using the name `eclipse-iot`. Of course you may choose
@@ -59,7 +59,7 @@ and if you want to search for *packages* only
 
 ## How chart publishing works
 
-All chart changes will be verified by a [Github action](https://github.com/eclipse/packages/actions), this is done on every pull request.
+All chart changes will be verified by a [GitHub action](https://github.com/eclipse/packages/actions), this is done on every pull request.
 
 Once a pull request is merged, the updated chart will be deployed by a [Jenkins job](https://ci.eclipse.org/packages/job/Website/job/master/).
 This job takes care of publishing the resources and generating an updated `index.yaml`.


### PR DESCRIPTION
This is for #560.

I've also removed usage of `https://staging.eclipse.org/packages/charts` in the `Jenkinsfile`. I guess this doesn't work anymore since the website moved from Gerrit to GitHub (as stated [here](https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/2689)).
