### PR TITLE
[#563] Use bitnamilegacy repository in Hono values.yaml.

### DIFF
--- a/charts/hono/Chart.yaml
+++ b/charts/hono/Chart.yaml
@@ -15,7 +15,7 @@ name: hono
 description: |
   Eclipse Hono™ provides remote service interfaces for connecting large numbers of IoT devices to a back end and
   interacting with them in a uniform way regardless of the device communication protocol.
-version: 2.6.4
+version: 2.6.5
 # Version of Hono being deployed by the chart
 appVersion: 2.6.0
 keywords:

--- a/charts/hono/README.md
+++ b/charts/hono/README.md
@@ -101,6 +101,11 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Release Notes
 
+### 2.6.5
+
+* Use the bitnamilegacy image repository in the mongodb and kafka chart configurations as used images aren't
+  available anymore in the bitnami repository.
+
 ### 2.6.4
 
 * Recreate expired demo certificates.

--- a/charts/hono/values.yaml
+++ b/charts/hono/values.yaml
@@ -1426,6 +1426,8 @@ mongodb:
   # do not use the default name ("mongodb") because it will lead to a config
   # property name clash in the device registry pod when using "hono" as the release name
   nameOverride: "monogodb-server"
+  image:
+    repository: bitnamilegacy/mongodb
   # run single node instance
   architecture: "standalone"
   # Use StatefulSet instead of Deployment when deploying standalone
@@ -1730,6 +1732,9 @@ kafka:
   # the name of the template (maintains the release name)
   nameOverride: "kafka"
 
+  image:
+    repository: bitnamilegacy/kafka
+
   broker:
     automountServiceAccountToken: true
 
@@ -1749,6 +1754,11 @@ kafka:
       protocol: "SASL_SSL"
     external:
       protocol: "SASL_SSL"
+
+  metrics:
+    jmx:
+      image:
+        repository: bitnamilegacy/jmx-exporter
 
   sasl:
     client:
@@ -1770,6 +1780,8 @@ kafka:
     enabled: true
     autoDiscovery:
       enabled: true
+      image:
+        repository: bitnamilegacy/kubectl
     broker:
       service:
         type: "LoadBalancer"
@@ -1786,6 +1798,9 @@ kafka:
     # Note that this could require creating RBAC rules, for more information refer to
     # https://github.com/bitnami/charts/tree/master/bitnami/kafka#accessing-kafka-brokers-from-outside-the-cluster
     create: true
+  volumePermissions:
+    image:
+      repository: bitnamilegacy/os-shell
 
 # amqpMessagingNetworkExample contains properties for configuring an example AMQP network
 # to be used for messaging if "messagingNetworkTypes" contains "amqp"


### PR DESCRIPTION
This is for #563.

Use the bitnamilegacy image repository in the mongodb and kafka chart configurations as used images aren't available anymore in the bitnami repository.