### PR TITLE
[#563] Use bitnamilegacy repository in hawkBit values.yaml.

### DIFF
--- a/charts/hawkbit/Chart.yaml
+++ b/charts/hawkbit/Chart.yaml
@@ -10,7 +10,7 @@
 # SPDX-License-Identifier: EPL-2.0
 ---
 apiVersion: v2
-version: 1.7.0
+version: 1.7.1
 appVersion: "0.5.0-mysql"
 description: |
    Eclipse hawkBit™ is a domain independent back-end framework for rolling out software updates

--- a/charts/hawkbit/values.yaml
+++ b/charts/hawkbit/values.yaml
@@ -176,11 +176,15 @@ config:
 ## ref: https://github.com/bitnami/charts/blob/master/bitnami/mysql/values.yaml
 mysql:
   enabled: true
+  image:
+    repository: bitnamilegacy/mysql
   primary:
     persistence:
       enabled: true
   volumePermissions:
     enabled: true
+    image:
+      repository: bitnamilegacy/os-shell
   architecture: standalone
   auth:
     username: hawkbit
@@ -188,14 +192,21 @@ mysql:
     database: hawkbit
   metrics:
     enabled: true
+    image:
+      repository: bitnamilegacy/mysqld-exporter
 
 ## ref: https://github.com/bitnami/charts/blob/master/bitnami/rabbitmq/values.yaml
 rabbitmq:
   enabled: true
+  image:
+    repository: bitnamilegacy/rabbitmq
   persistence:
     enabled: true
   volumePermissions:
     enabled: true
+    image:
+      repository: bitnamilegacy/os-shell
+      tag: 11-debian-11-r90
   auth:
     username: hawkbit
     password: hawkbit


### PR DESCRIPTION
This is for #563.

Use the bitnamilegacy image repository in the mysql and rabbitmq chart configurations as used images aren't available anymore in the bitnami repository.